### PR TITLE
Finalizer for GameServer until backing Pods are Terminated

### DIFF
--- a/pkg/apis/stable/v1alpha1/types_test.go
+++ b/pkg/apis/stable/v1alpha1/types_test.go
@@ -91,6 +91,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 			test.gameServer.ApplyDefaults()
 
 			spec := test.gameServer.Spec
+			assert.Contains(t, test.gameServer.ObjectMeta.Finalizers, stable.GroupName)
 			assert.Equal(t, test.expectedContainer, spec.Container)
 			assert.Equal(t, test.expectedProtocol, spec.Protocol)
 			assert.Equal(t, test.expectedState, test.gameServer.Status.State)

--- a/sdks/cpp/Makefile
+++ b/sdks/cpp/Makefile
@@ -60,7 +60,6 @@ ensure-bin:
 	-mkdir $(build_path)/bin
 
 # build dev and runtime tarballs
-# TODO: add the verrsion to the archive (pass through from main Makefile
 archive: VERSION = "dev"
 archive:
 	-rm $(build_path)/bin/argonsdk-$(VERSION)-dev-linux-arch_64.tar.gz


### PR DESCRIPTION
Because we allocate a port to a GameSever, we cannot delete the GameServer until that port is free again.

This means that a GameServer must not be hard deleted until the backing Pod is successfully Terminated - and the port is now free again.

This implements a finalizer and backing controller code to manage this.

This is work that need to occur for #14 (Dynamic Port Allocation) to be completed.