### PR TITLE
Zip archive of sdk server server binaries for release

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -136,6 +136,8 @@ build-agones-sdk-binary: ensure-build-image
 		-o $(mount_path)/cmd/sdk-server/bin/sdk-server.darwin.amd64 $(go_version_flags) $(agones_package)/cmd/sdk-server
 	docker run --rm -e "GOOS=windows" -e "GOARCH=amd64" $(common_mounts) $(build_tag) go build \
 		-o $(mount_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_version_flags) $(agones_package)/cmd/sdk-server
+	docker run --rm $(common_mounts) -w $(mount_path)/cmd/sdk-server/bin/ $(build_tag) zip \
+		agonessdk-server-$(VERSION).zip sdk-server.darwin.amd64 sdk-server.linux.amd64 sdk-server.windows.amd64.exe
 
 # Build the image for the gameserver sidecar
 build-agones-sdk-image: ensure-build-image build-agones-sdk-binary

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -19,7 +19,7 @@
 FROM grpc/cxx:1.8
 
 RUN apt-get update && \
-    apt-get install -y wget rsync make python bash-completion && \
+    apt-get install -y wget rsync make python bash-completion zip && \
     apt-get clean
 
 # install go

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,6 +34,9 @@ steps:
 - name: 'gcr.io/cloud-builders/gsutil'
   dir: "sdks/cpp/bin"
   args: ['cp', '*.tar.gz', 'gs://agones-artifacts/cpp-sdk']
+- name: 'gcr.io/cloud-builders/gsutil'
+  dir: "cmd/sdk-server/bin"
+  args: ['cp', '*.zip', 'gs://agones-artifacts/sdk-server']
 - name: "make-docker"
   dir: "build"
   args: ["push-build-image"] # push the build image (which won't do anything if it's already there)


### PR DESCRIPTION
This creates a versions zip with all the os versions of the sdk server binary, so it can be distributed with development build, and final release.

This also includes the step to upload it to a GCS bucket so it can be shared on pull requests to the project.

Closes #87