### PR TITLE
Consolidate the Version constant

### DIFF
--- a/gameservers/controller/main.go
+++ b/gameservers/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agonio/agon/pkg"
 	"github.com/agonio/agon/pkg/client/clientset/versioned"
 	"github.com/agonio/agon/pkg/client/informers/externalversions"
 	"github.com/agonio/agon/pkg/signals"
@@ -32,9 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// Version the release version of the gameserver controller
 const (
-	Version         = "0.1"
 	sidecarFlag     = "sidecar"
 	pullSidecarFlag = "always-pull-sidecar"
 )
@@ -45,7 +44,7 @@ func init() {
 
 // main starts the operator for the gameserver CRD
 func main() {
-	viper.SetDefault(sidecarFlag, "gcr.io/agon-images/gameservers-sidecar:"+Version)
+	viper.SetDefault(sidecarFlag, "gcr.io/agon-images/gameservers-sidecar:"+pkg.Version)
 	viper.SetDefault(pullSidecarFlag, false)
 
 	pflag.String(sidecarFlag, viper.GetString(sidecarFlag), "Flag to overwrite the GameServer sidecar image that is used. Can also use SIDECAR env variable")
@@ -62,7 +61,7 @@ func main() {
 
 	logrus.WithField(sidecarFlag, sidecarImage).
 		WithField("alwaysPullSidecarImage", alwaysPullSidecar).
-		WithField("Version", Version).Info("starting gameServer operator...")
+		WithField("Version", pkg.Version).Info("starting gameServer operator...")
 
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/gameservers/sidecar/main.go
+++ b/gameservers/sidecar/main.go
@@ -20,6 +20,7 @@ import (
 	"net"
 
 	"github.com/agonio/agon/gameservers/sidecar/sdk"
+	"github.com/agonio/agon/pkg"
 	"github.com/agonio/agon/pkg/util/runtime"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -29,9 +30,7 @@ import (
 )
 
 const (
-	// Version the release version of the sidecar
-	Version = "0.1"
-	port    = 59357
+	port = 59357
 
 	// gameServerNameEnv is the environment variable for the Game Server name
 	gameServerNameEnv = "GAMESERVER_NAME"
@@ -58,7 +57,7 @@ func main() {
 
 	isLocal := viper.GetBool(localFlag)
 
-	logrus.WithField(localFlag, isLocal).WithField("version", Version).WithField("port", port).Info("Starting sdk sidecar")
+	logrus.WithField(localFlag, isLocal).WithField("version", pkg.Version).WithField("port", port).Info("Starting sdk sidecar")
 
 	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,0 +1,20 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+const (
+	// Version is the global version for all binaries
+	Version = "0.1"
+)


### PR DESCRIPTION
This puts the Version in a single place,
which is a setup for #21, and means there will
always be constant version information across
all the moving pieces.

Closes #2