### PR TITLE
Dynamic Port Allocation for GameServers

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -34,7 +34,7 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && un
     /opt/google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/root/.bashrc
 
 # update the path for both go and gcloud
-ENV PATH /usr/local/go/bin:/opt/google-cloud-sdk/bin:$PATH
+ENV PATH /usr/local/go/bin:/go/bin:/opt/google-cloud-sdk/bin:$PATH
 
 # RUN gcloud components update
 RUN gcloud components update && gcloud components install kubectl

--- a/build/build-image/gen-crd-client.sh
+++ b/build/build-image/gen-crd-client.sh
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 rsync -r /go/src/github.com/agonio/agon/vendor/k8s.io/ /go/src/k8s.io/
-/go/src/k8s.io/code-generator/generate-groups.sh "all" \
+cd /go/src/k8s.io/code-generator
+./generate-groups.sh "all" \
     github.com/agonio/agon/pkg/client \
     github.com/agonio/agon/pkg/apis stable:v1alpha1 \
     --go-header-file=/go/src/github.com/agonio/agon/build/boilerplate.go.txt

--- a/build/install.yaml
+++ b/build/install.yaml
@@ -51,6 +51,10 @@ spec:
           value: "true"
         - name: SIDECAR # overwrite the GameServer sidecar image that is used
           value: ${REGISTRY}/gameservers-sidecar:${VERSION}
+        - name: MIN_PORT
+          value: "7000"
+        - name: MAX_PORT
+          value: "8000"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/cpp-simple/gameserver.yaml
+++ b/examples/cpp-simple/gameserver.yaml
@@ -15,11 +15,11 @@
 apiVersion: "stable.agon.io/v1alpha1"
 kind: GameServer
 metadata:
-  name: cpp-simple
+  # generate a unique name
+  # will need to be created with `kubectl create`
+  generateName: cpp-simple-
 spec:
-  portPolicy: "static"
   containerPort: 7654
-  hostPort: 7778
   template:
     spec:
       containers:

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -25,21 +25,27 @@
 
 apiVersion: "stable.agon.io/v1alpha1"
 kind: GameServer
+# GameServer Metadata
+# https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#objectmeta-v1-meta
 metadata:
-  name: "gds-example"
+  # generateName: "gds-example" # generate a unique name, with the given prefix
+  name: "gds-example" # set a fixed name
 spec:
   # if there is more than one container, specify which one is the game server
   container: example-server
-  # `static` is the only current option. Dynamic port allocated will come in future releases.
-  # When `static` is the policy specified, `hostPort` is required, to specify the port that game clients will connect to
+  # portPolicy has two options:
+  # - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
+  # - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+  # port is available. When static is the policy specified, `hostPort` is required to be populated
   portPolicy: "static"
   # the port that is being opened on the game server process
   containerPort: 7654
-  # the port exposed on the host
+  # the port exposed on the host, only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
   hostPort: 7777
   # protocol being used. Defaults to UDP. TCP is the only other option
   protocol: UDP
-  # Pod configuration
+  # Pod template configuration
+  # https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#podtemplate-v1-core
   template:
     # pod metadata. Name & Namespace is overwritten
     metadata:

--- a/gameservers/controller/helper_test.go
+++ b/gameservers/controller/helper_test.go
@@ -1,0 +1,68 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"context"
+
+	agonfake "github.com/agonio/agon/pkg/client/clientset/versioned/fake"
+	"github.com/agonio/agon/pkg/client/informers/externalversions"
+	"github.com/sirupsen/logrus"
+	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+// holder for all my fakes and mocks
+type mocks struct {
+	kubeClient             *kubefake.Clientset
+	kubeInformationFactory informers.SharedInformerFactory
+	extClient              *extfake.Clientset
+	agonClient             *agonfake.Clientset
+	agonInformerFactory    externalversions.SharedInformerFactory
+}
+
+func newMocks() mocks {
+	kubeClient := &kubefake.Clientset{}
+	kubeInformationFactory := informers.NewSharedInformerFactory(kubeClient, 30*time.Second)
+	extClient := &extfake.Clientset{}
+	agonClient := &agonfake.Clientset{}
+	agonInformerFactory := externalversions.NewSharedInformerFactory(agonClient, 30*time.Second)
+	m := mocks{
+		kubeClient:             kubeClient,
+		kubeInformationFactory: kubeInformationFactory,
+		extClient:              extClient,
+		agonClient:             agonClient,
+		agonInformerFactory:    agonInformerFactory}
+	return m
+}
+
+func startInformers(mocks mocks, sync ...cache.InformerSynced) (<-chan struct{}, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	stop := ctx.Done()
+
+	mocks.kubeInformationFactory.Start(stop)
+	mocks.agonInformerFactory.Start(stop)
+
+	logrus.Info("Wait for cache sync")
+	if !cache.WaitForCacheSync(stop, sync...) {
+		panic("Cache never synced")
+	}
+
+	return stop, cancel
+}

--- a/gameservers/controller/portallocator.go
+++ b/gameservers/controller/portallocator.go
@@ -1,0 +1,255 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sync"
+
+	"github.com/agonio/agon/pkg/apis/stable/v1alpha1"
+	"github.com/agonio/agon/pkg/client/informers/externalversions"
+	listerv1alpha1 "github.com/agonio/agon/pkg/client/listers/stable/v1alpha1"
+	"github.com/agonio/agon/pkg/util/runtime"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ErrPortNotFound is returns when a port is unable to be allocated
+var ErrPortNotFound = errors.New("Unable to allocate a port")
+
+// A set of port allocations for a node
+type portAllocation map[int32]bool
+
+// PortAllocator manages the dynamic port
+// allocation strategy. Only use exposed methods to ensure
+// appropriate locking is taken.
+// The PortAllocator does not currently support mixing static portAllocations (or any pods with defined HostPort)
+// within the dynamic port range other than the ones it coordinates.
+type PortAllocator struct {
+	mutex              sync.RWMutex
+	portAllocations    []portAllocation
+	minPort            int32
+	maxPort            int32
+	gameServerSynced   cache.InformerSynced
+	gameServerLister   listerv1alpha1.GameServerLister
+	gameServerInformer cache.SharedIndexInformer
+	nodeSynced         cache.InformerSynced
+	nodeLister         corelisterv1.NodeLister
+	nodeInformer       cache.SharedIndexInformer
+}
+
+// NewPortAllocator returns a new dynamic port
+// allocator. minPort and maxPort are the top and bottom portAllocations that can be allocated in the range for
+// the game servers
+func NewPortAllocator(minPort, maxPort int32,
+	kubeInformerFactory informers.SharedInformerFactory,
+	agonInformerFactory externalversions.SharedInformerFactory) *PortAllocator {
+	logrus.WithField("minPort", minPort).WithField("maxPort", maxPort).Info("Starting port allocator")
+
+	v1 := kubeInformerFactory.Core().V1()
+	nodes := v1.Nodes()
+	gameServers := agonInformerFactory.Stable().V1alpha1().GameServers()
+
+	pa := &PortAllocator{
+		mutex:              sync.RWMutex{},
+		minPort:            minPort,
+		maxPort:            maxPort,
+		gameServerSynced:   gameServers.Informer().HasSynced,
+		gameServerLister:   gameServers.Lister(),
+		gameServerInformer: gameServers.Informer(),
+		nodeLister:         nodes.Lister(),
+		nodeInformer:       nodes.Informer(),
+		nodeSynced:         nodes.Informer().HasSynced,
+	}
+
+	return pa
+}
+
+// Run sets up the current state of port allocations and
+// starts tracking Pod and Node changes
+func (pa *PortAllocator) Run(stop <-chan struct{}) error {
+	logrus.Info("Running Pod Allocator")
+	pa.gameServerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: pa.syncDeleteGameServer,
+	})
+
+	// Experimental support for node adding/removal
+	pa.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: pa.syncAddNode,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldNode := oldObj.(*corev1.Node)
+			newNode := newObj.(*corev1.Node)
+			if oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable {
+				err := pa.syncPortAllocations(stop)
+				if err != nil {
+					err := errors.Wrap(err, "error resetting ports on node update")
+					runtime.HandleError(logrus.WithField("node", newNode), err)
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			err := pa.syncPortAllocations(stop)
+			if err != nil {
+				err := errors.Wrap(err, "error on node deletion")
+				runtime.HandleError(logrus.WithField("node", obj), err)
+			}
+		},
+	})
+
+	logrus.Info("Flush cache sync, before syncing gameserver and node state")
+	if !cache.WaitForCacheSync(stop, pa.gameServerSynced, pa.nodeSynced) {
+		return nil
+	}
+
+	return pa.syncPortAllocations(stop)
+}
+
+// Allocate allocates a port. Return ErrPortNotFound if no port is
+// allocatable
+func (pa *PortAllocator) Allocate() (int32, error) {
+	pa.mutex.Lock()
+	defer pa.mutex.Unlock()
+	for _, n := range pa.portAllocations {
+		for p, taken := range n {
+			if !taken {
+				n[p] = true
+				return p, nil
+			}
+		}
+	}
+	return -1, ErrPortNotFound
+}
+
+// syncAddNode adds another node port section
+// to the available ports
+func (pa *PortAllocator) syncAddNode(obj interface{}) {
+	pa.mutex.Lock()
+	defer pa.mutex.Unlock()
+
+	node := obj.(*corev1.Node)
+	logrus.WithField("node", node.ObjectMeta.Name).Info("Adding Node to port allocations")
+
+	ports := portAllocation{}
+	for i := pa.minPort; i <= pa.maxPort; i++ {
+		ports[i] = false
+	}
+
+	pa.portAllocations = append(pa.portAllocations, ports)
+}
+
+// syncDeleteGameServer when a GameServer Pod is deleted
+// make the HostPort available
+func (pa *PortAllocator) syncDeleteGameServer(object interface{}) {
+	pa.mutex.Lock()
+	defer pa.mutex.Unlock()
+
+	gs := object.(*v1alpha1.GameServer)
+	logrus.WithField("gs", gs).Info("syncing deleted GameServer")
+	pa.portAllocations = setPortAllocation(gs.Spec.HostPort, pa.portAllocations, false)
+}
+
+// syncPortAllocations syncs the pod, node and gameserver caches then
+// traverses all Nodes in the cluster and all looks at GameServers
+// and Terminating Pods values make sure those
+// portAllocations are marked as taken.
+// Locks the mutex while doing this.
+// This is basically a stop the world Garbage Collection on port allocations.
+func (pa *PortAllocator) syncPortAllocations(stop <-chan struct{}) error {
+	pa.mutex.Lock()
+	defer pa.mutex.Unlock()
+
+	logrus.Info("Resetting Port Allocation")
+
+	if !cache.WaitForCacheSync(stop, pa.gameServerSynced, pa.nodeSynced) {
+		return nil
+	}
+
+	nodes, err := pa.nodeLister.List(labels.Everything())
+	if err != nil {
+		return errors.Wrap(err, "error listing all nodes")
+	}
+
+	// setup blank port values
+	nodePorts := pa.nodePortAllocation(nodes)
+
+	gameservers, err := pa.gameServerLister.List(labels.Everything())
+	if err != nil {
+		return errors.Wrapf(err, "error listing all GameServers")
+	}
+
+	// place to put GameServer port allocations that are not ready yet/after the ready state
+	var nonReadyNodesPorts []int32
+	// Check GameServers as well, as some
+	for _, gs := range gameservers {
+		// if the node doesn't exist, it's likely unscheduled
+		_, ok := nodePorts[gs.Status.NodeName]
+		if gs.Status.NodeName != "" && ok {
+			nodePorts[gs.Status.NodeName][gs.Status.Port] = true
+		} else if gs.Spec.HostPort != 0 {
+			nonReadyNodesPorts = append(nonReadyNodesPorts, gs.Spec.HostPort)
+		}
+	}
+
+	// this gives us back an ordered node list.
+	allocations := make([]portAllocation, len(nodePorts))
+	i := 0
+	for _, np := range nodePorts {
+		allocations[i] = np
+		i++
+	}
+
+	// close off the port on the first node you find
+	// we actually don't mind what node it is, since we only care
+	// that there is a port open *somewhere* as the default scheduler
+	// will re-route for us based on HostPort allocation
+	for _, p := range nonReadyNodesPorts {
+		allocations = setPortAllocation(p, allocations, true)
+	}
+
+	pa.portAllocations = allocations
+
+	return nil
+}
+
+// nodePortAllocation returns a map of port allocations all set to being available
+// with a map key for each node
+func (pa *PortAllocator) nodePortAllocation(nodes []*corev1.Node) map[string]portAllocation {
+	nodePorts := map[string]portAllocation{}
+	for _, n := range nodes {
+		// ignore unschedulable nodes
+		if !n.Spec.Unschedulable {
+			nodePorts[n.Name] = portAllocation{}
+			for i := pa.minPort; i <= pa.maxPort; i++ {
+				nodePorts[n.Name][i] = false
+			}
+		}
+	}
+	return nodePorts
+}
+
+// setPortAllocation takes a port from an all
+func setPortAllocation(port int32, allocations []portAllocation, taken bool) []portAllocation {
+	for _, np := range allocations {
+		if np[port] != taken {
+			np[port] = taken
+			break
+		}
+	}
+	return allocations
+}

--- a/gameservers/controller/portallocator_test.go
+++ b/gameservers/controller/portallocator_test.go
@@ -1,0 +1,358 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"sync"
+
+	"github.com/agonio/agon/pkg/apis/stable/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	n1 = corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	n2 = corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+	n3 = corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3"}}
+)
+
+func TestPortAllocatorAllocate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ports are all allocated", func(t *testing.T) {
+		m := newMocks()
+		pa := NewPortAllocator(10, 20, m.kubeInformationFactory, m.agonInformerFactory)
+		nodeWatch := watch.NewFake()
+		m.kubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
+
+		stop, cancel := startInformers(m)
+		defer cancel()
+
+		// Make sure the add's don't corrupt the sync
+		nodeWatch.Add(&n1)
+		nodeWatch.Add(&n2)
+
+		err := pa.Run(stop)
+		assert.Nil(t, err)
+
+		// two nodes
+		for x := 0; x < 2; x++ {
+			// ports between 10 and 20
+			for i := 10; i <= 20; i++ {
+				var p int32
+				p, err = pa.Allocate()
+				assert.True(t, 10 <= p && p <= 20, "%v is not between 10 and 20", p)
+				assert.Nil(t, err)
+			}
+		}
+
+		// now we should have none left
+		_, err = pa.Allocate()
+		assert.Equal(t, ErrPortNotFound, err)
+	})
+
+	t.Run("ports are unique in a node", func(t *testing.T) {
+		m := newMocks()
+		pa := NewPortAllocator(10, 20, m.kubeInformationFactory, m.agonInformerFactory)
+
+		m.kubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			nl := &corev1.NodeList{Items: []corev1.Node{n1}}
+			return true, nl, nil
+		})
+		stop, cancel := startInformers(m)
+		defer cancel()
+		err := pa.Run(stop)
+		assert.Nil(t, err)
+		var ports []int32
+		for i := 10; i <= 20; i++ {
+			p, err := pa.Allocate()
+			assert.Nil(t, err)
+			assert.NotContains(t, ports, p)
+			ports = append(ports, p)
+		}
+	})
+}
+
+func TestPortAllocatorMultithreadAllocate(t *testing.T) {
+	m := newMocks()
+	pa := NewPortAllocator(10, 110, m.kubeInformationFactory, m.agonInformerFactory)
+
+	m.kubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		nl := &corev1.NodeList{Items: []corev1.Node{n1, n2}}
+		return true, nl, nil
+	})
+	stop, cancel := startInformers(m)
+	defer cancel()
+	err := pa.Run(stop)
+	assert.Nil(t, err)
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(i int) {
+			for x := 0; x < 10; x++ {
+				logrus.WithField("x", x).WithField("i", i).Info("allocating!")
+				_, err := pa.Allocate()
+				assert.Nil(t, err)
+			}
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestPortAllocatorSyncPortAllocations(t *testing.T) {
+	t.Parallel()
+
+	m := newMocks()
+	pa := NewPortAllocator(10, 20, m.kubeInformationFactory, m.agonInformerFactory)
+
+	m.kubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		nl := &corev1.NodeList{Items: []corev1.Node{n1, n2, n3}}
+		return true, nl, nil
+	})
+
+	m.agonClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		gs1 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs1"}, Spec: v1alpha1.GameServerSpec{HostPort: 10},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Ready, Port: 10, NodeName: n1.ObjectMeta.Name}}
+		gs2 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs2"}, Spec: v1alpha1.GameServerSpec{HostPort: 10},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Ready, Port: 10, NodeName: n2.ObjectMeta.Name}}
+		gs3 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs3"}, Spec: v1alpha1.GameServerSpec{HostPort: 11},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Ready, Port: 11, NodeName: n3.ObjectMeta.Name}}
+		gs4 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs4"}, Spec: v1alpha1.GameServerSpec{HostPort: 12},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Creating}}
+		gs5 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs5"}, Spec: v1alpha1.GameServerSpec{HostPort: 12},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Creating}}
+		gsl := &v1alpha1.GameServerList{Items: []v1alpha1.GameServer{gs1, gs2, gs3, gs4, gs5}}
+		return true, gsl, nil
+	})
+
+	stop, cancel := startInformers(m)
+	defer cancel()
+	err := pa.syncPortAllocations(stop)
+	assert.Nil(t, err)
+	assert.Len(t, pa.portAllocations, 3)
+
+	// count the number of allocated ports,
+	assert.Equal(t, 2, countAllocatedPorts(pa, 10))
+	assert.Equal(t, 1, countAllocatedPorts(pa, 11))
+	assert.Equal(t, 2, countAllocatedPorts(pa, 12))
+
+	count := 0
+	for i := int32(10); i <= 20; i++ {
+		count += countAllocatedPorts(pa, i)
+	}
+	assert.Equal(t, 5, count)
+}
+
+func TestPortAllocatorSyncDeleteGameServer(t *testing.T) {
+	t.Parallel()
+
+	m := newMocks()
+	fakeWatch := watch.NewFake()
+	m.agonClient.AddWatchReactor("gameservers", k8stesting.DefaultWatchReactor(fakeWatch, nil))
+
+	gs1Fixture := &v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs4"}, Spec: v1alpha1.GameServerSpec{HostPort: 10}}
+	gs2Fixture := gs1Fixture.DeepCopy()
+	gs2Fixture.ObjectMeta.Name = "gs5"
+
+	pa := NewPortAllocator(10, 20, m.kubeInformationFactory, m.agonInformerFactory)
+
+	m.kubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		nl := &corev1.NodeList{Items: []corev1.Node{n1, n2, n3}}
+		return true, nl, nil
+	})
+
+	m.agonClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		gs1 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs1"}, Spec: v1alpha1.GameServerSpec{HostPort: 10},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Ready, Port: 10, NodeName: n1.ObjectMeta.Name}}
+		gs2 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs2"}, Spec: v1alpha1.GameServerSpec{HostPort: 11},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Ready, Port: 11, NodeName: n1.ObjectMeta.Name}}
+		gs3 := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs3"}, Spec: v1alpha1.GameServerSpec{HostPort: 10},
+			Status: v1alpha1.GameServerStatus{State: v1alpha1.Ready, Port: 10, NodeName: n2.ObjectMeta.Name}}
+
+		gsl := &v1alpha1.GameServerList{Items: []v1alpha1.GameServer{gs1, gs2, gs3}}
+		return true, gsl, nil
+	})
+
+	stop, cancel := startInformers(m)
+	defer cancel()
+
+	// this should do nothing, as it's before pa.Created is called
+	fakeWatch.Add(gs2Fixture.DeepCopy())
+	fakeWatch.Delete(gs2Fixture.DeepCopy())
+
+	err := pa.Run(stop)
+	assert.Nil(t, err)
+
+	nonGSPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "notagameserver"}}
+	fakeWatch.Add(gs1Fixture.DeepCopy())
+	fakeWatch.Add(nonGSPod.DeepCopy())
+	assert.True(t, cache.WaitForCacheSync(stop, pa.gameServerSynced))
+
+	// gate
+	pa.mutex.RLock() // reading mutable state, so read lock
+	assert.Equal(t, 2, countAllocatedPorts(pa, 10))
+	assert.Equal(t, 1, countAllocatedPorts(pa, 11))
+	pa.mutex.RUnlock()
+
+	fakeWatch.Delete(gs1Fixture.DeepCopy())
+	assert.True(t, cache.WaitForCacheSync(stop, pa.gameServerSynced))
+
+	pa.mutex.RLock() // reading mutable state, so read lock
+	assert.Equal(t, 1, countAllocatedPorts(pa, 10))
+	assert.Equal(t, 1, countAllocatedPorts(pa, 11))
+	pa.mutex.RUnlock()
+
+	// delete the non gameserver pod, all should be the same
+	fakeWatch.Delete(nonGSPod.DeepCopy())
+	assert.True(t, cache.WaitForCacheSync(stop, pa.gameServerSynced))
+	pa.mutex.RLock() // reading mutable state, so read lock
+	assert.Equal(t, 1, countAllocatedPorts(pa, 10))
+	assert.Equal(t, 1, countAllocatedPorts(pa, 11))
+	pa.mutex.RUnlock()
+}
+
+func TestPortAllocatorNodeEvents(t *testing.T) {
+	m := newMocks()
+	pa := NewPortAllocator(10, 20, m.kubeInformationFactory, m.agonInformerFactory)
+	nodeWatch := watch.NewFake()
+	gsWatch := watch.NewFake()
+	m.kubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
+	m.agonClient.AddWatchReactor("gameservers", k8stesting.DefaultWatchReactor(gsWatch, nil))
+
+	stop, cancel := startInformers(m)
+	defer cancel()
+
+	// Make sure the add's don't corrupt the sync
+	nodeWatch.Add(&n1)
+	nodeWatch.Add(&n2)
+
+	err := pa.Run(stop)
+	assert.Nil(t, err)
+
+	// add a game server
+	port, err := pa.Allocate()
+	assert.Nil(t, err)
+	gs := v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs1"}, Spec: v1alpha1.GameServerSpec{HostPort: port}}
+	gsWatch.Add(&gs)
+
+	pa.mutex.RLock()
+	assert.Len(t, pa.portAllocations, 2)
+	assert.Equal(t, 1, countAllocatedPorts(pa, port))
+	pa.mutex.RUnlock()
+
+	// add the n3 node
+	logrus.Info("adding n3")
+	nodeWatch.Add(&n3)
+	assert.True(t, cache.WaitForCacheSync(stop, pa.nodeSynced))
+
+	pa.mutex.RLock()
+	assert.Len(t, pa.portAllocations, 3)
+	assert.Equal(t, 1, countAllocatedPorts(pa, port))
+	pa.mutex.RUnlock()
+
+	// mark the node as unscheduled
+	logrus.Info("unscheduling n3")
+	copy := n3.DeepCopy()
+	copy.Spec.Unschedulable = true
+	assert.True(t, copy.Spec.Unschedulable)
+	nodeWatch.Modify(copy)
+	assert.True(t, cache.WaitForCacheSync(stop, pa.nodeSynced))
+	pa.mutex.RLock()
+	assert.Len(t, pa.portAllocations, 2)
+	assert.Equal(t, 1, countAllocatedPorts(pa, port))
+	pa.mutex.RUnlock()
+
+	// schedule the n3 node again
+	logrus.Info("scheduling n3")
+	copy = n3.DeepCopy()
+	copy.Spec.Unschedulable = false
+	nodeWatch.Modify(copy)
+	assert.True(t, cache.WaitForCacheSync(stop, pa.nodeSynced))
+	pa.mutex.RLock()
+	assert.Len(t, pa.portAllocations, 3)
+	assert.Equal(t, 1, countAllocatedPorts(pa, port))
+	pa.mutex.RUnlock()
+
+	// delete the n3 node
+	logrus.Info("deleting n3")
+	nodeWatch.Delete(n3.DeepCopy())
+	assert.True(t, cache.WaitForCacheSync(stop, pa.nodeSynced))
+	pa.mutex.RLock()
+	assert.Len(t, pa.portAllocations, 2)
+	assert.Equal(t, 1, countAllocatedPorts(pa, port))
+	pa.mutex.RUnlock()
+}
+
+func TestNodePortAllocation(t *testing.T) {
+	t.Parallel()
+
+	m := newMocks()
+	pa := NewPortAllocator(10, 20, m.kubeInformationFactory, m.agonInformerFactory)
+	nodes := []corev1.Node{n1, n2, n3}
+	m.kubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		nl := &corev1.NodeList{Items: nodes}
+		return true, nl, nil
+	})
+	result := pa.nodePortAllocation([]*corev1.Node{&n1, &n2, &n3})
+	assert.Len(t, result, 3)
+	for _, n := range nodes {
+		ports, ok := result[n.ObjectMeta.Name]
+		assert.True(t, ok, "Should have a port allocation for %s", n.ObjectMeta.Name)
+		assert.Len(t, ports, 11)
+		for _, v := range ports {
+			assert.False(t, v)
+		}
+	}
+}
+
+func TestTakePortAllocation(t *testing.T) {
+	t.Parallel()
+
+	fixture := []portAllocation{{1: false, 2: false}, {1: false, 2: false}, {1: false, 3: false}}
+	result := setPortAllocation(2, fixture, true)
+	assert.True(t, result[0][2])
+
+	for i, row := range fixture {
+		for p, taken := range row {
+			if i != 0 && p != 2 {
+				assert.False(t, taken, fmt.Sprintf("row %d and port %d should be false", i, p))
+			}
+		}
+	}
+}
+
+// countAllocatedPorts counts how many of a given port have been
+// allocated across nodes
+func countAllocatedPorts(pa *PortAllocator, p int32) int {
+	count := 0
+	for _, node := range pa.portAllocations {
+		if node[p] {
+			count++
+		}
+	}
+	return count
+}

--- a/install.yaml
+++ b/install.yaml
@@ -44,6 +44,12 @@ spec:
       - name: gameservers-controller
         image: gcr.io/agon-images/gameservers-controller:0.1
         env:
+        # minimum port that can be exposed to GameServer traffic
+        - name: MIN_PORT
+          value: "7000"
+        # maximum port that can be exposed to GameServer traffic
+        - name: MAX_PORT
+          value: "8000"
         # - name: SIDECAR # overwrite the GameServer sidecar image that is used
         #   value: gcr.io/agon-images/gameservers-sidecar:0.1
         livenessProbe:

--- a/pkg/apis/stable/v1alpha1/types.go
+++ b/pkg/apis/stable/v1alpha1/types.go
@@ -44,6 +44,9 @@ const (
 	// Static PortPolicy means that the user defines the hostPort to be used
 	// in the configuration.
 	Static PortPolicy = "static"
+	// Dynamic PortPolicy means that the system will choose an open
+	// port for the GameServer in question
+	Dynamic PortPolicy = "dynamic"
 
 	// RoleLabel is the label in which the Agon role is specified.
 	// Pods from a GameServer will have the value "gameserver"
@@ -102,9 +105,10 @@ type PortPolicy string
 // GameServerStatus is the status for a GameServer resource
 type GameServerStatus struct {
 	// The current state of a GameServer, e.g. Creating, Starting, Ready, etc
-	State   State  `json:"state"`
-	Port    int32  `json:"port"`
-	Address string `json:"address"`
+	State    State  `json:"state"`
+	Port     int32  `json:"port"`
+	Address  string `json:"address"`
+	NodeName string `json:"nodeName"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -123,6 +127,10 @@ func (gs *GameServer) ApplyDefaults() {
 
 	if len(gs.Spec.Template.Spec.Containers) == 1 {
 		gs.Spec.Container = gs.Spec.Template.Spec.Containers[0].Name
+	}
+
+	if gs.Spec.PortPolicy == "" {
+		gs.Spec.PortPolicy = Dynamic
 	}
 
 	if gs.Spec.Protocol == "" {

--- a/pkg/apis/stable/v1alpha1/types_test.go
+++ b/pkg/apis/stable/v1alpha1/types_test.go
@@ -58,6 +58,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 		expectedContainer string
 		expectedProtocol  corev1.Protocol
 		expectedState     State
+		expectedPolicy    PortPolicy
 	}{
 		"set basic defaults on a very simple gameserver": {
 			gameServer: GameServer{
@@ -68,11 +69,13 @@ func TestGameServerApplyDefaults(t *testing.T) {
 			expectedContainer: "testing",
 			expectedProtocol:  "UDP",
 			expectedState:     Creating,
+			expectedPolicy:    Dynamic,
 		},
 		"defaults are already set": {
 			gameServer: GameServer{
 				Spec: GameServerSpec{
 					Container: "testing2", Protocol: "TCP",
+					PortPolicy: Static,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{Containers: []corev1.Container{
 							{Name: "testing", Image: "testing/image"},
@@ -83,6 +86,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 			expectedContainer: "testing2",
 			expectedProtocol:  "TCP",
 			expectedState:     "TestState",
+			expectedPolicy:    Static,
 		},
 	}
 


### PR DESCRIPTION
Implementation of a PortAllocator that ties into the GameServer controller that will allocate a port on
GameServer creations (if "dynamic" portPolicy is set) and then also release the port when a GameServer has been deleted.

This also includes experimental support for node adding, removal and unscheduling within the cluster.

Closes #14