### PR TITLE
Flaky: TestSDKSetAnnotation

### DIFF
--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -189,6 +189,12 @@ type GameServerStatusPort struct {
 
 // ApplyDefaults applies default values to the GameServer if they are not already populated
 func (gs *GameServer) ApplyDefaults() {
+	// VersionAnnotation is the annotation that stores
+	// the version of sdk which runs in a sidecar
+	if gs.ObjectMeta.Annotations == nil {
+		gs.ObjectMeta.Annotations = map[string]string{}
+	}
+	gs.ObjectMeta.Annotations[stable.VersionAnnotation] = pkg.Version
 	gs.ObjectMeta.Finalizers = append(gs.ObjectMeta.Finalizers, stable.GroupName)
 
 	gs.Spec.ApplyDefaults()
@@ -477,9 +483,6 @@ func (gs *GameServer) podObjectMeta(pod *corev1.Pod) {
 	if gs.ObjectMeta.Annotations == nil {
 		gs.ObjectMeta.Annotations = make(map[string]string, 1)
 	}
-	// VersionAnnotation is the annotation that stores
-	// the version of sdk which runs in a sidecar
-	gs.ObjectMeta.Annotations[stable.VersionAnnotation] = pkg.Version
 }
 
 // podScheduling applies the Fleet scheduling strategy to the passed in Pod

--- a/pkg/apis/stable/v1alpha1/gameserver_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserver_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"agones.dev/agones/pkg"
 	"agones.dev/agones/pkg/apis"
 	"agones.dev/agones/pkg/apis/stable"
 	"github.com/stretchr/testify/assert"
@@ -222,6 +223,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 	for name, test := range data {
 		t.Run(name, func(t *testing.T) {
 			test.gameServer.ApplyDefaults()
+
+			assert.Equal(t, pkg.Version, test.gameServer.Annotations[stable.VersionAnnotation])
 
 			spec := test.gameServer.Spec
 			assert.Contains(t, test.gameServer.ObjectMeta.Finalizers, stable.GroupName)

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -140,7 +140,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 	assert.Equal(t, "ACK: ANNOTATION\n", reply)
 
 	// the label is set in a queue, so it may take a moment
-	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 		gs, err = framework.AgonesClient.StableV1alpha1().GameServers(defaultNs).Get(readyGs.ObjectMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
@@ -150,7 +150,11 @@ func TestSDKSetAnnotation(t *testing.T) {
 		return ok, nil
 	})
 
-	assert.Nil(t, err)
+	logrus.WithField("annotations", gs.ObjectMeta.Annotations).Info("annotation information")
+
+	if !assert.Nil(t, err) {
+		assert.FailNow(t, "error waiting on annotation to be set")
+	}
 	assert.NotEmpty(t, gs.ObjectMeta.Annotations[annotation])
 	assert.NotEmpty(t, gs.ObjectMeta.Annotations[stable.VersionAnnotation])
 }


### PR DESCRIPTION
Moved the application of the version annotation to `ApplyDefaults()` on the GameServer.

I'm not quite sure why it was this way in the first place, but this should ensure this test doesn't fail again.