### PR TITLE
Use a sha256 of Dockerfile for build-image

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -23,9 +23,7 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
-NAME = agon-build
 VERSION ?= 0.1
-TAG = $(NAME):$(VERSION)
 CLUSTER_NAME ?= test-cluster
 KUBECONFIG ?= $(build_path)/.kube
 REPOSITORY ?= gcr.io/agon-images
@@ -41,6 +39,10 @@ common_mounts = -v $(build_path)/.config/gcloud:/root/.config/gcloud \
 				-v $(KUBECONFIG):/root/.kube \
 				-v $(agon_path):$(mount_path)
 
+# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
+# it automatically rebuilds
+build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
+build_tag = agon-build:$(build_version)
 gameserver_tag = $(REPOSITORY)/gameservers-controller:$(VERSION)
 sidecar_tag = $(REPOSITORY)/gameservers-sidecar:$(VERSION)
 
@@ -56,11 +58,11 @@ build: build-gameservers-controller-image build-gameservers-sidecar-image
 
 # Run all tests
 test: ensure-image
-	docker run --rm $(common_mounts) --entrypoint=go $(TAG) test -race $(agon_package)/...
+	docker run --rm $(common_mounts) --entrypoint=go $(build_tag) test -race $(agon_package)/...
 
 # Build a static binary for the gameserver controller
 build-gameservers-controller-binary: ensure-image
-	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) --entrypoint=go $(TAG) build \
+	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) --entrypoint=go $(build_tag) build \
 		-o $(mount_path)/gameservers/controller/bin/controller -a -installsuffix cgo $(agon_package)/gameservers/controller
 
 # Build the image for the gameserver controller
@@ -69,7 +71,7 @@ build-gameservers-controller-image: ensure-image build-gameservers-controller-bi
 
 # build the static binary for the gamesever sidecar
 build-gameservers-sidecar-binary: ensure-image
-	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) --entrypoint=go $(TAG) build \
+	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) --entrypoint=go $(build_tag) build \
 		-o $(mount_path)/gameservers/sidecar/bin/sidecar -a -installsuffix cgo $(agon_package)/gameservers/sidecar
 
 # Build the image for the gameserver sidecar
@@ -78,12 +80,12 @@ build-gameservers-sidecar-image: ensure-image build-gameservers-sidecar-binary
 
 # Generate the sidecar gRPC code
 gen-gameservers-sidecar-grpc: ensure-image
-	docker run --rm $(common_mounts) --entrypoint="/root/gen-grpc-go.sh" $(TAG)
+	docker run --rm $(common_mounts) --entrypoint="/root/gen-grpc-go.sh" $(build_tag)
 
 # Generate the client for our CustomResourceDefinition
 gen-crd-client: ensure-image
-	docker run --rm $(common_mounts) --entrypoint="/root/gen-crd-client.sh" $(TAG)
-	docker run --rm $(common_mounts) --entrypoint=goimports $(TAG) -w $(mount_path)/pkg
+	docker run --rm $(common_mounts) --entrypoint="/root/gen-crd-client.sh" $(build_tag)
+	docker run --rm $(common_mounts) --entrypoint=goimports $(build_tag) -w $(mount_path)/pkg
 
 # Run a bash shell with the developer tools in it. (Creates the image if it doesn't exist)
 # Can use ARGS for extra arguments.
@@ -92,35 +94,35 @@ shell: ensure-image
 		$(common_mounts) \
 		-w $(mount_path) \
 		$(ARGS) \
-		--entrypoint=bash $(TAG) -l
+		--entrypoint=bash $(build_tag) -l
 
 # run a container with godoc
 godoc:
 	if [ ! -f $(build_path)/.index ]; then \
 		touch $(build_path)/.index && \
 		docker run -p 8888:8888 --rm $(common_mounts) -v $(build_path)/.index:/root/.index \
-				--entrypoint=godoc $(TAG) -http=":8888" -index=true -write_index=true -index_files=/root/.index;\
+				--entrypoint=godoc $(build_tag) -http=":8888" -index=true -write_index=true -index_files=/root/.index;\
 	fi
 	docker run -p 8888:8888 --rm $(common_mounts) -v $(build_path)/.index:/root/.index \
-		--entrypoint=godoc $(TAG) -http=":8888" -index=true -index_files=/root/.index
+		--entrypoint=godoc $(build_tag) -http=":8888" -index=true -index_files=/root/.index
 
 .PHONY: build-image
 
 # Creates the build docker image
 build-image:
-	docker build --tag=$(TAG) $(build_path)/build-image
+	docker build --tag=$(build_tag) $(build_path)/build-image
 
 # Deletes the local build docker image
 clean-image:
-	docker rmi $(TAG)
+	docker rmi $(build_tag)
 
 ensure-config:
 	-mkdir -p $(build_path)/.kube
 	-mkdir -p $(build_path)/.config/gcloud
 
 ensure-image: ensure-config
-	@if [ -z $$(docker images -q $(TAG)) ]; then\
-		echo "Could not find $(TAG) image. Building...";\
+	@if [ -z $$(docker images -q $(build_tag)) ]; then\
+		echo "Could not find $(build_tag) image. Building...";\
 		$(MAKE) build-image;\
 	fi
 
@@ -128,22 +130,22 @@ ensure-image: ensure-config
 gcloud-init: ensure-config
 	docker run --rm -it \
 		$(common_mounts) \
-		--entrypoint="gcloud" $(TAG) init
+		--entrypoint="gcloud" $(build_tag) init
 
 # Creates and authenticates a small, 3 node GKE cluster to work against
 gcloud-test-cluster:
 	docker run --rm -it $(common_mounts) \
-		--entrypoint="gcloud" $(TAG) \
+		--entrypoint="gcloud" $(build_tag) \
 		deployment-manager deployments create test-cluster --config=$(mount_path)/build/gke-test-cluster/deployment.yml
 	$(MAKE) gcloud-auth-cluster
 
 # Pulls down authentication information for kubectl against a cluster, name can be specified through CLUSTER_NAME
 # (defaults to 'test-cluster')
 gcloud-auth-cluster:
-	docker run --rm $(common_mounts) --entrypoint="gcloud" $(TAG) config set container/cluster $(CLUSTER_NAME)
-	docker run --rm $(common_mounts) --entrypoint="gcloud" $(TAG) config set compute/zone \
+	docker run --rm $(common_mounts) --entrypoint="gcloud" $(build_tag) config set container/cluster $(CLUSTER_NAME)
+	docker run --rm $(common_mounts) --entrypoint="gcloud" $(build_tag) config set compute/zone \
 		`grep zone: $(build_path)/gke-test-cluster/deployment.yml | sed 's/zone: //'`
-	docker run --rm $(common_mounts) --entrypoint="gcloud" $(TAG) container clusters get-credentials $(CLUSTER_NAME)
+	docker run --rm $(common_mounts) --entrypoint="gcloud" $(build_tag) container clusters get-credentials $(CLUSTER_NAME)
 
 # Clean the kubernetes and gcloud configuration
 clean-config:


### PR DESCRIPTION
This change means that when the Dockerfile for the
build image changes, then the build image will automatically
rebuild for each developer.

This will be a nice setup for CI as well.

Closes #19