### PR TITLE
Initial version of SDK conformance Testing framework for Golang, NodeJS and others

### DIFF
--- a/build/build-sdk-conformance/Dockerfile
+++ b/build/build-sdk-conformance/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM golang:latest
+
+RUN apt-get update && \
+    apt-get install -y wget jq && \
+    apt-get clean
+
+# install go
+WORKDIR /usr/local
+ENV GO_VERSION=1.12
+ENV GO111MODULE=on
+ENV GOPATH /go
+RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir -p ${GOPATH}
+
+WORKDIR /go/src/agones.dev/agones
+ENV PATH /usr/local/go/bin:/go/bin:$PATH
+
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
+    apt-get install -y nodejs
+
+# code generation scripts
+COPY *.sh /root/
+RUN chmod +x /root/*.sh

--- a/build/build-sdk-conformance/jstest.sh
+++ b/build/build-sdk-conformance/jstest.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+
+cd /go/src/agones.dev/agones/test/sdk
+./sdk --test="" --sdk="nodejs"
+cd /go/src/agones.dev/agones/test/sdk/bin/nodejs
+npm install --cache /tmp/empty-cache
+npm rebuild
+
+cd /go/src/agones.dev/agones/test/sdk
+./sdk --verify=true --sdk nodejs

--- a/build/build-sdk-conformance/sidecar.sh
+++ b/build/build-sdk-conformance/sidecar.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+GO111MODULE=off
+cd /go/src/agones.dev/agones/cmd/sdk-server
+go build
+cd /go/src/agones.dev/agones/test/sdk
+rm -rf ./bin
+mkdir -p ./bin
+mv /go/src/agones.dev/agones/cmd/sdk-server/sdk-server ./bin
+go build

--- a/build/build-sdk-conformance/test.sh
+++ b/build/build-sdk-conformance/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+GO111MODULE=off
+
+cd /go/src/agones.dev/agones/test/sdk
+./sdk --test=""
+cd ./bin/golang/
+dirs=($(find . -mindepth 1 -type d))
+for dir in "${dirs[@]}"; do
+  cd "$dir"
+  go build
+  echo $PWD
+  cd -
+done
+cd /go/src/agones.dev/agones/test/sdk
+./sdk --verify=true

--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -26,6 +26,7 @@ build_sdk_base_remote_tag = $(REGISTRY)/$(build_sdk_base_tag)
 build_sdk_prefix = agones-build-sdk-
 grpc_release_tag = v1.16.1
 sdk_build_folder = build-sdk-images/
+sdk_build_conformance-folder = build-sdk-conformance/
 SDK_FOLDER ?= go
 COMMAND ?= gen
 
@@ -108,3 +109,14 @@ ensure-build-sdk-image-base:
 # create the build image sdk if it doesn't exist
 ensure-build-sdk-image:
 	$(MAKE) build-build-sdk-image SDK_FOLDER=$(SDK_FOLDER)
+
+build-conformance-tests:
+	cd $(sdk_build_conformance-folder); \
+	docker build --tag=conformance:$(build_version) ./ $(DOCKER_BUILD_ARGS)
+	docker run --rm $(common_mounts) -e "VERSION=$(VERSION)" $(DOCKER_RUN_ARGS) conformance:$(build_version) /root/sidecar.sh
+
+run-conformance-tests:
+	docker run --rm $(common_mounts) -e "VERSION=$(VERSION)" $(DOCKER_RUN_ARGS) conformance:$(build_version) /root/test.sh
+
+run-conformance-jstests:
+	docker run --rm $(common_mounts) -e "VERSION=$(VERSION)" $(DOCKER_RUN_ARGS) conformance:$(build_version) /root/jstest.sh

--- a/test/sdk/harness/testGetGameserver.yaml
+++ b/test/sdk/harness/testGetGameserver.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - init
+  - ready
+  - getGameServer
+  - watchGameServer
+  - setlabel
+  - setannotation
+  - cleanup
+expected:
+  - Ready
+  - getting GameServer details
+  - connected to watch GameServer
+  - Setting label
+  - Setting annotation

--- a/test/sdk/harness/testHealth.yaml
+++ b/test/sdk/harness/testHealth.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - init
+  - ready
+  - health
+  - shutdown
+  - cleanup
+expected:
+  - Ready
+  - Health
+  - Shutdown

--- a/test/sdk/harness/testReady.yaml
+++ b/test/sdk/harness/testReady.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - init
+  - ready
+  - allocate
+  - setlabel
+  - setannotation
+  - cleanup
+expected:
+  - Ready
+  - Allocate
+  - Setting label
+  - Setting annotation

--- a/test/sdk/sdk_client/golang.yaml
+++ b/test/sdk/sdk_client/golang.yaml
@@ -1,0 +1,91 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+functions:
+  health: |
+    time.Sleep(1*time.Second)
+    for i := 0 ; i < 5; i ++ {
+      err = s.Health()
+      if err != nil {
+        log.Fatalf("Could not send Health check")
+      } else {
+        log.Println("Health message sent")
+      }
+    }
+  ready:  |
+    err = s.Ready()
+    if err != nil {
+      log.Fatalf("Could not send ready message")
+    }
+  shutdown: |
+    err = s.Shutdown()
+    if err != nil {
+      log.Fatalf("Could not send shutdown request")
+    }
+  getGameServer: |
+    gs, err := s.GameServer()
+    if err != nil {
+      log.Fatalf("Could not get gameserver parameters")
+    }
+    log.Println(gs)
+  watchGameServer: |
+    err = s.WatchGameServer(func(*pkgSdk.GameServer) {
+      // TODO: add error if not received
+      log.Println("Received GameServer update")
+    })
+    if err != nil {
+      log.Fatalf("Could not watch gameserver")
+    }
+  allocate: |
+    err = s.Allocate()
+    if err != nil {
+      log.Fatalf("Could not send allocate request")
+    }
+  setlabel: |
+    err = s.SetLabel("new", "label")
+    if err != nil {
+      log.Fatalf("Could not set label")
+    }
+  setannotation: |
+    err = s.SetAnnotation("new", "annotation")
+    if err != nil {
+      log.Fatalf("Could not set annotation")
+    }
+  init: |
+    package main
+
+    import (
+      "time"
+      "log"
+
+      goSdk "agones.dev/agones/sdks/go"
+      pkgSdk "agones.dev/agones/pkg/sdk"
+    )
+
+    func main() {
+      log.SetFlags(log.Lshortfile)
+      log.Println("starting")
+      // Additional call to supress errors
+      e := pkgSdk.Empty{}
+      e.ProtoMessage()
+      time.Sleep(100 * time.Millisecond)
+      s, err := goSdk.NewSDK()
+      if err != nil {
+        log.Fatalf("Could not connect to sdk: %v", err)
+      } else {
+        log.Println("SDK initialised")
+      }
+  cleanup: |
+      time.Sleep(3*time.Second)
+      }

--- a/test/sdk/sdk_client/nodejs.yaml
+++ b/test/sdk/sdk_client/nodejs.yaml
@@ -1,0 +1,54 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+functions:
+  health: |
+    let result = await agonesSDK.health();
+  ready:  |
+    await agonesSDK.ready();
+  setlabel: |
+    await agonesSDK.setLabel("label", "labelValue");
+  setannotation: |
+    await agonesSDK.setAnnotation("annotation", "annotationValue");
+  init: |
+    const AgonesSDK = require('agones');
+    const agonesSDK = new AgonesSDK();
+    const connect = async function() {
+      agonesSDK.watchGameServer((result) => {
+        console.log('watch', result);
+      });
+      try {
+  watchGameServer: |
+    agonesSDK.watchGameServer((result) => {
+      console.log('watch', result);
+    });
+  getGameServer: |
+    const result = await agonesSDK.getGameServer();
+    console.log('gameServer', result);
+  shutdown: |
+    setTimeout(() => {
+      console.log('send shutdown request');
+      agonesSDK.shutdown();
+    }, 1000);
+  allocate: |
+    setTimeout(() => {
+      console.log('send shutdown request');
+      agonesSDK.allocate();
+    }, 1000);
+  cleanup: |
+    } catch (error) {
+        console.error(error);
+      }
+    };
+    connect();

--- a/test/sdk/test_engine.go
+++ b/test/sdk/test_engine.go
@@ -1,0 +1,234 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+type testCase struct {
+	Steps  []string `yaml:"steps,omitempty"`
+	Result []string `yaml:"expected,omitempty"`
+}
+
+func runSidecar(language string) []bool {
+	files, err := ioutil.ReadDir("./bin/" + language)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var tc testCase
+	testResults := make([]bool, 0)
+	for _, f := range files {
+		if f.Name() == "node_modules" || !f.IsDir() {
+			continue
+		}
+		sidecar := "bin/sdk-server"
+		cmdSdk := exec.Command(sidecar, "--local", "-f", "../../examples/gameserver.yaml",
+			"--timeout", "15")
+		sdkServer, err := cmdSdk.StderrPipe()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := cmdSdk.Start(); err != nil {
+			log.Fatal(err)
+		}
+		//Wait for GRPC gateway to start
+		time.Sleep(2 * time.Second)
+
+		//cmd = exec.Command("cd", "./bin", "&&", "go", "build")
+
+		yamlFile, err := ioutil.ReadFile("harness/" + f.Name() + ".yaml")
+		if err != nil {
+			log.Printf("yamlFile.Get err   #%v ", err)
+		}
+
+		if err := yaml.Unmarshal(yamlFile, &tc); err != nil {
+			log.Fatal(err)
+		}
+
+		var cmdTest *exec.Cmd
+
+		if language == "nodejs" {
+			cmdTest = exec.Command("npm", "run", f.Name())
+			cmdTest.Dir = "./bin/nodejs/"
+		} else {
+			cmdTest = exec.Command("./bin/golang/" + f.Name() + "/" + f.Name())
+		}
+		stderr, err := cmdTest.StderrPipe()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := cmdTest.Start(); err != nil {
+			log.Fatal(err)
+		}
+
+		sc := bufio.NewScanner(stderr)
+		for sc.Scan() {
+			log.Printf("Line: %s\n", sc.Text())
+		}
+
+		sc = bufio.NewScanner(sdkServer)
+
+		result := make(map[string]bool)
+		for sc.Scan() {
+			log.Printf("SDK Line : %s\n", sc.Text())
+
+			for _, v := range tc.Result {
+				if strings.Contains(sc.Text(), v) {
+					result[v] = true
+				}
+			}
+		}
+
+		if err := cmdTest.Wait(); err != nil {
+			log.Fatal(err)
+		}
+
+		if err := cmdSdk.Wait(); err != nil {
+			log.Fatal(err)
+		}
+		all := true
+		for _, v := range tc.Result {
+			if _, ok := result[v]; !ok {
+				all = false
+				log.Printf("FAIL in %s file. Could not find expected: %s\n", f.Name(), v)
+			}
+
+		}
+		testResults = append(testResults, all)
+	}
+	return testResults
+}
+
+// Code Generation function which would
+// create a client code with test steps
+// described by test files
+func main() {
+	lang := flag.String("sdk", "golang", "sdk language")
+	testname := flag.String("test", "testReady", "test name")
+	verify := flag.Bool("verify", false, "run sidecar and appropriate test")
+	flag.Parse()
+	log.Println(*lang)
+	log.Println(*testname)
+	// Enable line numbers in logging
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	if *verify {
+		testResults := runSidecar(*lang)
+		log.Println("test Results: ", testResults)
+		return
+	}
+	fileExtensions := map[string]string{"golang": "go", "nodejs": "js", "cpp": "cpp"}
+	// Functions which contains code excerpts like init, ready, cleanup
+	var functions struct {
+		Functions map[string]string `yaml:"functions,omitempty"`
+	}
+	yamlFile, err := ioutil.ReadFile("sdk_client/" + *lang + ".yaml")
+	if err != nil {
+		log.Printf("yamlFile.Get err: %v ", err)
+	}
+	if err := yaml.Unmarshal(yamlFile, &functions); err != nil {
+		log.Fatal(err)
+	}
+
+	for i := range functions.Functions {
+		log.Printf("Function loaded '%s' \n", i)
+	}
+
+	testList := make([]string, 0)
+	if *testname == "" {
+		files, err := ioutil.ReadDir("./harness")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, f := range files {
+			testList = append(testList, f.Name())
+		}
+	} else {
+		testList = append(testList, *testname+".yaml")
+	}
+
+	var tc testCase
+	for i, f := range testList {
+		log.Println("Creating test ", i, " ", f)
+		yamlFile, err = ioutil.ReadFile("harness/" + f)
+		if err != nil {
+			log.Printf("yamlFile.Get err: %v ", err)
+		}
+
+		if err := yaml.Unmarshal(yamlFile, &tc); err != nil {
+			log.Fatal(err)
+		}
+		code := ""
+		for _, v := range tc.Steps {
+			if f, ok := functions.Functions[v]; ok {
+				code += f
+			} else {
+				log.Printf("Could not find function declaration %s \n", v)
+			}
+		}
+		test := f[:strings.IndexByte(f, '.')]
+		path := "./bin/" + *lang + "/" + test
+		err = os.MkdirAll(path, 0700)
+		if err != nil {
+			log.Printf("Create dir error: %v ", err)
+		}
+		err = ioutil.WriteFile(path+"/"+test+"."+fileExtensions[*lang], []byte(code), 0644)
+		if err != nil {
+			log.Printf("Write to file error: %v ", err)
+		}
+	}
+
+	if *lang == "nodejs" {
+		packagesBegin := `
+{
+"dependencies": {
+"agones": "../../../../sdks/nodejs"
+},
+"scripts": {
+			
+		`
+		packagesEnd := `
+		
+}
+}	
+`
+		scripts := ""
+		for i, f := range testList {
+			test := f[:strings.IndexByte(f, '.')]
+			scripts += fmt.Sprintf("\"%s\": \"node ./%s/%s.js\"", test, test, test)
+			if i+1 < len(testList) {
+				scripts += ",\n"
+			}
+		}
+		packages := packagesBegin + scripts + packagesEnd
+		err = ioutil.WriteFile("./bin/nodejs/package.json", []byte(packages), 0644)
+		if err != nil {
+			log.Printf("Write to file error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
PoC for SDK conformance testing.
Proposal Document could be found [here](https://docs.google.com/document/d/1Qjy-wXA1wsZB8PE_CP_GCgnyWktySm_ytZgRUZ2wtCo/edit?usp=sharing).
Test engine performs two tasks: code generation for Golang, Node SDKs and verification that SDK sends and sidecar receives all GRPC messages as intended.
YAML file with test definition in Formal language -> translates and concatenates from excerpts in SDK target language.
Code generator use code templates from sdk_client use test Case
scenarios from harness folder and produce go file which would run the
scenario.
`make build-conformance-tests` - build docker image and binaries of sdk-server (sidecar) and `test_engine`
`make run-conformance-tests` - build binaries and perform verify step (also `run-conformance-jstests`):
>`./sdk --verify=true --sdk=nodejs`  - runs sdk-server and binaries of target SDK client generated before.
Added --timeout for sdk-server (Sidecar) local run.

For #672.