### PR TITLE
Move WaitForEstablishedCRD into central `crd` package

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"agones.dev/agones/pkg/apis/stable"
 	stablev1alpha1 "agones.dev/agones/pkg/apis/stable/v1alpha1"
@@ -26,6 +25,7 @@ import (
 	getterv1alpha1 "agones.dev/agones/pkg/client/clientset/versioned/typed/stable/v1alpha1"
 	"agones.dev/agones/pkg/client/informers/externalversions"
 	listerv1alpha1 "agones.dev/agones/pkg/client/listers/stable/v1alpha1"
+	"agones.dev/agones/pkg/util/crd"
 	"agones.dev/agones/pkg/util/runtime"
 	"agones.dev/agones/pkg/util/webhooks"
 	"agones.dev/agones/pkg/util/workerqueue"
@@ -34,14 +34,12 @@ import (
 	"github.com/sirupsen/logrus"
 	admv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apiv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	extclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -231,7 +229,7 @@ func (c *Controller) Run(threadiness int, stop <-chan struct{}) error {
 	}()
 	defer c.server.Close() // nolint: errcheck
 
-	err := c.waitForEstablishedCRD()
+	err := crd.WaitForEstablishedCRD(c.crdGetter, "gameservers.stable.agones.dev", c.logger)
 	if err != nil {
 		return err
 	}
@@ -605,27 +603,4 @@ func (c *Controller) address(pod *corev1.Pod) (string, error) {
 	}
 
 	return "", errors.Errorf("Could not find an address for Node: %s", node.ObjectMeta.Name)
-}
-
-// waitForEstablishedCRD blocks until CRD comes to an Established state.
-// Has a deadline of 60 seconds for this to occur.
-func (c *Controller) waitForEstablishedCRD() error {
-	return wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (done bool, err error) {
-		crd, err := c.crdGetter.Get("gameservers.stable.agones.dev", metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiv1beta1.Established:
-				if cond.Status == apiv1beta1.ConditionTrue {
-					c.logger.WithField("crd", crd).Info("GameServer custom resource definition is established")
-					return true, err
-				}
-			}
-		}
-
-		return false, nil
-	})
 }

--- a/pkg/util/crd/crd.go
+++ b/pkg/util/crd/crd.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package crd contains utilities for working with
+// CustomResourceDefinitions
+package crd
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	apiv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// WaitForEstablishedCRD blocks until CRD comes to an Established state.
+// Has a deadline of 60 seconds for this to occur.
+func WaitForEstablishedCRD(crdGetter extv1beta1.CustomResourceDefinitionInterface, name string, logger *logrus.Entry) error {
+	return wait.PollImmediate(time.Second, 60*time.Second, func() (done bool, err error) {
+		crd, err := crdGetter.Get(name, v1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiv1beta1.Established:
+				if cond.Status == apiv1beta1.ConditionTrue {
+					logger.WithField("crd", crd.ObjectMeta.Name).Info("custom resource definition established")
+					return true, err
+				}
+			}
+		}
+
+		return false, nil
+	})
+}

--- a/pkg/util/crd/crd_test.go
+++ b/pkg/util/crd/crd_test.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crd
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestWaitForEstablishedCRD(t *testing.T) {
+	t.Parallel()
+	crd := &v1beta1.CustomResourceDefinition{
+		Status: v1beta1.CustomResourceDefinitionStatus{
+			Conditions: []v1beta1.CustomResourceDefinitionCondition{{
+				Type:   v1beta1.Established,
+				Status: v1beta1.ConditionTrue,
+			}},
+		},
+	}
+
+	t.Run("CRD already established", func(t *testing.T) {
+		extClient := &extfake.Clientset{}
+		extClient.AddReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, crd, nil
+		})
+
+		err := WaitForEstablishedCRD(extClient.ApiextensionsV1beta1().CustomResourceDefinitions(), "test", logrus.WithField("test", "already-established"))
+		assert.Nil(t, err)
+	})
+
+	t.Run("CRD takes a second to become established", func(t *testing.T) {
+		extClient := &extfake.Clientset{}
+		m := sync.RWMutex{}
+		established := false
+
+		extClient.AddReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			m.RLock()
+			defer m.RUnlock()
+			if established {
+				return true, crd, nil
+			}
+			return false, nil, nil
+		})
+
+		go func() {
+			time.Sleep(3 * time.Second)
+			m.Lock()
+			defer m.Unlock()
+			established = true
+		}()
+
+		err := WaitForEstablishedCRD(extClient.ApiextensionsV1beta1().CustomResourceDefinitions(), "test", logrus.WithField("test", "already-established"))
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
Make this reusable as we are adding more CustomResourceDefinitions