### PR TITLE
Support builds on macOS

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -53,9 +53,6 @@ common_mounts = -v $(build_path)/.config/gcloud:/root/.config/gcloud \
 				-v $(KUBEPATH):/root/.kube \
 				-v $(agones_path):$(mount_path)
 
-# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
-# it automatically rebuilds
-build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
 build_tag = agones-build:$(build_version)
 build_remote_tag = $(REGISTRY)/$(build_tag)
 controller_tag = $(REGISTRY)/agones-controller:$(VERSION)
@@ -76,7 +73,7 @@ ifneq ($(findstring Microsoft,$(shell uname -r)),)
 else ifeq ($(uname),Linux)
 	osinclude := linux.mk
 else ifeq ($(uname),Darwin)
-	osinclude := osx.mk
+	osinclude := macos.mk
 endif
 
 include ./includes/$(osinclude)
@@ -112,9 +109,10 @@ install: ALWAYS_PULL_SIDECAR := true
 install: IMAGE_PULL_POLICY := "Always"
 install: ensure-build-image
 	cp $(build_path)/install.yaml $(build_path)/.install.yaml
-	sed -i -e 's!$${REGISTRY}!$(REGISTRY)!g' -e 's!$${VERSION}!$(VERSION)!g' \
-		-e 's!$${IMAGE_PULL_POLICY}!$(IMAGE_PULL_POLICY)!g' -e 's!$${ALWAYS_PULL_SIDECAR}!$(ALWAYS_PULL_SIDECAR)!g' \
-		$(build_path)/.install.yaml
+	sed -i -e 's!$${REGISTRY}!$(REGISTRY)!g' $(build_path)/.install.yaml
+	sed -i -e 's!$${VERSION}!$(VERSION)!g' $(build_path)/.install.yaml
+	sed -i -e 's!$${IMAGE_PULL_POLICY}!$(IMAGE_PULL_POLICY)!g' $(build_path)/.install.yaml
+	sed -i -e 's!$${ALWAYS_PULL_SIDECAR}!$(ALWAYS_PULL_SIDECAR)!g' $(build_path)/.install.yaml
 	docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) kubectl apply -f $(mount_path)/build/.install.yaml
 
 # Build a static binary for the gameserver controller
@@ -258,8 +256,8 @@ clean-gcloud-config:
 # Switches to an "agones" profile, and starts a kubernetes cluster
 # of the right version.
 #
-# Use MINIKUBE_DRIVER variable to change the VM driver 
-# (defaults virtualbox for Linux and OSX, hyperv for windows) if you so desire.
+# Use MINIKUBE_DRIVER variable to change the VM driver
+# (defaults virtualbox for Linux and macOS, hyperv for windows) if you so desire.
 minikube-test-cluster: minikube-agones-profile
 	$(MINIKUBE) start --kubernetes-version v1.8.0 --vm-driver $(MINIKUBE_DRIVER)
 	$(MAKE) minikube-post-start

--- a/build/README.md
+++ b/build/README.md
@@ -14,7 +14,7 @@ tasks you may wish to accomplish.
    1. [Building on Different Platforms](#building-on-different-platforms)
       1. [Linux](#linux)
       1. [Windows](#windows)
-      1. [OSX](#osx)
+      1. [macOS](#macOS)
    1. [GOPATH](#gopath)
    1. [Testing and Building](#testing-and-building)
       1. [Running a Test Google Kubernetes Engine Cluster](#running-a-test-google-kubernetes-engine-cluster)
@@ -60,7 +60,7 @@ as this makes it easy to create a (relatively) cross platform development and bu
   driver - the same virtualisation platform as the Docker installation.
 - **Note**: If you want to dev and test with Minikube, you **must** run WSL as Administrator, otherwise Minikube can't control HyperV.
 
-### OSX
+### macOS
 
 - Install Make, `brew install make`, if it's not installed already
 - Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
@@ -71,9 +71,7 @@ This has currently yet to be tested, but should have few issues around testing, 
 
 Issues with building and developing on Minikube are currently expected, due to lack of testing, but Agones will run on Minikube.  
 
-Testing on OSX and reporting bugs are appreciated. 
-
-You can see progress on this on the [Build Agones on OSX](https://github.com/googleprivate/agones/issues/46) ticket.
+Testing on macOS and reporting bugs are appreciated.
 
 ## GOPATH
 
@@ -326,8 +324,8 @@ Since Minikube runs locally, there are some targets that need to be used instead
 Switches to an "agones" profile, and starts a kubernetes cluster
 of the right version.
 
-Use MINIKUBE_DRIVER variable to change the VM driver 
-(defaults virtualbox for Linux and OSX, hyperv for windows) if you so desire.
+Use MINIKUBE_DRIVER variable to change the VM driver
+(defaults virtualbox for Linux and macOS, hyperv for windows) if you so desire.
 
 #### `minikube-push`
 Push the local Agones Docker images that have already been built 

--- a/build/includes/linux.mk
+++ b/build/includes/linux.mk
@@ -23,6 +23,10 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
+# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
+# it automatically rebuilds
+build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
+
 # Minikube executable
 MINIKUBE ?= minikube
 # Default minikube driver

--- a/build/includes/macos.mk
+++ b/build/includes/macos.mk
@@ -23,6 +23,10 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
+# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
+# it automatically rebuilds
+build_version := $(shell shasum -a 256 $(build_path)/build-image/Dockerfile | head -c 10)
+
 # Minikube executable
 MINIKUBE ?= minikube
 # Default minikube driver

--- a/build/includes/windows.mk
+++ b/build/includes/windows.mk
@@ -23,6 +23,10 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
+# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
+# it automatically rebuilds
+build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
+
 # Minikube executable
 MINIKUBE ?= minikube.exe
 # Default minikube driver


### PR DESCRIPTION
In addition to renaming occurrences of OS X to macOS, this commit makes some minor changes to the Makefile to ensure macOS users can build Agones.

Fixes #46.