### PR TITLE
Windows and OSX builds of the sidecar

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -104,8 +104,12 @@ push-gameservers-controller-image: ensure-image
 
 # build the static binary for the gamesever sidecar
 build-gameservers-sidecar-binary: ensure-image
-	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) --entrypoint=go $(build_tag) build \
-		-o $(mount_path)/gameservers/sidecar/bin/sidecar -a $(go_version_flags) -installsuffix cgo $(agon_package)/gameservers/sidecar
+	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) $(build_tag) go build \
+		-o $(mount_path)/gameservers/sidecar/bin/sidecar.linux.amd64 -a $(go_version_flags) -installsuffix cgo $(agon_package)/gameservers/sidecar
+	docker run --rm -e "GOOS=darwin" -e "GOARCH=amd64" $(common_mounts) $(build_tag) go build \
+		-o $(mount_path)/gameservers/sidecar/bin/sidecar.darwin.amd64 $(go_version_flags) $(agon_package)/gameservers/sidecar
+	docker run --rm -e "GOOS=windows" -e "GOARCH=amd64" $(common_mounts) $(build_tag) go build \
+		-o $(mount_path)/gameservers/sidecar/bin/sidecar.windows.amd64.exe $(go_version_flags) $(agon_package)/gameservers/sidecar
 
 # Build the image for the gameserver sidecar
 build-gameservers-sidecar-image: ensure-image build-gameservers-sidecar-binary

--- a/build/README.md
+++ b/build/README.md
@@ -38,8 +38,10 @@ Make sure you are in the `build` directory to start.
 
 First, let's test all the code. To do this, run `make test`, which will execute all the unit tests for the codebase. 
 
-If you haven't run any of the `build` make targets before then this will also create the build image, and then run the tests.
-Building the `build-image` may take a few minutes to download all the dependencies, so feel 
+If you haven't run any of the `build` make targets before then this will also create the Docker based build image,
+and then run the tests.
+
+Building the build image may take a few minutes to download all the dependencies, so feel 
 free to make cup of tea or coffee at this point. ☕️ 
 
 The build image is only created the first time one of the make targets is executed, and will only rebuild if the build
@@ -47,12 +49,18 @@ Dockerfile has changed.
 
 Assuming that the tests all pass, let's go ahead an compile the code and build the Docker images that Agon consists of.
 
-To compile the code, create the Docker images, and compile and archive the sdks, 
-run `make build`. This will compile the code and create the docker image.
-You may note that the docker image is tagged with a concatenation of the upcoming release number and short git hash
-for the current commit. This has also been set in the code itself, so that it can be seen in log statements.
+Let's compile and build everything, by running `make build`, this will:
 
-Congratulations! You have now successfully tested and built Agon!  
+- Compile the Agon Kubernetes integration code
+- Create the Docker images that we will later push
+- Build the local development tooling for all supported OS's
+- Compile and archive the SDKs in various languages
+
+You may note that docker images, and tar archives are tagged with a concatenation of the 
+upcoming release number and short git hash for the current commit. This has also been set in 
+the code itself, so that it can be seen in via log statements.
+
+Congratulations! You have now successfully tested and built Agon!
 
 ### Running a Test Google Kubernetes Engine Cluster
 

--- a/gameservers/sidecar/Dockerfile
+++ b/gameservers/sidecar/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-COPY ./bin/sidecar /home/agon/sidecar
+COPY ./bin/sidecar.linux.amd64 /home/agon/sidecar
 RUN apk --update add ca-certificates && \
                 adduser -D agon && \
                 chown -R agon /home/agon && \

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -34,4 +34,35 @@ The GameServer state will be set `Shutdown` and the
 backing Pod will be deleted, if they have not shut themselves down already. 
 
 ## Local Development
-(Coming soon: Track [this bug](https://github.com/googleprivate/agon/issues/8) for details)
+_Note:_ There has yet to be a release of Agon, so if you want the local
+development tools, you will need to [build from source](build/README.md).
+
+If you do not wish to `make build` and build everything, 
+the `make` target `build-gameservers-sidecar-binary` will compile the necessary binaries
+for all supported operating systems (64 bit windows, linux and osx).
+
+You can find the binaries in the `bin` folder in [`gameservers/sidecar`](../gameservers/sidecar)
+once compilation is complete.
+
+When the game server is running on Agon, the SDK communicates over TCP to a small
+gRPC server that Agon coordinated to runs in a container in the same network 
+namespace as it - usually referred to in Kubernetes terms as a "sidecar".
+
+Therefore, when developing locally, we also need a process for the SDK to connect to!
+
+To do this, we can run the same binary that runs inside Agon, but pass in a flag
+to run it in "local mode". Local mode means that the sidecar binary
+won't try and connect to anything, and will just send logs messages to stdout so 
+that you can see exactly what the SDK in your game server is doing, and can
+confirm everything works.
+
+To run in local mode, pass the flag `--local` to the executable.
+
+For example:
+
+```bash
+$ ./sidecar.linux.amd64 --local
+{"level":"info","local":true,"msg":"Starting sdk sidecar","port":59357,"time":"2017-12-22T16:09:03-08:00","version":"0.1-5217b21"}
+{"level":"info","msg":"Ready request has been received!","time":"2017-12-22T16:09:19-08:00"}
+{"level":"info","msg":"Shutdown request has been received!","time":"2017-12-22T16:10:19-08:00"}
+```


### PR DESCRIPTION
This now means local development on Windows and OSX is possible. Also added documentation
on how to run this process when developing locally with Agon.

Closes #8