### PR TITLE
Extend documentation for SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,16 @@ development release or [build from source](build/README.md)
 
 Documentation and usage guides on how to develop and host dedicated game servers on top of Agones.
 
-More documentation forthcoming.
-
-### Quickstarts: 
+### Quickstarts:
  - [Create a Game Server](./docs/create_gameserver.md)
 
 ### Guides
- - Integrating the C++ SDK (forthcoming)
+ - [Integrating the Game Server SDK](sdks)
  - [GameServer Health Checking](./docs/health_checking.md)
  - [Accessing Agones via the Kubernetes API](./docs/access_api.md)
 
 ### Reference
 - [Game Server Specification](./docs/gameserver_spec.md)
-- [SDK](sdks)
 
 ### Examples
 - [Full GameServer Configuration](./examples/gameserver.yaml)

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -6,7 +6,7 @@ They are required for a game server to work with Agones.
 
 There are currently two support SDKs:
 - [C++](cpp)
-- [Go](go)
+- [Go](https://godoc.org/agones.dev/agones/sdks/go)
 
 The SDKs are relatively thin wrappers around [gRPC](https://grpc.io), generated clients,
 which connects to a small process that Agones coordinates to run alongside the Game Server
@@ -20,11 +20,11 @@ While each of the SDKs are canonical to their languages, they all have the follo
 functions that implement the core responsibilities of the SDK.
 
 For language specific documentation, have a look at the respective source (linked above), 
-and the [examples](../examples)
+and the [examples](../examples).
 
 ### Ready()
 This tells Agones that the Game Server is ready to take player connections.
-One a Game Server has specified that it is `Ready`, then the Kubernetes
+Once a Game Server has specified that it is `Ready`, then the Kubernetes
 GameServer record will be moved to the `Ready` state, and the details
 for its public address and connection port will be populated.
 
@@ -42,18 +42,9 @@ The GameServer state will be set `Shutdown` and the
 backing Pod will be deleted, if they have not shut themselves down already. 
 
 ## Local Development
-_Note:_ There has yet to be a release of Agones, so if you want the local
-development tools, you will need to [build from source](build/README.md).
-
-If you do not wish to `make build` and build everything, 
-the `make` target `build-agones-sdk-binary` will compile the necessary binaries
-for all supported operating systems (64 bit windows, linux and osx).
-
-You can find the binaries in the `bin` folder in [`cmd/sdk-server`](../cmd/sdk-server)
-once compilation is complete.
 
 When the game server is running on Agones, the SDK communicates over TCP to a small
-gRPC server that Agones coordinated to runs in a container in the same network 
+gRPC server that Agones coordinated to run in a container in the same network 
 namespace as it - usually referred to in Kubernetes terms as a "sidecar".
 
 Therefore, when developing locally, we also need a process for the SDK to connect to!
@@ -63,6 +54,14 @@ to run it in "local mode". Local mode means that the sidecar binary
 won't try and connect to anything, and will just send logs messages to stdout so 
 that you can see exactly what the SDK in your game server is doing, and can
 confirm everything works.
+
+To do this you will need to download the latest agonessdk-server-{VERSION}.zip from 
+[releases](https://github.com/googlecloudplatform/agones/releases), and unzip it.
+You will find the executables for the SDK server, one for each type of operating system.
+
+- `sdk-server.windows.amd64.exe` - Windows
+- `sdk-server.darwin.amd64` - macOS  
+-  `sdk-server.linux.amd64` - Linux
 
 To run in local mode, pass the flag `--local` to the executable.
 
@@ -74,3 +73,14 @@ $ ./sidecar.linux.amd64 --local
 {"level":"info","msg":"Ready request has been received!","time":"2017-12-22T16:09:19-08:00"}
 {"level":"info","msg":"Shutdown request has been received!","time":"2017-12-22T16:10:19-08:00"}
 ```
+
+### Building the Local Tools
+
+If you wish to build the binaries for local development from source
+the `make` target `build-agones-sdk-binary` will compile the necessary binaries
+for all supported operating systems (64 bit windows, linux and osx).
+
+You can find the binaries in the `bin` folder in [`cmd/sdk-server`](../cmd/sdk-server)
+once compilation is complete.
+
+See [Developing, Testing and Building Agones](../build) for more details.

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -1,22 +1,84 @@
 # C++ Game Server Client SDK
 
+This is the C++ version of the Agones Game Server Client SDK. 
+Check the [Client SDK Documentation](../) for more details on each of the SDK functions and how to run the SDK locally.
+
 ## Usage
-Read the [SDK Overview](../), check out [sdk.h](sdk.h) and also look at the
+
+The C++ SDK is specifically designed to be as simple as possible, and deliberately doesn't include any kind
+of singleton management, or threading/asynchronous processing to allow developers to manage these aspects as they deem
+appropriate for their system.  
+
+We may consider these types of features in the future, depending on demand. 
+
+To begin working with the SDK, create an instance of it.
+```cpp
+agones::SDK *sdk = new agones::SDK();
+```
+
+To connect to the SDK server, either local or when running on Agones, run the `sdk->Connect()` method.
+This will block for up to 30 seconds if the SDK server has not yet started and the connection cannot be made,
+and will return `false` if there was an issue connecting.
+
+```cpp
+bool ok = sdk->Connect();
+```
+
+To send a [health check](../README.md#health) ping call `sdk->Health()`. This is a synchronous request that will
+return `false` if it has failed in any way. Read [GameServer Health Checking](../../docs/health_checking.md) for more
+details on the game server health checking strategy.
+
+```cpp
+bool ok = sdk->Health();
+```
+
+To mark the game server as [ready to receive player connections](../README.md#ready), call `sdk->Ready()`.
+This will return a grpc::Status object, from which we can call `status.ok()` to determine
+if the function completed successfully.
+
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html)
+
+```cpp
+grpc::Status status = sdk->Ready();
+if (!status.ok()) { ... }
+```
+
+To mark that the [game session is completed](../README.md#shutdown) and the game server should be shut down call `sdk->Shutdown()`. 
+
+This will return a grpc::Status object, from which we can call `status.ok()` to determine
+if the function completed successfully.
+
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html)
+
+
+```cpp
+grpc::Status status = sdk->Shutdown();
+if (!status.ok()) { ... }
+```
+
+For more information, you can also read the [SDK Overview](../), check out [sdk.h](sdk.h) and also look at the
 [C++ example](../../examples/cpp-simple).
 
-## Dynamic and Static Libraries
-_Note:_ There has yet to be a release of Agones, so if you want static and dynamic libraries,
-you will need to [build from source](build/README.md).
+### Failure
+When running on Agones, the above functions should only fail under exceptional circumstances, so please 
+file a bug if it occurs.
 
-If you do not wish to `make build` and build everything, 
-the `make` target `build-sdk-cpp` will compile both static and dynamic libraries for Debian/Linux
-for your usage, and build two archives that can be untar'd in `/usr/local` (or wherever you like
-to keep you .h and .so/.a files) in a `bin` directory inside this one.
+## Dynamic and Static Libraries
+
+In the [releases](https://github.com/googlecloudplatform/agones/releases) folder
+you will find two archives for download that contain both static and dynamic libraries for building your
+game server on Linux:
 
 - `argonsdk-$(VERSION)-dev-linux-arch_64.tar.gz`: This includes all the 
 headers as well as dynamic and static libraries that are needed for development and runtime.
 - `argonsdk-$(VERSION)-runtime-linux-arch_64.tar.gz`: This includes just the dynamic libraries that 
 are needed to run a binary compiled against the SDK and its dependencies.
+
+### Building the Libraries
+
+If you want to build the libraries from Agones source, 
+the `make` target `build-sdk-cpp` will compile both static and dynamic libraries for Debian/Linux
+for your usage, to be found in the `bin` directory inside this one.
 
 ## Building From Source
 If you wish to compile from source, you will need to compile and install the following dependencies:
@@ -26,3 +88,9 @@ If you wish to compile from source, you will need to compile and install the fol
 
 For convenience, it's worth noting that protobuf is include in gRPC's source code, in the `third_party`
 directory, and can be compiled from there, rather than being pulling down separately.
+
+## Windows and macOS
+
+If you are building a server on Windows or macOS, and need a development build to run on
+that platform, at this time you will need to compile from source. Windows and macOS libraries
+for the C++ SDK for easier cross platform development are planned and will be provided in the near future.


### PR DESCRIPTION
This includes updates for the fact we will have releases soon, as well as extending the documentation for the C++ SDK, as that will likely be the most popular.