### PR TITLE
Introduce GameServer Status Subresource

### DIFF
--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -53,5 +53,7 @@ spec:
   validation:
     openAPIV3Schema:
       {{- include "gameserver.validation" . | indent 6 }}
+  subresources:
+    status: {}
 
 {{- end }}

--- a/install/helm/agones/templates/extensions.yaml
+++ b/install/helm/agones/templates/extensions.yaml
@@ -74,6 +74,7 @@ webhooks:
           - "fleets"
           - "gameservers"
           - "gameserversets"
+          - "gameservers/status"
           - "fleetallocations"
           - "fleetautoscalers"
         apiVersions:
@@ -85,6 +86,7 @@ webhooks:
         resources:
           - "fleets"
           - "gameserversets"
+          - "gameservers/status"
           - "fleetallocations"
           - "fleetautoscalers"
         apiVersions:
@@ -120,6 +122,7 @@ webhooks:
           - stable.agones.dev
         resources:
           - "gameservers"
+          - "gameservers/status"
           - "fleets"
           - "fleetallocations"
         apiVersions:

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -50,7 +50,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["get"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["gameservers", "gameserversets"]
+  resources: ["gameservers", "gameserversets", "gameservers/status"]
   verbs: ["create", "delete", "get", "list", "update", "watch"]
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]

--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -41,7 +41,7 @@ rules:
   resources: ["events"]
   verbs: ["create"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["gameservers"]
+  resources: ["gameservers", "gameservers/status"]
   verbs: ["list", "update", "watch"]
 ---
   {{- range .Values.gameservers.namespaces }}

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -48,7 +48,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["get"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["gameservers", "gameserversets"]
+  resources: ["gameservers", "gameserversets", "gameservers/status"]
   verbs: ["create", "delete", "get", "list", "update", "watch"]
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
@@ -676,6 +676,8 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 2147483648
+  subresources:
+    status: {}
 
 ---
 # Source: agones/templates/crds/gameserverallocationpolicy.yaml

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -151,7 +151,7 @@ rules:
   resources: ["events"]
   verbs: ["create"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["gameservers"]
+  resources: ["gameservers", "gameservers/status"]
   verbs: ["list", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1379,3 +1379,111 @@ description: "This priority class should be used for Agones service pods only."
 # Source: agones/templates/hooks/scripts.yaml
 
 
+<<<<<<< HEAD
+=======
+---
+# Source: agones/templates/admissionregistration.yaml
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: agones-validation-webhook
+webhooks:
+  - name: validations.stable.agones.dev
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        name: agones-controller-service
+        namespace: agones-system
+        path: /validate
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVLVENDQXhHZ0F3SUJBZ0lKQU9KUDY0MTB3dkdTTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdxTVFzd0NRWUQKVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFUE1BMEdBMVVFQ2d3R1FXZHZibVZ6TVE4dwpEUVlEVlFRTERBWkJaMjl1WlhNeE5EQXlCZ05WQkFNTUsyRm5iMjVsY3kxamIyNTBjbTlzYkdWeUxYTmxjblpwClkyVXVZV2R2Ym1WekxYTjVjM1JsYlM1emRtTXhMakFzQmdrcWhraUc5dzBCQ1FFV0gyRm5iMjVsY3kxa2FYTmoKZFhOelFHZHZiMmRzWldkeWIzVndjeTVqYjIwd0hoY05NVGd3TWpFME1EUTBORFEyV2hjTk1qZ3dNakV5TURRMApORFEyV2pDQnFqRUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeER6QU5CZ05WCkJBb01Ca0ZuYjI1bGN6RVBNQTBHQTFVRUN3d0dRV2R2Ym1Wek1UUXdNZ1lEVlFRRERDdGhaMjl1WlhNdFkyOXUKZEhKdmJHeGxjaTF6WlhKMmFXTmxMbUZuYjI1bGN5MXplWE4wWlcwdWMzWmpNUzR3TEFZSktvWklodmNOQVFrQgpGaDloWjI5dVpYTXRaR2x6WTNWemMwQm5iMjluYkdWbmNtOTFjSE11WTI5dE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXpnVlQ5MGVqeE5ud0NvL09qTUQyNmZVNGRya1NlZndkUWd3aWJpZmEKbDhyazZZMFZ2T0lWMUgrbFJvd2UwNm1XTnVSNUZPWEZBMGZYbHZ4Q0tLWVZRcFNQRUsyWVN5aC9hU25KUUw2cQpvOGVBWVRKQmtPWUxCNUNiekl6aVdlb1FmT1lOOE1sRW44YlhKZGllSmhISDhVbnlqdHlvVGx4emhabVgrcGZ0CmhVZGVhM1Zrek8yMW40K1FFM1JYNWYxMzJGVEZjdXFYT1VBL3BpOGNjQU5HYzN6akxlWkp2QTlvZFBFaEdmN2cKQzhleUE2OFNWY3NoK1BqejBsdzk1QVB2bE12MWptcVVSRldjRVNUTGFRMEZ4NUt3UnlWMHppWm1VdkFBRjJaeApEWmhIVWNvRlBIQXdUbDc1TkFobkhwTWxMTnA1TDd0Y1ZkeVQ4QjJHUnMrc2xRSURBUUFCbzFBd1RqQWRCZ05WCkhRNEVGZ1FVZ3YxblRQYVFKU04zTHFtNWpJalc0eEhtZEcwd0h3WURWUjBqQkJnd0ZvQVVndjFuVFBhUUpTTjMKTHFtNWpJalc0eEhtZEcwd0RBWURWUjBUQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSEtFQwprdEVqWU5VQ0ErbXlzejRvclc3cFJVdmhCSERWU2dzWTZlRVZSTHpmLzF5SVpFMHU2NTZrcEs2T1Q3TWhKR2xVCkt3R1NTb1VCQnpWZ1VzWmpEbTdQZ2JrNGlZem40TTF4THpiTFFCcjNNYzV6WEhlZlB2YmltaEQ1NWNMenBWRnUKVlFtQm1aVjJOalU1RHVTZFJuZGxjUGFOY2cvdU9jdlpLNEtZMUtDQkEzRW9BUUlrcHpIWDJpVU1veGlSdlpWTgpORXdnRlR0SUdCWW4wSGZML3ZnT3NIOGZWck1Va3VHMnZoR2RlWEJwWmlxL0JaSmJaZU4yckNmMmdhWDFRSXYwCkVLYmN1RnFNOThXVDVaVlpSdFgxWTNSd2V2ZzRteFlKWEN1SDZGRjlXOS9TejI5NEZ5Mk9CS0I4SkFWYUV4OW4KMS9pNmZJZmZHbkhUWFdIc1ZRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    rules:
+      - apiGroups:
+          - stable.agones.dev
+        resources:
+          - "fleets"
+          - "gameservers"
+          - "gameserversets"
+          - "gameservers/status"
+          - "fleetallocations"
+          - "fleetautoscalers"
+        apiVersions:
+          - "v1alpha1"
+        operations:
+          - CREATE
+      - apiGroups:
+          - stable.agones.dev
+        resources:
+          - "fleets"
+          - "gameserversets"
+          - "gameservers/status"
+          - "fleetallocations"
+          - "fleetautoscalers"
+          - "gameserverallocations"
+        apiVersions:
+          - "v1alpha1"
+        operations:
+          - UPDATE
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: agones-mutation-webhook
+  labels:
+    component: controller
+    app: agones
+    chart: agones-0.9.0
+    release: agones-manual
+    heritage: Tiller
+webhooks:
+  - name: mutations.stable.agones.dev
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        name: agones-controller-service
+        namespace: agones-system
+        path: /mutate
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVLVENDQXhHZ0F3SUJBZ0lKQU9KUDY0MTB3dkdTTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdxTVFzd0NRWUQKVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFUE1BMEdBMVVFQ2d3R1FXZHZibVZ6TVE4dwpEUVlEVlFRTERBWkJaMjl1WlhNeE5EQXlCZ05WQkFNTUsyRm5iMjVsY3kxamIyNTBjbTlzYkdWeUxYTmxjblpwClkyVXVZV2R2Ym1WekxYTjVjM1JsYlM1emRtTXhMakFzQmdrcWhraUc5dzBCQ1FFV0gyRm5iMjVsY3kxa2FYTmoKZFhOelFHZHZiMmRzWldkeWIzVndjeTVqYjIwd0hoY05NVGd3TWpFME1EUTBORFEyV2hjTk1qZ3dNakV5TURRMApORFEyV2pDQnFqRUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeER6QU5CZ05WCkJBb01Ca0ZuYjI1bGN6RVBNQTBHQTFVRUN3d0dRV2R2Ym1Wek1UUXdNZ1lEVlFRRERDdGhaMjl1WlhNdFkyOXUKZEhKdmJHeGxjaTF6WlhKMmFXTmxMbUZuYjI1bGN5MXplWE4wWlcwdWMzWmpNUzR3TEFZSktvWklodmNOQVFrQgpGaDloWjI5dVpYTXRaR2x6WTNWemMwQm5iMjluYkdWbmNtOTFjSE11WTI5dE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXpnVlQ5MGVqeE5ud0NvL09qTUQyNmZVNGRya1NlZndkUWd3aWJpZmEKbDhyazZZMFZ2T0lWMUgrbFJvd2UwNm1XTnVSNUZPWEZBMGZYbHZ4Q0tLWVZRcFNQRUsyWVN5aC9hU25KUUw2cQpvOGVBWVRKQmtPWUxCNUNiekl6aVdlb1FmT1lOOE1sRW44YlhKZGllSmhISDhVbnlqdHlvVGx4emhabVgrcGZ0CmhVZGVhM1Zrek8yMW40K1FFM1JYNWYxMzJGVEZjdXFYT1VBL3BpOGNjQU5HYzN6akxlWkp2QTlvZFBFaEdmN2cKQzhleUE2OFNWY3NoK1BqejBsdzk1QVB2bE12MWptcVVSRldjRVNUTGFRMEZ4NUt3UnlWMHppWm1VdkFBRjJaeApEWmhIVWNvRlBIQXdUbDc1TkFobkhwTWxMTnA1TDd0Y1ZkeVQ4QjJHUnMrc2xRSURBUUFCbzFBd1RqQWRCZ05WCkhRNEVGZ1FVZ3YxblRQYVFKU04zTHFtNWpJalc0eEhtZEcwd0h3WURWUjBqQkJnd0ZvQVVndjFuVFBhUUpTTjMKTHFtNWpJalc0eEhtZEcwd0RBWURWUjBUQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSEtFQwprdEVqWU5VQ0ErbXlzejRvclc3cFJVdmhCSERWU2dzWTZlRVZSTHpmLzF5SVpFMHU2NTZrcEs2T1Q3TWhKR2xVCkt3R1NTb1VCQnpWZ1VzWmpEbTdQZ2JrNGlZem40TTF4THpiTFFCcjNNYzV6WEhlZlB2YmltaEQ1NWNMenBWRnUKVlFtQm1aVjJOalU1RHVTZFJuZGxjUGFOY2cvdU9jdlpLNEtZMUtDQkEzRW9BUUlrcHpIWDJpVU1veGlSdlpWTgpORXdnRlR0SUdCWW4wSGZML3ZnT3NIOGZWck1Va3VHMnZoR2RlWEJwWmlxL0JaSmJaZU4yckNmMmdhWDFRSXYwCkVLYmN1RnFNOThXVDVaVlpSdFgxWTNSd2V2ZzRteFlKWEN1SDZGRjlXOS9TejI5NEZ5Mk9CS0I4SkFWYUV4OW4KMS9pNmZJZmZHbkhUWFdIc1ZRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    rules:
+      - apiGroups:
+          - stable.agones.dev
+        resources:
+          - "gameservers"
+          - "gameservers/status"
+          - "fleets"
+          - "fleetallocations"
+          - "gameserverallocations"
+        apiVersions:
+          - "v1alpha1"
+        operations:
+          - CREATE
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agones-manual-cert
+  namespace: agones-system
+  labels:
+    app: agones-manual
+    chart: "agones-0.9.0"
+    release: "agones-manual"
+    heritage: "Tiller"
+type: Opaque
+data:
+  server.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVLVENDQXhHZ0F3SUJBZ0lKQU9KUDY0MTB3dkdTTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdxTVFzd0NRWUQKVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFUE1BMEdBMVVFQ2d3R1FXZHZibVZ6TVE4dwpEUVlEVlFRTERBWkJaMjl1WlhNeE5EQXlCZ05WQkFNTUsyRm5iMjVsY3kxamIyNTBjbTlzYkdWeUxYTmxjblpwClkyVXVZV2R2Ym1WekxYTjVjM1JsYlM1emRtTXhMakFzQmdrcWhraUc5dzBCQ1FFV0gyRm5iMjVsY3kxa2FYTmoKZFhOelFHZHZiMmRzWldkeWIzVndjeTVqYjIwd0hoY05NVGd3TWpFME1EUTBORFEyV2hjTk1qZ3dNakV5TURRMApORFEyV2pDQnFqRUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeER6QU5CZ05WCkJBb01Ca0ZuYjI1bGN6RVBNQTBHQTFVRUN3d0dRV2R2Ym1Wek1UUXdNZ1lEVlFRRERDdGhaMjl1WlhNdFkyOXUKZEhKdmJHeGxjaTF6WlhKMmFXTmxMbUZuYjI1bGN5MXplWE4wWlcwdWMzWmpNUzR3TEFZSktvWklodmNOQVFrQgpGaDloWjI5dVpYTXRaR2x6WTNWemMwQm5iMjluYkdWbmNtOTFjSE11WTI5dE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXpnVlQ5MGVqeE5ud0NvL09qTUQyNmZVNGRya1NlZndkUWd3aWJpZmEKbDhyazZZMFZ2T0lWMUgrbFJvd2UwNm1XTnVSNUZPWEZBMGZYbHZ4Q0tLWVZRcFNQRUsyWVN5aC9hU25KUUw2cQpvOGVBWVRKQmtPWUxCNUNiekl6aVdlb1FmT1lOOE1sRW44YlhKZGllSmhISDhVbnlqdHlvVGx4emhabVgrcGZ0CmhVZGVhM1Zrek8yMW40K1FFM1JYNWYxMzJGVEZjdXFYT1VBL3BpOGNjQU5HYzN6akxlWkp2QTlvZFBFaEdmN2cKQzhleUE2OFNWY3NoK1BqejBsdzk1QVB2bE12MWptcVVSRldjRVNUTGFRMEZ4NUt3UnlWMHppWm1VdkFBRjJaeApEWmhIVWNvRlBIQXdUbDc1TkFobkhwTWxMTnA1TDd0Y1ZkeVQ4QjJHUnMrc2xRSURBUUFCbzFBd1RqQWRCZ05WCkhRNEVGZ1FVZ3YxblRQYVFKU04zTHFtNWpJalc0eEhtZEcwd0h3WURWUjBqQkJnd0ZvQVVndjFuVFBhUUpTTjMKTHFtNWpJalc0eEhtZEcwd0RBWURWUjBUQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSEtFQwprdEVqWU5VQ0ErbXlzejRvclc3cFJVdmhCSERWU2dzWTZlRVZSTHpmLzF5SVpFMHU2NTZrcEs2T1Q3TWhKR2xVCkt3R1NTb1VCQnpWZ1VzWmpEbTdQZ2JrNGlZem40TTF4THpiTFFCcjNNYzV6WEhlZlB2YmltaEQ1NWNMenBWRnUKVlFtQm1aVjJOalU1RHVTZFJuZGxjUGFOY2cvdU9jdlpLNEtZMUtDQkEzRW9BUUlrcHpIWDJpVU1veGlSdlpWTgpORXdnRlR0SUdCWW4wSGZML3ZnT3NIOGZWck1Va3VHMnZoR2RlWEJwWmlxL0JaSmJaZU4yckNmMmdhWDFRSXYwCkVLYmN1RnFNOThXVDVaVlpSdFgxWTNSd2V2ZzRteFlKWEN1SDZGRjlXOS9TejI5NEZ5Mk9CS0I4SkFWYUV4OW4KMS9pNmZJZmZHbkhUWFdIc1ZRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  server.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBemdWVDkwZWp4Tm53Q28vT2pNRDI2ZlU0ZHJrU2Vmd2RRZ3dpYmlmYWw4cms2WTBWCnZPSVYxSCtsUm93ZTA2bVdOdVI1Rk9YRkEwZlhsdnhDS0tZVlFwU1BFSzJZU3loL2FTbkpRTDZxbzhlQVlUSkIKa09ZTEI1Q2J6SXppV2VvUWZPWU44TWxFbjhiWEpkaWVKaEhIOFVueWp0eW9UbHh6aFptWCtwZnRoVWRlYTNWawp6TzIxbjQrUUUzUlg1ZjEzMkZURmN1cVhPVUEvcGk4Y2NBTkdjM3pqTGVaSnZBOW9kUEVoR2Y3Z0M4ZXlBNjhTClZjc2grUGp6MGx3OTVBUHZsTXYxam1xVVJGV2NFU1RMYVEwRng1S3dSeVYwemlabVV2QUFGMlp4RFpoSFVjb0YKUEhBd1RsNzVOQWhuSHBNbExOcDVMN3RjVmR5VDhCMkdScytzbFFJREFRQUJBb0lCQUVvVTVHS1E0alRRNFY0Swo1QXo4L2t5V254MGg0NkQxcFZld29WalcvK1dCVWRzaG5tVnpMc0pndS8rb054V0piN2lCWTRDK05wKzlYNnF0ClB1VDdBNzRUU1hhSDFiR0ErSC9LUk5JQlBiN3k2QmtMUjBSaFZDbitOK2ZQNlR6SHkvSDlqNW03NWU5R1F1c2EKLzVOVTVYN0FSblpVcGppM1Nkc0twZm00VS9LT1YrcDJqV1NQWDdIT0J1L0tZYTFqdmVDdDZKTVBRMzZLQlhrUgpNbFZDa0FEY3ZBQUd1T2JwYS9zbTBNQTYzK2loZGVTWWhrRVhLcXhINEF6M1BWREx3UDgwVDhmNVZxd1dZbW5xCkwvQmc2SG5WNUdIbmxUWEErV2VwTmJIa29rTjlHMEg2bTBJdGo0YWwzYkdUQjRqZUJDSlpwNUZIVzVvYko0cVAKV2tjZlhjRUNnWUVBOFVJWnZkTlNzU3BSWlZUZTRoaHRYbmNPcHRGVGRvVktJelR1VVZLZktlOU9CNWkzMkI5dQo0aEROcEJEcWtnRWt0ZzRSOC9jbjU3ejZaVWRVQ2NvYmpXUWJKTFhFNXdwN0h0ZjdqQ0duTDJRbUljcDIwcmJGCkhyRTJsSHIwb05yM01MVXJ1QnZBclZCM0xMR21PRWduM05RdzlhSndnLzU0MkVEUzd4NXYzWGtDZ1lFQTJwd0cKSGlHWVhUSmZZTmcvK1NtRHVTRFdGZTRpTVBUUncxVFQ4NXVHRTlVRXJZUFFkOE9xWVFRT2dJQVQ3eHAxejBvcQo2cG1zalBPNkhabmc5b0hLZUFPL0pQZVN1WEUrYko4SFlLcDdXOTI5RitMR0pvcWl0T0xQTW0vOU9vdllEQ3ZoCjYrcURZNUxOUkhkQWVUcXd3STJ5dWdmNFluQmpZNnpJZkJwNUxQMENnWUVBeXJydjVKcVNienVQUUdaTUVKUFUKTzhBeCtLNEh3NTJIeWdQdGl6cXhjc3lidGpoM3JFM2xvR1BjV2RTNU9FMXJxdXd4Mjk5QmtqTXoraTB4Q2pUaQphRExKdUZSaURIKzdMQlQwVlRIbVNpV1BBWEFmM3pza2M0RVl5elp6SUVRLzJaYzBFTGFKZDFvWmV0NGhQa1FyCjh4My9zamw0OFFIQ1RINVVnZ2tDbVlrQ2dZQWZLL3BQVjVrRFNRaUNwYk5Sa3hMZVZnbFE3VGpnNURmNDgyS1oKclFhTVUyYXNXMHhobDN2M0EzNFI0ckYwK2Ivc3cvV2txQzhMbGtGbXNTZDczdndBNnYvWmhKZmVhNEJzT3F6eApvcjJlVnRyOHlmQlpWSkZvMjZLUjNaZ3RQZjJibHJKTFVwQlRwWDR4a2hPV2RjRDRZL3dsUExlMVNiTlNaalBjClJtWWEvUUtCZ1FDNmE3ek5BU1AwQTBxTVBocXlKWmxiZzRGOFdNUnRnSEZmc3kvaUx3ZGlFVUd1Q2hRV1VMa2MKaHpQV3BqRDB6d3JTeFp0eWhTTDBiNlRIbnFUaWluMjNPdnRJTmxWaVptb3M1bVdXMFZlR3NiSG5KdVJhM1RIeQpFalNrU1A0bVI3dEpsSm9rYm9aK2xZTDdnQUJIbjJFUm5Ec3FYOG9FVTZRcERQMXJaaFlTemc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+
+>>>>>>> Fixed Portallocation and Fleetallocation

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1293,6 +1293,7 @@ webhooks:
           - "fleets"
           - "gameservers"
           - "gameserversets"
+          - "gameservers/status"
           - "fleetallocations"
           - "fleetautoscalers"
         apiVersions:
@@ -1304,6 +1305,7 @@ webhooks:
         resources:
           - "fleets"
           - "gameserversets"
+          - "gameservers/status"
           - "fleetallocations"
           - "fleetautoscalers"
         apiVersions:
@@ -1335,6 +1337,7 @@ webhooks:
           - stable.agones.dev
         resources:
           - "gameservers"
+          - "gameservers/status"
           - "fleets"
           - "fleetallocations"
         apiVersions:
@@ -1379,111 +1382,3 @@ description: "This priority class should be used for Agones service pods only."
 # Source: agones/templates/hooks/scripts.yaml
 
 
-<<<<<<< HEAD
-=======
----
-# Source: agones/templates/admissionregistration.yaml
-# Copyright 2018 Google Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: agones-validation-webhook
-webhooks:
-  - name: validations.stable.agones.dev
-    failurePolicy: Fail
-    clientConfig:
-      service:
-        name: agones-controller-service
-        namespace: agones-system
-        path: /validate
-      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVLVENDQXhHZ0F3SUJBZ0lKQU9KUDY0MTB3dkdTTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdxTVFzd0NRWUQKVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFUE1BMEdBMVVFQ2d3R1FXZHZibVZ6TVE4dwpEUVlEVlFRTERBWkJaMjl1WlhNeE5EQXlCZ05WQkFNTUsyRm5iMjVsY3kxamIyNTBjbTlzYkdWeUxYTmxjblpwClkyVXVZV2R2Ym1WekxYTjVjM1JsYlM1emRtTXhMakFzQmdrcWhraUc5dzBCQ1FFV0gyRm5iMjVsY3kxa2FYTmoKZFhOelFHZHZiMmRzWldkeWIzVndjeTVqYjIwd0hoY05NVGd3TWpFME1EUTBORFEyV2hjTk1qZ3dNakV5TURRMApORFEyV2pDQnFqRUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeER6QU5CZ05WCkJBb01Ca0ZuYjI1bGN6RVBNQTBHQTFVRUN3d0dRV2R2Ym1Wek1UUXdNZ1lEVlFRRERDdGhaMjl1WlhNdFkyOXUKZEhKdmJHeGxjaTF6WlhKMmFXTmxMbUZuYjI1bGN5MXplWE4wWlcwdWMzWmpNUzR3TEFZSktvWklodmNOQVFrQgpGaDloWjI5dVpYTXRaR2x6WTNWemMwQm5iMjluYkdWbmNtOTFjSE11WTI5dE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXpnVlQ5MGVqeE5ud0NvL09qTUQyNmZVNGRya1NlZndkUWd3aWJpZmEKbDhyazZZMFZ2T0lWMUgrbFJvd2UwNm1XTnVSNUZPWEZBMGZYbHZ4Q0tLWVZRcFNQRUsyWVN5aC9hU25KUUw2cQpvOGVBWVRKQmtPWUxCNUNiekl6aVdlb1FmT1lOOE1sRW44YlhKZGllSmhISDhVbnlqdHlvVGx4emhabVgrcGZ0CmhVZGVhM1Zrek8yMW40K1FFM1JYNWYxMzJGVEZjdXFYT1VBL3BpOGNjQU5HYzN6akxlWkp2QTlvZFBFaEdmN2cKQzhleUE2OFNWY3NoK1BqejBsdzk1QVB2bE12MWptcVVSRldjRVNUTGFRMEZ4NUt3UnlWMHppWm1VdkFBRjJaeApEWmhIVWNvRlBIQXdUbDc1TkFobkhwTWxMTnA1TDd0Y1ZkeVQ4QjJHUnMrc2xRSURBUUFCbzFBd1RqQWRCZ05WCkhRNEVGZ1FVZ3YxblRQYVFKU04zTHFtNWpJalc0eEhtZEcwd0h3WURWUjBqQkJnd0ZvQVVndjFuVFBhUUpTTjMKTHFtNWpJalc0eEhtZEcwd0RBWURWUjBUQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSEtFQwprdEVqWU5VQ0ErbXlzejRvclc3cFJVdmhCSERWU2dzWTZlRVZSTHpmLzF5SVpFMHU2NTZrcEs2T1Q3TWhKR2xVCkt3R1NTb1VCQnpWZ1VzWmpEbTdQZ2JrNGlZem40TTF4THpiTFFCcjNNYzV6WEhlZlB2YmltaEQ1NWNMenBWRnUKVlFtQm1aVjJOalU1RHVTZFJuZGxjUGFOY2cvdU9jdlpLNEtZMUtDQkEzRW9BUUlrcHpIWDJpVU1veGlSdlpWTgpORXdnRlR0SUdCWW4wSGZML3ZnT3NIOGZWck1Va3VHMnZoR2RlWEJwWmlxL0JaSmJaZU4yckNmMmdhWDFRSXYwCkVLYmN1RnFNOThXVDVaVlpSdFgxWTNSd2V2ZzRteFlKWEN1SDZGRjlXOS9TejI5NEZ5Mk9CS0I4SkFWYUV4OW4KMS9pNmZJZmZHbkhUWFdIc1ZRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    rules:
-      - apiGroups:
-          - stable.agones.dev
-        resources:
-          - "fleets"
-          - "gameservers"
-          - "gameserversets"
-          - "gameservers/status"
-          - "fleetallocations"
-          - "fleetautoscalers"
-        apiVersions:
-          - "v1alpha1"
-        operations:
-          - CREATE
-      - apiGroups:
-          - stable.agones.dev
-        resources:
-          - "fleets"
-          - "gameserversets"
-          - "gameservers/status"
-          - "fleetallocations"
-          - "fleetautoscalers"
-          - "gameserverallocations"
-        apiVersions:
-          - "v1alpha1"
-        operations:
-          - UPDATE
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: agones-mutation-webhook
-  labels:
-    component: controller
-    app: agones
-    chart: agones-0.9.0
-    release: agones-manual
-    heritage: Tiller
-webhooks:
-  - name: mutations.stable.agones.dev
-    failurePolicy: Fail
-    clientConfig:
-      service:
-        name: agones-controller-service
-        namespace: agones-system
-        path: /mutate
-      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVLVENDQXhHZ0F3SUJBZ0lKQU9KUDY0MTB3dkdTTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdxTVFzd0NRWUQKVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFUE1BMEdBMVVFQ2d3R1FXZHZibVZ6TVE4dwpEUVlEVlFRTERBWkJaMjl1WlhNeE5EQXlCZ05WQkFNTUsyRm5iMjVsY3kxamIyNTBjbTlzYkdWeUxYTmxjblpwClkyVXVZV2R2Ym1WekxYTjVjM1JsYlM1emRtTXhMakFzQmdrcWhraUc5dzBCQ1FFV0gyRm5iMjVsY3kxa2FYTmoKZFhOelFHZHZiMmRzWldkeWIzVndjeTVqYjIwd0hoY05NVGd3TWpFME1EUTBORFEyV2hjTk1qZ3dNakV5TURRMApORFEyV2pDQnFqRUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeER6QU5CZ05WCkJBb01Ca0ZuYjI1bGN6RVBNQTBHQTFVRUN3d0dRV2R2Ym1Wek1UUXdNZ1lEVlFRRERDdGhaMjl1WlhNdFkyOXUKZEhKdmJHeGxjaTF6WlhKMmFXTmxMbUZuYjI1bGN5MXplWE4wWlcwdWMzWmpNUzR3TEFZSktvWklodmNOQVFrQgpGaDloWjI5dVpYTXRaR2x6WTNWemMwQm5iMjluYkdWbmNtOTFjSE11WTI5dE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXpnVlQ5MGVqeE5ud0NvL09qTUQyNmZVNGRya1NlZndkUWd3aWJpZmEKbDhyazZZMFZ2T0lWMUgrbFJvd2UwNm1XTnVSNUZPWEZBMGZYbHZ4Q0tLWVZRcFNQRUsyWVN5aC9hU25KUUw2cQpvOGVBWVRKQmtPWUxCNUNiekl6aVdlb1FmT1lOOE1sRW44YlhKZGllSmhISDhVbnlqdHlvVGx4emhabVgrcGZ0CmhVZGVhM1Zrek8yMW40K1FFM1JYNWYxMzJGVEZjdXFYT1VBL3BpOGNjQU5HYzN6akxlWkp2QTlvZFBFaEdmN2cKQzhleUE2OFNWY3NoK1BqejBsdzk1QVB2bE12MWptcVVSRldjRVNUTGFRMEZ4NUt3UnlWMHppWm1VdkFBRjJaeApEWmhIVWNvRlBIQXdUbDc1TkFobkhwTWxMTnA1TDd0Y1ZkeVQ4QjJHUnMrc2xRSURBUUFCbzFBd1RqQWRCZ05WCkhRNEVGZ1FVZ3YxblRQYVFKU04zTHFtNWpJalc0eEhtZEcwd0h3WURWUjBqQkJnd0ZvQVVndjFuVFBhUUpTTjMKTHFtNWpJalc0eEhtZEcwd0RBWURWUjBUQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSEtFQwprdEVqWU5VQ0ErbXlzejRvclc3cFJVdmhCSERWU2dzWTZlRVZSTHpmLzF5SVpFMHU2NTZrcEs2T1Q3TWhKR2xVCkt3R1NTb1VCQnpWZ1VzWmpEbTdQZ2JrNGlZem40TTF4THpiTFFCcjNNYzV6WEhlZlB2YmltaEQ1NWNMenBWRnUKVlFtQm1aVjJOalU1RHVTZFJuZGxjUGFOY2cvdU9jdlpLNEtZMUtDQkEzRW9BUUlrcHpIWDJpVU1veGlSdlpWTgpORXdnRlR0SUdCWW4wSGZML3ZnT3NIOGZWck1Va3VHMnZoR2RlWEJwWmlxL0JaSmJaZU4yckNmMmdhWDFRSXYwCkVLYmN1RnFNOThXVDVaVlpSdFgxWTNSd2V2ZzRteFlKWEN1SDZGRjlXOS9TejI5NEZ5Mk9CS0I4SkFWYUV4OW4KMS9pNmZJZmZHbkhUWFdIc1ZRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    rules:
-      - apiGroups:
-          - stable.agones.dev
-        resources:
-          - "gameservers"
-          - "gameservers/status"
-          - "fleets"
-          - "fleetallocations"
-          - "gameserverallocations"
-        apiVersions:
-          - "v1alpha1"
-        operations:
-          - CREATE
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: agones-manual-cert
-  namespace: agones-system
-  labels:
-    app: agones-manual
-    chart: "agones-0.9.0"
-    release: "agones-manual"
-    heritage: "Tiller"
-type: Opaque
-data:
-  server.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVLVENDQXhHZ0F3SUJBZ0lKQU9KUDY0MTB3dkdTTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdxTVFzd0NRWUQKVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFUE1BMEdBMVVFQ2d3R1FXZHZibVZ6TVE4dwpEUVlEVlFRTERBWkJaMjl1WlhNeE5EQXlCZ05WQkFNTUsyRm5iMjVsY3kxamIyNTBjbTlzYkdWeUxYTmxjblpwClkyVXVZV2R2Ym1WekxYTjVjM1JsYlM1emRtTXhMakFzQmdrcWhraUc5dzBCQ1FFV0gyRm5iMjVsY3kxa2FYTmoKZFhOelFHZHZiMmRzWldkeWIzVndjeTVqYjIwd0hoY05NVGd3TWpFME1EUTBORFEyV2hjTk1qZ3dNakV5TURRMApORFEyV2pDQnFqRUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeER6QU5CZ05WCkJBb01Ca0ZuYjI1bGN6RVBNQTBHQTFVRUN3d0dRV2R2Ym1Wek1UUXdNZ1lEVlFRRERDdGhaMjl1WlhNdFkyOXUKZEhKdmJHeGxjaTF6WlhKMmFXTmxMbUZuYjI1bGN5MXplWE4wWlcwdWMzWmpNUzR3TEFZSktvWklodmNOQVFrQgpGaDloWjI5dVpYTXRaR2x6WTNWemMwQm5iMjluYkdWbmNtOTFjSE11WTI5dE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXpnVlQ5MGVqeE5ud0NvL09qTUQyNmZVNGRya1NlZndkUWd3aWJpZmEKbDhyazZZMFZ2T0lWMUgrbFJvd2UwNm1XTnVSNUZPWEZBMGZYbHZ4Q0tLWVZRcFNQRUsyWVN5aC9hU25KUUw2cQpvOGVBWVRKQmtPWUxCNUNiekl6aVdlb1FmT1lOOE1sRW44YlhKZGllSmhISDhVbnlqdHlvVGx4emhabVgrcGZ0CmhVZGVhM1Zrek8yMW40K1FFM1JYNWYxMzJGVEZjdXFYT1VBL3BpOGNjQU5HYzN6akxlWkp2QTlvZFBFaEdmN2cKQzhleUE2OFNWY3NoK1BqejBsdzk1QVB2bE12MWptcVVSRldjRVNUTGFRMEZ4NUt3UnlWMHppWm1VdkFBRjJaeApEWmhIVWNvRlBIQXdUbDc1TkFobkhwTWxMTnA1TDd0Y1ZkeVQ4QjJHUnMrc2xRSURBUUFCbzFBd1RqQWRCZ05WCkhRNEVGZ1FVZ3YxblRQYVFKU04zTHFtNWpJalc0eEhtZEcwd0h3WURWUjBqQkJnd0ZvQVVndjFuVFBhUUpTTjMKTHFtNWpJalc0eEhtZEcwd0RBWURWUjBUQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSEtFQwprdEVqWU5VQ0ErbXlzejRvclc3cFJVdmhCSERWU2dzWTZlRVZSTHpmLzF5SVpFMHU2NTZrcEs2T1Q3TWhKR2xVCkt3R1NTb1VCQnpWZ1VzWmpEbTdQZ2JrNGlZem40TTF4THpiTFFCcjNNYzV6WEhlZlB2YmltaEQ1NWNMenBWRnUKVlFtQm1aVjJOalU1RHVTZFJuZGxjUGFOY2cvdU9jdlpLNEtZMUtDQkEzRW9BUUlrcHpIWDJpVU1veGlSdlpWTgpORXdnRlR0SUdCWW4wSGZML3ZnT3NIOGZWck1Va3VHMnZoR2RlWEJwWmlxL0JaSmJaZU4yckNmMmdhWDFRSXYwCkVLYmN1RnFNOThXVDVaVlpSdFgxWTNSd2V2ZzRteFlKWEN1SDZGRjlXOS9TejI5NEZ5Mk9CS0I4SkFWYUV4OW4KMS9pNmZJZmZHbkhUWFdIc1ZRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-  server.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBemdWVDkwZWp4Tm53Q28vT2pNRDI2ZlU0ZHJrU2Vmd2RRZ3dpYmlmYWw4cms2WTBWCnZPSVYxSCtsUm93ZTA2bVdOdVI1Rk9YRkEwZlhsdnhDS0tZVlFwU1BFSzJZU3loL2FTbkpRTDZxbzhlQVlUSkIKa09ZTEI1Q2J6SXppV2VvUWZPWU44TWxFbjhiWEpkaWVKaEhIOFVueWp0eW9UbHh6aFptWCtwZnRoVWRlYTNWawp6TzIxbjQrUUUzUlg1ZjEzMkZURmN1cVhPVUEvcGk4Y2NBTkdjM3pqTGVaSnZBOW9kUEVoR2Y3Z0M4ZXlBNjhTClZjc2grUGp6MGx3OTVBUHZsTXYxam1xVVJGV2NFU1RMYVEwRng1S3dSeVYwemlabVV2QUFGMlp4RFpoSFVjb0YKUEhBd1RsNzVOQWhuSHBNbExOcDVMN3RjVmR5VDhCMkdScytzbFFJREFRQUJBb0lCQUVvVTVHS1E0alRRNFY0Swo1QXo4L2t5V254MGg0NkQxcFZld29WalcvK1dCVWRzaG5tVnpMc0pndS8rb054V0piN2lCWTRDK05wKzlYNnF0ClB1VDdBNzRUU1hhSDFiR0ErSC9LUk5JQlBiN3k2QmtMUjBSaFZDbitOK2ZQNlR6SHkvSDlqNW03NWU5R1F1c2EKLzVOVTVYN0FSblpVcGppM1Nkc0twZm00VS9LT1YrcDJqV1NQWDdIT0J1L0tZYTFqdmVDdDZKTVBRMzZLQlhrUgpNbFZDa0FEY3ZBQUd1T2JwYS9zbTBNQTYzK2loZGVTWWhrRVhLcXhINEF6M1BWREx3UDgwVDhmNVZxd1dZbW5xCkwvQmc2SG5WNUdIbmxUWEErV2VwTmJIa29rTjlHMEg2bTBJdGo0YWwzYkdUQjRqZUJDSlpwNUZIVzVvYko0cVAKV2tjZlhjRUNnWUVBOFVJWnZkTlNzU3BSWlZUZTRoaHRYbmNPcHRGVGRvVktJelR1VVZLZktlOU9CNWkzMkI5dQo0aEROcEJEcWtnRWt0ZzRSOC9jbjU3ejZaVWRVQ2NvYmpXUWJKTFhFNXdwN0h0ZjdqQ0duTDJRbUljcDIwcmJGCkhyRTJsSHIwb05yM01MVXJ1QnZBclZCM0xMR21PRWduM05RdzlhSndnLzU0MkVEUzd4NXYzWGtDZ1lFQTJwd0cKSGlHWVhUSmZZTmcvK1NtRHVTRFdGZTRpTVBUUncxVFQ4NXVHRTlVRXJZUFFkOE9xWVFRT2dJQVQ3eHAxejBvcQo2cG1zalBPNkhabmc5b0hLZUFPL0pQZVN1WEUrYko4SFlLcDdXOTI5RitMR0pvcWl0T0xQTW0vOU9vdllEQ3ZoCjYrcURZNUxOUkhkQWVUcXd3STJ5dWdmNFluQmpZNnpJZkJwNUxQMENnWUVBeXJydjVKcVNienVQUUdaTUVKUFUKTzhBeCtLNEh3NTJIeWdQdGl6cXhjc3lidGpoM3JFM2xvR1BjV2RTNU9FMXJxdXd4Mjk5QmtqTXoraTB4Q2pUaQphRExKdUZSaURIKzdMQlQwVlRIbVNpV1BBWEFmM3pza2M0RVl5elp6SUVRLzJaYzBFTGFKZDFvWmV0NGhQa1FyCjh4My9zamw0OFFIQ1RINVVnZ2tDbVlrQ2dZQWZLL3BQVjVrRFNRaUNwYk5Sa3hMZVZnbFE3VGpnNURmNDgyS1oKclFhTVUyYXNXMHhobDN2M0EzNFI0ckYwK2Ivc3cvV2txQzhMbGtGbXNTZDczdndBNnYvWmhKZmVhNEJzT3F6eApvcjJlVnRyOHlmQlpWSkZvMjZLUjNaZ3RQZjJibHJKTFVwQlRwWDR4a2hPV2RjRDRZL3dsUExlMVNiTlNaalBjClJtWWEvUUtCZ1FDNmE3ek5BU1AwQTBxTVBocXlKWmxiZzRGOFdNUnRnSEZmc3kvaUx3ZGlFVUd1Q2hRV1VMa2MKaHpQV3BqRDB6d3JTeFp0eWhTTDBiNlRIbnFUaWluMjNPdnRJTmxWaVptb3M1bVdXMFZlR3NiSG5KdVJhM1RIeQpFalNrU1A0bVI3dEpsSm9rYm9aK2xZTDdnQUJIbjJFUm5Ec3FYOG9FVTZRcERQMXJaaFlTemc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
-
->>>>>>> Fixed Portallocation and Fleetallocation

--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -189,7 +189,6 @@ func (gs *GameServer) ApplyDefaults() {
 
 	gs.applyContainerDefaults()
 	gs.applyPortDefaults()
-	gs.applyStateDefaults()
 	gs.applyHealthDefaults()
 	gs.applySchedulingDefaults()
 }
@@ -212,16 +211,6 @@ func (gs *GameServer) applyHealthDefaults() {
 		}
 		if gs.Spec.Health.InitialDelaySeconds <= 0 {
 			gs.Spec.Health.InitialDelaySeconds = 5
-		}
-	}
-}
-
-// applyStateDefaults applies state defaults
-func (gs *GameServer) applyStateDefaults() {
-	if gs.Status.State == "" {
-		gs.Status.State = GameServerStateCreating
-		if gs.HasPortPolicy(Dynamic) {
-			gs.Status.State = GameServerStatePortAllocation
 		}
 	}
 }

--- a/pkg/apis/stable/v1alpha1/gameserver_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserver_test.go
@@ -204,7 +204,6 @@ func TestGameServerApplyDefaults(t *testing.T) {
 			assert.Contains(t, test.gameServer.ObjectMeta.Finalizers, stable.GroupName)
 			assert.Equal(t, test.container, spec.Container)
 			assert.Equal(t, test.expected.protocol, spec.Ports[0].Protocol)
-			assert.Equal(t, test.expected.state, test.gameServer.Status.State)
 			assert.Equal(t, test.expected.health, test.gameServer.Spec.Health)
 			assert.Equal(t, test.expected.scheduling, test.gameServer.Spec.Scheduling)
 		})

--- a/pkg/fleetallocation/controller.go
+++ b/pkg/fleetallocation/controller.go
@@ -292,7 +292,7 @@ func (c *Controller) allocate(f *v1alpha1.Fleet, fam *v1alpha1.MetaPatch) (*v1al
 		c.patchMetadata(gsCopy, fam)
 	}
 
-	gs, err := c.gameServerGetter.GameServers(f.ObjectMeta.Namespace).Update(gsCopy)
+	gs, err := c.gameServerGetter.GameServers(f.ObjectMeta.Namespace).UpdateStatus(gsCopy)
 	if err != nil {
 		return gs, errors.Wrapf(err, "error updating GameServer %s", gsCopy.ObjectMeta.Name)
 	}

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -139,6 +139,8 @@ func NewController(
 	wh.AddHandler("/mutate", v1alpha1.Kind("GameServer"), admv1beta1.Create, c.creationMutationHandler)
 	wh.AddHandler("/validate", v1alpha1.Kind("GameServer"), admv1beta1.Create, c.creationValidationHandler)
 
+	wh.AddHandler("/mutate", v1alpha1.Kind("GameServer/Status"), admv1beta1.Create, c.creationMutationHandler)
+
 	gsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.enqueueGameServerBasedOnState,
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -218,6 +220,8 @@ func (c *Controller) creationMutationHandler(review admv1beta1.AdmissionReview) 
 	// This is the main logic of this function
 	// the rest is really just json plumbing
 	gs.ApplyDefaults()
+
+	c.logger.WithField("gs234", gs.ObjectMeta.Name).WithField("Whole review", fmt.Sprintf("%+v", review)).Infof("patch created!")
 
 	newGS, err := json.Marshal(gs)
 	if err != nil {
@@ -357,8 +361,9 @@ func (c *Controller) syncGameServer(key string) error {
 	gs, err := c.gameServerLister.GameServers(namespace).Get(name)
 	applyStateDefaults(gs)
 	gss := c.gameServerGetter.GameServers(namespace)
-	//gss.Update(gs)
-	gss.UpdateStatus(gs)
+	gss.Update(gs)
+	//gss.UpdateStatus(gs)
+	//gs, err = c.gameServerLister.GameServers(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			c.loggerForGameServerKey(key).Info("GameServer is no longer available for syncing")
@@ -445,7 +450,22 @@ func (c *Controller) syncGameServerPortAllocationState(gs *v1alpha1.GameServer) 
 	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Port allocated")
 
 	c.loggerForGameServer(gsCopy).Info("Syncing Port Allocation GameServerState")
+	//gs2, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).GetStatus(gsCopy)
+	//gsCopy.ObjectMeta.ResourceVersion = gs2.ObjectMeta.ResourceVersion
 	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy)
+	if err != nil {
+		// if the GameServer doesn't get updated with the port data, then put the port
+		// back in the pool, as it will get retried on the next pass
+		return gs, errors.Wrapf(err, "error updating status of GameServer %s to default values", gs.Name)
+	}
+	gsCopy2, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Get(gs.Name, metav1.GetOptions{})
+	if err != nil {
+		// if the GameServer doesn't get updated with the port data, then put the port
+		// back in the pool, as it will get retried on the next pass
+		return gs, errors.Wrapf(err, "error Getting GameServer %s", gs.Name)
+	}
+	gsCopy2.Spec = gsCopy.Spec
+	gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy2)
 	if err != nil {
 		// if the GameServer doesn't get updated with the port data, then put the port
 		// back in the pool, as it will get retried on the next pass
@@ -517,7 +537,8 @@ func (c *Controller) syncDevelopmentGameServer(gs *v1alpha1.GameServer) (*v1alph
 	gsCopy.Status.Ports = ports
 	gsCopy.Status.Address = devIPAddress
 	gsCopy.Status.NodeName = devIPAddress
-	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy)
+	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy)
+	// TODO was Update()
 	if err != nil {
 		return gs, errors.Wrapf(err, "error updating GameServer %s to %v status", gs.Name, gs.Status)
 	}
@@ -665,16 +686,17 @@ func (c *Controller) syncGameServerStartingState(gs *v1alpha1.GameServer) (*v1al
 	}
 
 	gsCopy.Status.State = v1alpha1.GameServerStateScheduled
+	gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy)
+	if err != nil {
+		return gs, errors.Wrapf(err, "error updating GameServer %s to Scheduled state", gs.Name)
+	}
+
 	/*
-		gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy)
+		gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy)
 		if err != nil {
-			return gs, errors.Wrapf(err, "error updating GameServer %s to Scheduled state", gs.Name)
+			return gs, errors.Wrapf(err, "error updating GameServer %s to Port state", gs.Name)
 		}
 	*/
-	gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy)
-	if err != nil {
-		return gs, errors.Wrapf(err, "error updating GameServer %s to Port state", gs.Name)
-	}
 	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Address and port populated")
 
 	return gs, nil
@@ -735,16 +757,17 @@ func (c *Controller) syncGameServerRequestReadyState(gs *v1alpha1.GameServer) (*
 	}
 
 	gsCopy.Status.State = v1alpha1.GameServerStateReady
+
+	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy)
+	if err != nil {
+		return gs, errors.Wrapf(err, "error setting Ready, Port and address on GameServer %s Status", gs.ObjectMeta.Name)
+	}
 	/*
-		gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy)
+		gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy)
 		if err != nil {
 			return gs, errors.Wrapf(err, "error setting Ready, Port and address on GameServer %s Status", gs.ObjectMeta.Name)
 		}
 	*/
-	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy)
-	if err != nil {
-		return gs, errors.Wrapf(err, "error setting Ready, Port and address on GameServer %s Status", gs.ObjectMeta.Name)
-	}
 
 	if addressPopulated {
 		c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Address and port populated")
@@ -776,8 +799,8 @@ func (c *Controller) moveToErrorState(gs *v1alpha1.GameServer, msg string) (*v1a
 	copy := gs.DeepCopy()
 	copy.Status.State = v1alpha1.GameServerStateError
 
-	//gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(copy)
-	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(copy)
+	gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(copy)
+	//gs, err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(copy)
 	if err != nil {
 		return gs, errors.Wrapf(err, "error moving GameServer %s to Error State", gs.ObjectMeta.Name)
 	}

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -173,7 +173,7 @@ func (hc *HealthController) syncGameServer(key string) error {
 	gsCopy := gs.DeepCopy()
 	gsCopy.Status.State = v1alpha1.GameServerStateUnhealthy
 
-	if _, err := hc.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy); err != nil {
+	if _, err := hc.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy); err != nil {
 		return errors.Wrapf(err, "error updating GameServer %s to unhealthy", gs.ObjectMeta.Name)
 	}
 

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -498,7 +498,7 @@ func (c *Controller) deleteGameServers(gsSet *v1alpha1.GameServerSet, toDelete [
 		// We should not delete the gameservers directly buy set their state to shutdown and let the gameserver controller to delete
 		gsCopy := gs.DeepCopy()
 		gsCopy.Status.State = v1alpha1.GameServerStateShutdown
-		_, err := c.gameServerGetter.GameServers(gs.Namespace).Update(gsCopy)
+		_, err := c.gameServerGetter.GameServers(gs.Namespace).UpdateStatus(gsCopy)
 		if err != nil {
 			return errors.Wrapf(err, "error updating gameserver %s from status %s to Shutdown status.", gs.ObjectMeta.Name, gs.Status.State)
 		}

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -263,6 +263,7 @@ func (s *SDKServer) updateState() error {
 	gs.Status.State = s.gsState
 	s.gsUpdateMutex.RUnlock()
 	// Status changes are ignored on the main resource endpoint.
+	//_, err = gameServers.Update(gs)
 	_, err = gameServers.UpdateStatus(gs)
 
 	// state specific work here

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -258,13 +258,15 @@ func (s *SDKServer) updateState() error {
 		return nil
 	}
 
-	//UpdateStatus
 	s.gsUpdateMutex.RLock()
 	gs.Status.State = s.gsState
 	s.gsUpdateMutex.RUnlock()
+	// Using Status Endpoint for SDK Server
 	// Status changes are ignored on the main resource endpoint.
-	//_, err = gameServers.Update(gs)
 	_, err = gameServers.UpdateStatus(gs)
+	if err != nil {
+		return err
+	}
 
 	// state specific work here
 	if gs.Status.State == stablev1alpha1.GameServerStateUnhealthy {
@@ -371,7 +373,7 @@ func (s *SDKServer) Allocate(context.Context, *sdk.Empty) (*sdk.Empty, error) {
 
 		gsCopy := gs.DeepCopy()
 		gsCopy.Status.State = stablev1alpha1.GameServerStateAllocated
-		_, err = s.gameServerGetter.GameServers(s.namespace).Update(gsCopy)
+		_, err = s.gameServerGetter.GameServers(s.namespace).UpdateStatus(gsCopy)
 
 		// if a contention, and we are under the timeout period.
 		if k8serrors.IsConflict(err) {

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -258,10 +258,12 @@ func (s *SDKServer) updateState() error {
 		return nil
 	}
 
+	//UpdateStatus
 	s.gsUpdateMutex.RLock()
 	gs.Status.State = s.gsState
 	s.gsUpdateMutex.RUnlock()
-	_, err = gameServers.Update(gs)
+	// Status changes are ignored on the main resource endpoint.
+	_, err = gameServers.UpdateStatus(gs)
 
 	// state specific work here
 	if gs.Status.State == stablev1alpha1.GameServerStateUnhealthy {


### PR DESCRIPTION
Switch to using `UpdateStatus()` function where GameServer Status is changed.
Now Updates on main Gameserver Resource endpoint does not change Status.
Moved Initial Status setting out of Creation Mutation Handler to Sync function.

Is needed for #150 ticket.
This is Work In Progress. Do we need to move Labels and Annotations from GameServer Spec to Status? Then we can actually 