### PR TITLE
add hostPort and container validations to webhook

### DIFF
--- a/pkg/apis/stable/v1alpha1/types_test.go
+++ b/pkg/apis/stable/v1alpha1/types_test.go
@@ -180,14 +180,23 @@ func TestGameServerValidate(t *testing.T) {
 
 	gs = GameServer{
 		Spec: GameServerSpec{
-			Container: "nope",
+			Container:  "",
+			HostPort:   5001,
+			PortPolicy: Dynamic,
 			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "testing", Image: "testing/image"}}}}},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "testing", Image: "testing/image"},
+					{Name: "anothertest", Image: "testing/image"},
+				}}}},
 	}
 	ok, causes = gs.Validate()
+	fields := []string{}
+	for _, f := range causes {
+		fields = append(fields, f.Field)
+	}
 	assert.False(t, ok)
-	assert.Len(t, causes, 1)
-	assert.Equal(t, causes[0].Field, "container")
+	assert.Len(t, causes, 3)
+	assert.Contains(t, fields, "container", "hostPort")
 	assert.Equal(t, causes[0].Type, metav1.CauseTypeFieldValueInvalid)
 }
 


### PR DESCRIPTION
I have added the remaining validations:
- Container is mandatory if multiple containers are specified in the pod.
- HostPort should only be used with static PortPolicy

I've still added the Container one even though this `_, _, err := gs.FindGameServerContainer()` would satisfy it, I think having a better error message make sense.

fixes #10 unless you want to wait for PodSpecTemplate via ref on the OpenAPIv3

