### PR TITLE
Add health check for gameserver-sidecar.

### DIFF
--- a/gameservers/controller/controller.go
+++ b/gameservers/controller/controller.go
@@ -34,6 +34,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -359,6 +360,16 @@ func (c *Controller) syncGameServerCreatingState(gs *stablev1alpha1.GameServer) 
 							},
 						},
 					},
+				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromInt(8080),
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       3,
 				},
 			}
 			if c.alwaysPullSidecarImage {

--- a/gameservers/controller/controller_test.go
+++ b/gameservers/controller/controller_test.go
@@ -382,8 +382,6 @@ func TestSyncGameServerBlankState(t *testing.T) {
 }
 
 func TestSyncGameServerCreatingState(t *testing.T) {
-	t.Parallel()
-
 	newFixture := func() *v1alpha1.GameServer {
 		fixture := &v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec: newSingeContainerSpec(), Status: v1alpha1.GameServerStatus{State: v1alpha1.Creating}}


### PR DESCRIPTION
Adding health check liveness probe to sidecar (#12).

Since sidecars for the GameServers aren't created in yaml config, I added the configuration to the controller startup.

Tested by following [these instructions](https://github.com/googleprivate/agon/blob/master/build/README.md) on a Linux machine and creating a test pod. However, I do not see any sidecar resources listed in `kubectl get all`, much less a test to see if the health check is working. Output from the command is below. Please let me know how to confirm that the sidecar and health check are working as intended.

`kubectl get all` output:

	NAME                            DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
	deploy/gameservers-controller   1         1         1            1           50m

	NAME                                   DESIRED   CURRENT   READY     AGE
	rs/gameservers-controller-3664581478   1         1         1         50m

	NAME                            DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
	deploy/gameservers-controller   1         1         1            1           50m

	NAME                                         READY     STATUS    RESTARTS   AGE
	po/gameservers-controller-3664581478-8d631   1/1       Running   0          6m

`kubectl describe po/gameservers-controller-3664581478-8d631` output:

	Name:           gameservers-controller-3664581478-8d631                                                                                                                                 
	Namespace:      default                                                                                                                                                                 
	Node:           gke-test-cluster-default-434a1e12-jg05/10.138.0.3                                                                                                                       
	Start Time:     Wed, 03 Jan 2018 23:30:05 +0000                                                                                                                                         
	Labels:         pod-template-hash=3664581478                                                                                                                                            
					stable.agon.io/role=controller                                                                                                                                          
	Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"gameservers-controller-3664581478","uid":"e7c43b8f-f0d7-11e7-aed...                                                                                                                                                     
					kubernetes.io/limit-ranger=LimitRanger plugin set: cpu request for container gameservers-controller                                                                     
	Status:         Running                                                                                                                                                                 
	IP:             10.48.1.7                                                                                                                                                               
	Created By:     ReplicaSet/gameservers-controller-3664581478                                                                                                                            
	Controlled By:  ReplicaSet/gameservers-controller-3664581478                                                                                                                            
	Containers:                                                                                                                                                                             
	  gameservers-controller:                                                                                                                                                               
		Container ID:   docker://8b6e51381a6ca627df573beaf4535516f193ab438520b624b2db01c2565b2e45                                                                                           
		Image:          gcr.io/dzlier-work/gameservers-controller:0.1-80b475e                                                                                                               
		Image ID:       docker-pullable://gcr.io/dzlier-work/gameservers-controller@sha256:530f4c226fbff314de58fb82b6b9afb0adb34d7709ea726d0786e1ad858e18d6
		Port:           <none>
		State:          Running
		  Started:      Wed, 03 Jan 2018 23:30:07 +0000
		Ready:          True
		Restart Count:  0
		Requests:
		  cpu:     100m
		Liveness:  http-get http://:8080/healthz delay=3s timeout=1s period=3s #success=1 #failure=3
		Environment:
		  ALWAYS_PULL_SIDECAR:  true
		  SIDECAR:              gcr.io/dzlier-work/gameservers-sidecar:0.1-80b475e
		  MIN_PORT:             7000
		  MAX_PORT:             8000
		Mounts:
		  /var/run/secrets/kubernetes.io/serviceaccount from default-token-pcdw1 (ro)
	Conditions:
	  Type           Status
	  Initialized    True 
	  Ready          True 
	  PodScheduled   True 
	Volumes:
	  default-token-pcdw1:
		Type:        Secret (a volume populated by a Secret)
		SecretName:  default-token-pcdw1
		Optional:    false
	QoS Class:       Burstable
	Node-Selectors:  <none>
	Tolerations:     node.alpha.kubernetes.io/notReady:NoExecute for 300s
					 node.alpha.kubernetes.io/unreachable:NoExecute for 300s
	Events:
	  Type    Reason                 Age   From                                             Message
	  ----    ------                 ----  ----                                             -------
	  Normal  Scheduled              6m    default-scheduler                                Successfully assigned gameservers-controller-3664581478-8d631 to gke-test-cluster-default-434a1e12-jg05
	  Normal  SuccessfulMountVolume  6m    kubelet, gke-test-cluster-default-434a1e12-jg05  MountVolume.SetUp succeeded for volume "default-token-pcdw1"
	  Normal  Pulling                6m    kubelet, gke-test-cluster-default-434a1e12-jg05  pulling image "gcr.io/dzlier-work/gameservers-controller:0.1-80b475e"
	  Normal  Pulled                 6m    kubelet, gke-test-cluster-default-434a1e12-jg05  Successfully pulled image "gcr.io/dzlier-work/gameservers-controller:0.1-80b475e"
	  Normal  Created                6m    kubelet, gke-test-cluster-default-434a1e12-jg05  Created container
	  Normal  Started                6m    kubelet, gke-test-cluster-default-434a1e12-jg05  Started container