### PR TITLE
Continuous Integration with Container Builder

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -55,6 +55,7 @@ common_mounts = -v $(build_path)/.config/gcloud:/root/.config/gcloud \
 # it automatically rebuilds
 build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
 build_tag = agon-build:$(build_version)
+build_remote_tag = $(REGISTRY)/$(build_tag)
 controller_tag = $(REGISTRY)/gameservers-controller:$(VERSION)
 sidecar_tag = $(REGISTRY)/gameservers-sidecar:$(VERSION)
 
@@ -77,7 +78,7 @@ build-images: build-gameservers-controller-image build-gameservers-sidecar-image
 build-sdks: build-sdk-cpp
 
 # Run all tests
-test: ensure-image
+test: ensure-build-image
 	docker run --rm $(common_mounts) --entrypoint=go $(build_tag) test -race $(agon_package)/...
 
 # Push all the images up to $(REGISTRY)
@@ -90,20 +91,20 @@ install:
 	docker run --rm $(common_mounts) --entrypoint=kubectl $(build_tag) apply -f $(mount_path)/build/.install.yaml
 
 # Build a static binary for the gameserver controller
-build-gameservers-controller-binary: ensure-image
+build-gameservers-controller-binary: ensure-build-image
 	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) --entrypoint=go $(build_tag) build \
 		-o $(mount_path)/gameservers/controller/bin/controller -a $(go_version_flags) -installsuffix cgo $(agon_package)/gameservers/controller
 
 # Build the image for the gameserver controller
-build-gameservers-controller-image: ensure-image build-gameservers-controller-binary
+build-gameservers-controller-image: ensure-build-image build-gameservers-controller-binary
 	docker build $(agon_path)/gameservers/controller/ --tag=$(controller_tag)
 
 # push the gameservers controller image
-push-gameservers-controller-image: ensure-image
+push-gameservers-controller-image: ensure-build-image
 	docker push $(controller_tag)
 
 # build the static binary for the gamesever sidecar
-build-gameservers-sidecar-binary: ensure-image
+build-gameservers-sidecar-binary: ensure-build-image
 	docker run --rm -e "CGO_ENABLED=0" $(common_mounts) $(build_tag) go build \
 		-o $(mount_path)/gameservers/sidecar/bin/sidecar.linux.amd64 -a $(go_version_flags) -installsuffix cgo $(agon_package)/gameservers/sidecar
 	docker run --rm -e "GOOS=darwin" -e "GOARCH=amd64" $(common_mounts) $(build_tag) go build \
@@ -112,30 +113,30 @@ build-gameservers-sidecar-binary: ensure-image
 		-o $(mount_path)/gameservers/sidecar/bin/sidecar.windows.amd64.exe $(go_version_flags) $(agon_package)/gameservers/sidecar
 
 # Build the image for the gameserver sidecar
-build-gameservers-sidecar-image: ensure-image build-gameservers-sidecar-binary
+build-gameservers-sidecar-image: ensure-build-image build-gameservers-sidecar-binary
 	docker build $(agon_path)/gameservers/sidecar/ --tag=$(sidecar_tag)
 
 # Build the cpp sdk linux archive
-build-sdk-cpp: ensure-image
+build-sdk-cpp: ensure-build-image
 	docker run --rm $(common_mounts) -w $(mount_path)/sdks/cpp --entrypoint make $(build_tag) build install archive VERSION=$(VERSION)
 
 # push the gameservers sidecar image
-push-gameservers-sidecar-image: ensure-image
+push-gameservers-sidecar-image: ensure-build-image
 	docker push $(sidecar_tag)
 
 # Generate the SDK gRPC server and client code
-gen-gameservers-sdk-grpc: ensure-image
+gen-gameservers-sdk-grpc: ensure-build-image
 	docker run --rm $(common_mounts) --entrypoint="/root/gen-grpc-go.sh" $(build_tag)
 	docker run --rm $(common_mounts) --entrypoint="/root/gen-grpc-cpp.sh" $(build_tag)
 
 # Generate the client for our CustomResourceDefinition
-gen-crd-client: ensure-image
+gen-crd-client: ensure-build-image
 	docker run --rm $(common_mounts) --entrypoint="/root/gen-crd-client.sh" $(build_tag)
 	docker run --rm $(common_mounts) --entrypoint=goimports $(build_tag) -w $(mount_path)/pkg
 
 # Run a bash shell with the developer tools in it. (Creates the image if it doesn't exist)
 # Can use ARGS for extra arguments.
-shell: ensure-image
+shell: ensure-build-image
 	docker run -it --rm \
 		$(common_mounts) \
 		-w $(mount_path) \
@@ -160,24 +161,35 @@ build-build-image:
 clean-build-image:
 	docker rmi $(build_tag)
 
-ensure-config:
+ensure-build-config:
 	-mkdir -p $(build_path)/.kube
 	-mkdir -p $(build_path)/.config/gcloud
 
-ensure-image: ensure-config
+# create the build image if it doesn't exist
+ensure-build-image: ensure-build-config
 	@if [ -z $$(docker images -q $(build_tag)) ]; then\
 		echo "Could not find $(build_tag) image. Building...";\
 		$(MAKE) build-build-image;\
 	fi
 
+# attempt to pull the image, if it exists and rename it to the local tag
+# exit's clean if it doesn't exist, so can be used on CI
+pull-build-image:
+	-docker pull $(build_remote_tag) && docker tag $(build_remote_tag) $(build_tag)
+
+# push the local build image up to your repository
+push-build-image:
+	docker tag $(build_tag) $(build_remote_tag)
+	docker push $(build_remote_tag)
+
 # Initialise the gcloud login and project configuration, if you are working with GCP
-gcloud-init: ensure-config
+gcloud-init: ensure-build-config
 	docker run --rm -it \
 		$(common_mounts) \
 		--entrypoint="gcloud" $(build_tag) init
 
 # Creates and authenticates a small, 3 node GKE cluster to work against
-gcloud-test-cluster: ensure-image
+gcloud-test-cluster: ensure-build-image
 	docker run --rm -it $(common_mounts) \
 		--entrypoint="gcloud" $(build_tag) \
 		deployment-manager deployments create test-cluster --config=$(mount_path)/build/gke-test-cluster/deployment.yml
@@ -185,7 +197,7 @@ gcloud-test-cluster: ensure-image
 
 # Pulls down authentication information for kubectl against a cluster, name can be specified through CLUSTER_NAME
 # (defaults to 'test-cluster')
-gcloud-auth-cluster: ensure-image
+gcloud-auth-cluster: ensure-build-image
 	docker run --rm $(common_mounts) --entrypoint="gcloud" $(build_tag) config set container/cluster $(CLUSTER_NAME)
 	docker run --rm $(common_mounts) --entrypoint="gcloud" $(build_tag) config set compute/zone \
 		`grep zone: $(build_path)/gke-test-cluster/deployment.yml | sed 's/zone: //'`
@@ -193,7 +205,7 @@ gcloud-auth-cluster: ensure-image
 
 # authenticate our docker configuration so that you can do a docker push directly
 # to the gcr.io repository
-gcloud-auth-docker: ensure-image
+gcloud-auth-docker: ensure-build-image
 	-sudo rm -rf /tmp/gcloud-auth-docker
 	mkdir -p /tmp/gcloud-auth-docker
 	-cp ~/.dockercfg /tmp/gcloud-auth-docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,41 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Google Cloud Builder CI configuration
+#
+
+# right now, do nothing.
+steps:
+- name: "ubuntu"
+  args: ["bash", "-c", "echo 'FROM gcr.io/cloud-builders/docker\nRUN apt-get install make\nENTRYPOINT [\"/usr/bin/make\"]' > Dockerfile.build"]
+- name: "gcr.io/cloud-builders/docker"
+  args: ['build', '-f', 'Dockerfile.build', '-t', 'make-docker', '.'] # we need docker and make to run everything.
+- name: "make-docker"
+  dir: "build"
+  args: ["pull-build-image"] # pull the build image if it exists
+- name: "make-docker"
+  dir: "build"
+  args: [ "test" ] # run tests
+- name: "make-docker"
+  dir: "build"
+  args: [ "build", "push" ] # build all the things, and push images
+- name: 'gcr.io/cloud-builders/gsutil'
+  dir: "sdks/cpp/bin"
+  args: ['cp', '*.tar.gz', 'gs://agon-artifacts/cpp-sdk']
+- name: "make-docker"
+  dir: "build"
+  args: ["push-build-image"] # push the build image (which won't do anything if it's already there)
+timeout: "1h"
+images: ['gcr.io/$PROJECT_ID/gameservers-controller', 'gcr.io/$PROJECT_ID/gameservers-sidecar']


### PR DESCRIPTION
Use the Make build system and Google Cloud
Container builder to build a continuous integration
system.

Configured through cloudbuild.yaml this builds everything,
pushes all the images (including the build image)
and stores the cpp sdk builds in cloud storage.

Closes #13