### PR TITLE
Add an `source` to all log statements

### DIFF
--- a/pkg/apis/stable/v1alpha1/types_test.go
+++ b/pkg/apis/stable/v1alpha1/types_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"agones.dev/agones/pkg/apis/stable"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -218,7 +217,6 @@ func TestGameServerPod(t *testing.T) {
 	assert.Equal(t, fixture.Spec.HostPort, pod.Spec.Containers[0].Ports[0].HostPort)
 	assert.Equal(t, fixture.Spec.ContainerPort, pod.Spec.Containers[0].Ports[0].ContainerPort)
 	assert.Equal(t, corev1.Protocol("UDP"), pod.Spec.Containers[0].Ports[0].Protocol)
-	logrus.SetFormatter(&logrus.JSONFormatter{})
 	assert.True(t, metav1.IsControlledBy(pod, fixture))
 
 	sidecar := corev1.Container{Name: "sidecar", Image: "container/sidecar"}

--- a/pkg/util/runtime/runtime.go
+++ b/pkg/util/runtime/runtime.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
+const sourceKey = "source"
+
 // stackTracer is the pkg/errors stacktrace interface
 type stackTracer interface {
 	StackTrace() errors.StackTrace
@@ -31,6 +33,8 @@ type stackTracer interface {
 
 // replace the standard glog error logger, with a logrus one
 func init() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+
 	runtime.ErrorHandlers[0] = func(err error) {
 		if stackTrace, ok := err.(stackTracer); ok {
 			var stack []string
@@ -57,4 +61,15 @@ func Must(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// NewLoggerWithSource returns a logrus.Entry to use when you want to specify an source
+func NewLoggerWithSource(source string) *logrus.Entry {
+	return logrus.WithField(sourceKey, source)
+}
+
+// NewLoggerWithType returns a logrus.Entry to use when you want to use a data type as the source
+// such as when you have a struct with methods
+func NewLoggerWithType(obj interface{}) *logrus.Entry {
+	return NewLoggerWithSource(fmt.Sprintf("%T", obj))
 }


### PR DESCRIPTION
This includes a `logger` as a data members for all objects, which sets a default "source" field on every log statement so that it's easy to track where log messages are coming from.

This is particularly useful as the overall controller for Agones gets more complicated, and we have many interacting controllers in a single binary.

Log statements now look like this:
```json
{"level":"info","msg":"Wait for cache sync","source":"*gameservers.Controller","time":"2018-02-22T22:58:58Z"}
{"level":"info","msg":"Running","origin":"*gameservers.PortAllocator","time":"2018-02-22T22:58:58Z"}
{"level":"info","msg":"Flush cache sync, before syncing gameserver and node state","source":"*gameservers.PortAllocator","time":"2018-02-22T22:58:58Z"}
{"level":"info","msg":"Adding Node to port allocations","node":"agones","source":"*gameservers.PortAllocator","time":"2018-02-22T22:58:58Z"}
{"level":"info","msg":"Resetting Port Allocation","origin":"*gameservers.PortAllocator","time":"2018-02-22T22:58:58Z"}
{"level":"info","msg":"Starting workers...","source":"*gameservers.Controller","time":"2018-02-22T22:58:58Z"}
{"level":"info","msg":"Starting worker","source":"*gameservers.HealthController","time":"2018-02-22T22:58:58Z"}
```

So now you can see the context of the log statement through the "source" field.

Would love to hear your thoughts on if this is a good idea, if there is a better word than "origin", or anything else - @dzlier-gcp @enocom @Kuqd 