### PR TITLE
Adding CoC and Discuss mailing lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ More documentation forthcoming.
 
 - Slack (forthcoming)
 - [Twitter](https://twitter.com/agonesdev)
-- Mailing List (forthcoming)
+- [Mailing List](https://groups.google.com/forum/#!forum/agones-discuss) 
 
 ## Development and Contribution
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at mark.mandel@gmail.com. All
+reported by contacting the project team at [agones-coc@googlegroups.com](mailto:agones-coc@googlegroups.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Created lists for discussing usage/development of Agones as well as a mailing list for CoC discussion and reports.

As an aside, if anyone wants to help on the CoC side of things, drop me a line, and I'll add you to the group.