### PR TITLE
Header insert on gRPC code gen touched too many files

### DIFF
--- a/build/boilerplate.go.txt
+++ b/build/boilerplate.go.txt
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/build-image/gen-grpc-cpp.sh
+++ b/build/build-image/gen-grpc-cpp.sh
@@ -18,7 +18,7 @@ cd /go/src/github.com/agonio/agon
 protoc -I . --grpc_out=./sdks/cpp --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` sdk.proto
 protoc -I . --cpp_out=./sdks/cpp sdk.proto
 mkdir /tmp/cpp
-ls ./sdks/cpp | xargs -I@ bash -c "cat ./build/boilerplate.go.txt ./sdks/cpp/@ >> /tmp/cpp/@"
+find ./sdks/cpp/ -type f \( -name '*.pb.cc' -or -name '*.pb.h' \) -printf "%f\n" | xargs -I@ bash -c "cat ./build/boilerplate.go.txt ./sdks/cpp/@ >> /tmp/cpp/@"
 # already has a header, so we'll remove it
 rm /tmp/cpp/sdk.grpc.pb.h
 mv /tmp/cpp/* ./sdks/cpp/


### PR DESCRIPTION
Header now only goes in generated files, as appropriate.

Also updated the header boilerplate to Copyright 2018 such that any new generation of code will be updated to the new year.