### PR TITLE
Expand on contributing documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,17 @@ again.
 
 Participation in this project comes under the [Contributor Covenant Code of Conduct](code-of-conduct.md)
 
-## Code reviews
+## Submitting code via Pull Requests
 
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
+- We follow the [Github Pull Request Model](https://help.github.com/articles/about-pull-requests/) for
+  all contributions.
+- For large bodies of work, we recommend creating an issue and labelling it
+  "[kind/design](https://github.com/googleprivate/agones/issues?q=is%3Aissue+is%3Aopen+label%3Akind%2Fdesign)"
+  outlining the feature that you wish to build, and describing how it will be implemented. This gives a chance
+  for review to happen early, and ensures no wasted effort occurs.
+- All submissions, including submissions by project members, will require review before being merged.
+- Once review has occurred, please rebase your PR down to a single commit. This will ensure a nice clean Git history.
+- Finally - *Thanks* for considering submitting code to Agones!
+
+### Additional Resources
+- [How to write a good Git Commit message](How to Write a Git Commit Message) 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ More documentation forthcoming.
 - Mailing List (forthcoming)
 
 ## Development and Contribution
+
+Please read the [contributing](CONTRIBUTING.md) guide for directions on submitting Pull Requests to Agones.
+
 See the tools in the [build](build/README.md) directory for testing and building Agones from source.
+
+Agones is in active development - we would love your help in shaping its future!
 
 ## Licence
 


### PR DESCRIPTION
Add sections on PR expectations, and explicitly link to contributing guideline.