### PR TITLE
Update everything to be Kubernetes 1.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This software is currently alpha, and subject to change. Not to be used in produ
 - Client SDKs for integration with dedicated game servers to work with Agones.
 
 ## Requirements
-- Requires a Kubernetes cluster of version 1.8+
+- Requires a Kubernetes cluster of version 1.9+
 - Open the firewall access for the range of ports that Game Servers can be connected to in the cluster.
 - Game Servers must have the [project SDK](sdks) integrated, to manage Game Server state, health checking, etc.
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -260,7 +260,7 @@ clean-gcloud-config:
 # Use MINIKUBE_DRIVER variable to change the VM driver
 # (defaults virtualbox for Linux and macOS, hyperv for windows) if you so desire.
 minikube-test-cluster: minikube-agones-profile
-	$(MINIKUBE) start --kubernetes-version v1.8.0 --vm-driver $(MINIKUBE_DRIVER) \
+	$(MINIKUBE) start --kubernetes-version v1.9.0 --vm-driver $(MINIKUBE_DRIVER) \
 		--extra-config=apiserver.Authorization.Mode=RBAC
 	# wait until the master is up
 	until docker run --rm $(common_mounts) --network=host -v $(minikube_cert_mount) $(DOCKER_RUN_ARGS) $(build_tag) kubectl cluster-info; \

--- a/build/gke-test-cluster/cluster.yml.jinja
+++ b/build/gke-test-cluster/cluster.yml.jinja
@@ -21,7 +21,7 @@ resources:
     cluster:
       name: test-cluster
       description: Test cluster for Agones
-      initialClusterVersion: 1.8.7-gke.1
+      initialClusterVersion: 1.9.2-gke.1 # be specific until 1.9.x becomes default
       nodePools:
         - name: "default"
           initialNodeCount: 3


### PR DESCRIPTION
Won't merge this until #57 is complete, but gives a base tickets such as #10 and #70 can start working from, and can then be merged at a later date.

*Note:* minikube doesn't start up with RBAC enabled, so development can continue on that platform for the moment.