### PR TITLE
Add CRD validation via OpenAPIv3 Schema

### DIFF
--- a/build/install.yaml
+++ b/build/install.yaml
@@ -31,6 +31,99 @@ spec:
     shortNames:
     - gs
     singular: gameserver
+  validation:
+    openAPIV3Schema:
+      required:
+      - spec
+      properties:
+        spec:
+          required:
+          - containerPort
+          - template
+          properties:
+            template:
+              type: object
+              required:
+              - spec
+              properties:
+                spec:
+                  type: object
+                  required:
+                  - containers
+                  properties:
+                    containers:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - image
+                        properties:
+                          name:
+                            type: string
+                            minLength: 0
+                            maxLength: 63
+                            pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                          image:
+                            type: string
+                            minLength: 1
+                      minItems: 1
+            container:
+              title: The container name running the gameserver
+              description: if there is more than one container, specify which one is the game server
+              type: string
+              minLength: 0
+              maxLength: 63
+              pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            portPolicy:
+              title: the port policy that will be applied to the game server
+              description: |
+                  portPolicy has two options:
+                  - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
+                  - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+                  port is available. When static is the policy specified, `hostPort` is required to be populated
+              type: string
+              enum:
+              - dynamic
+              - static
+            protocol:
+              title: Protocol being used. Defaults to UDP. TCP is the only other option
+              type: string
+              enum:
+              - UDP
+              - TCP
+            containerPort:
+              title: The port that is being opened on the game server process
+              type: integer
+              minimum: 0
+              maximum: 65535
+            hostPort:
+              title: The port exposed on the host
+              description: Only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
+              type: integer
+              minimum: 0
+              maximum: 65535
+            health:
+              type: object
+              title: Health checking for the running game server
+              properties:
+                disabled:
+                  title: Disable health checking. defaults to false, but can be set to true
+                  type: boolean
+                initialDelaySeconds:
+                  title: Number of seconds after the container has started before health check is initiated. Defaults to 5 seconds
+                  type: integer
+                  minimum: 0
+                  maximum: 2147483648
+                periodSeconds:
+                  title: How long before the server is considered not healthy
+                  type: integer
+                  minimum: 0
+                  maximum: 2147483648
+                failureThreshold:
+                  title: Minimum consecutive failures for the health probe to be considered failed after having succeeded.
+                  type: integer
+                  minimum: 1
+                  maximum: 2147483648
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/install.yaml
+++ b/install.yaml
@@ -31,6 +31,99 @@ spec:
     shortNames:
     - gs
     singular: gameserver
+  validation:
+    openAPIV3Schema:
+      required:
+      - spec
+      properties:
+        spec:
+          required:
+          - containerPort
+          - template
+          properties:
+            template:
+              type: object
+              required:
+              - spec
+              properties:
+                spec:
+                  type: object
+                  required:
+                  - containers
+                  properties:
+                    containers:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - image
+                        properties:
+                          name:
+                            type: string
+                            minLength: 0
+                            maxLength: 63
+                            pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                          image:
+                            type: string
+                            minLength: 1
+                      minItems: 1
+            container:
+              title: The container name running the gameserver
+              description: if there is more than one container, specify which one is the game server
+              type: string
+              minLength: 0
+              maxLength: 63
+              pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            portPolicy:
+              title: the port policy that will be applied to the game server
+              description: |
+                  portPolicy has two options:
+                  - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
+                  - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+                  port is available. When static is the policy specified, `hostPort` is required to be populated
+              type: string
+              enum:
+              - dynamic
+              - static
+            protocol:
+              title: Protocol being used. Defaults to UDP. TCP is the only other option
+              type: string
+              enum:
+              - UDP
+              - TCP
+            containerPort:
+              title: The port that is being opened on the game server process
+              type: integer
+              minimum: 0
+              maximum: 65535
+            hostPort:
+              title: The port exposed on the host
+              description: Only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
+              type: integer
+              minimum: 0
+              maximum: 65535
+            health:
+              type: object
+              title: Health checking for the running game server
+              properties:
+                disabled:
+                  title: Disable health checking. defaults to false, but can be set to true
+                  type: boolean
+                initialDelaySeconds:
+                  title: Number of seconds after the container has started before health check is initiated. Defaults to 5 seconds
+                  type: integer
+                  minimum: 0
+                  maximum: 2147483648
+                periodSeconds:
+                  title: How long before the server is considered not healthy
+                  type: integer
+                  minimum: 0
+                  maximum: 2147483648
+                failureThreshold:
+                  title: Minimum consecutive failures for the health probe to be considered failed after having succeeded.
+                  type: integer
+                  minimum: 1
+                  maximum: 2147483648
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This will prevent bad usage.

There is still some validations that we should add to #10 and fix via webhook.

- Container should be required if multiple containers are specified in the PodSpecTemplate.
- HostPort should only be passed if PortPolicy is static. (there is a typo in  #10 )

For the health I think we can live with default values.