### PR TITLE
SDK Conformance testing

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -338,8 +338,12 @@ build-agones-sdk-binary-windows: $(ensure-build-image)
 	$(GO_BUILD_WINDOWS_AMD64) \
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server
 
-# Build the image for the gameserver sidecar
+# Build the image for the gameserver sidecar and SDK binaries
 build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses build-required-src-dist
+	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
+
+# Build sidecar image only
+build-agones-sdk-server-image: $(ensure-build-image) build-agones-sdk-binary-linux
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
 
 # Build a static binary for the ping service

--- a/build/README.md
+++ b/build/README.md
@@ -34,6 +34,7 @@ Table of Contents
         * [make build-images](#make-build-images)
         * [make build-sdks](#make-build-sdks)
         * [make build-sdk-cpp](#make-build-sdk-cpp)
+        * [make run-sdk-conformance-tests](#make-run-sdk-conformance-tests)
         * [make test](#make-test)
         * [make push](#make-push)
         * [make install](#make-install)
@@ -415,6 +416,10 @@ Build all the sdks required for Agones
 
 #### `make build-sdk-cpp`
 Build the cpp sdk static and dynamic libraries (linux libraries only)
+
+#### `make run-sdk-conformance-tests`
+Run SDK conformance test.
+Run SDK server (sidecar) in test mode (which would record all GRPC requests) versus all SDK test clients which should generate those requests. All methods are verified.
 
 #### `make test`
 Run the linter and tests

--- a/build/build-sdk-images/go/sdktest.sh
+++ b/build/build-sdk-images/go/sdktest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+GO111MODULE=off
+cd /go/src/agones.dev/agones/test/sdk/go
+go run sdk-client-test.go

--- a/build/build-sdk-images/node/build.sh
+++ b/build/build-sdk-images/node/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd /go/src/agones.dev/agones/test/sdk/nodejs
+npm install
+npm rebuild
+
+# If first 'npm install' attempt fails, which could occur for a variety of reasons,
+# do one more attempt
+if [ $? -gt 0 ]
+then
+    echo "Run npm install one more time"
+    rm -rf /go/src/agones.dev/agones/sdks/nodejs/node_modules
+    rm -rf /go/src/agones.dev/agones/test/sdk/nodejs/node_modules
+    rm /go/src/agones.dev/agones/test/sdk/nodejs/package-lock.json
+    npm cache clean
+    npm rebuild
+    npm install
+fi

--- a/build/build-sdk-images/node/clean.sh
+++ b/build/build-sdk-images/node/clean.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rm -rf /go/src/agones.dev/agones/test/sdk/nodejs/node_modules
+rm /go/src/agones.dev/agones/test/sdk/nodejs/package-lock.json

--- a/build/build-sdk-images/node/sdktest.sh
+++ b/build/build-sdk-images/node/sdktest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+cd /go/src/agones.dev/agones/test/sdk/nodejs
+npm run testSDK

--- a/build/includes/build-image.mk
+++ b/build/includes/build-image.mk
@@ -63,3 +63,6 @@ push-remote-build-image:
 # pull a local image that may exist on a remote repository, to a local image
 pull-remote-build-image:
 	-docker pull $(REMOTE_TAG) && docker tag $(REMOTE_TAG) $(LOCAL_TAG)
+
+ensure-agones-sdk-image:
+	$(MAKE) ensure-image IMAGE_TAG=$(sidecar_tag) BUILD_TARGET=build-agones-sdk-server-image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -95,31 +95,6 @@ steps:
   args: ["lint"] # pull the build image if it exists
 
 #
-# Run the all the automated tests (except e2e) in parallel
-#
-
-- name: "make-docker"
-  id: tests
-  waitFor:
-    - lint
-    - ensure-build-sdk-image-base
-    - htmltest-restore-cache
-  dir: "build"
-  args: [ "-j", "5", "--output-sync=target", "test" ]
-
-#
-# Cache the htmltest url checks. Faster builds, and lower network flakiness.
-#
-- name: 'gcr.io/$PROJECT_ID/save_cache'
-  args:
-    - '--bucket=gs://$_CACHE_BUCKET'
-    - '--key=$_HTMLTEST_CACHE_KEY'
-    - '--path=site/tmp'
-  id: htmltest-save-cache
-  waitFor:
-    - tests
-
-#
 # Push the build image, can run while we do other things.
 #
 
@@ -158,6 +133,32 @@ steps:
   args: [ "-j", "3", "push"]
 
 #
+# Run the all the automated tests (except e2e) in parallel
+#
+
+- name: "make-docker"
+  id: tests
+  waitFor:
+    - lint
+    - ensure-build-sdk-image-base
+    - htmltest-restore-cache
+    - build
+  dir: "build"
+  args: [ "-j", "5", "--output-sync=target", "test" ]
+
+#
+# Cache the htmltest url checks. Faster builds, and lower network flakiness.
+#
+- name: 'gcr.io/$PROJECT_ID/save_cache'
+  args:
+    - '--bucket=gs://$_CACHE_BUCKET'
+    - '--key=$_HTMLTEST_CACHE_KEY'
+    - '--path=site/tmp'
+  id: htmltest-save-cache
+  waitFor:
+    - tests
+
+#
 # Site preview
 #
 
@@ -189,6 +190,18 @@ steps:
   waitFor:
     - push-images
     - build-e2e
+
+#
+# SDK conformance tests
+#
+
+- name: "make-docker"
+  id: sdk-conformance
+  dir: "build"
+  args: [ "run-sdk-conformance-tests"]
+  waitFor:
+    - build
+    - tests
 
 #
 # Zip up artifacts and push to storage

--- a/examples/nodejs-simple/src/index.js
+++ b/examples/nodejs-simple/src/index.js
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 const AgonesSDK = require('agones');
 
 const  agonesSDK = new AgonesSDK();

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -63,6 +63,22 @@ func TestLocal(t *testing.T) {
 	assert.Equal(t, defaultGs, gs)
 }
 
+func TestLocalSDKWithTestMode(t *testing.T) {
+	a := []string{"ready", "allocate", "setlabel", "setannotation", "gameserver", "health", "shutdown", "watch"}
+	b := []string{"ready", "health", "ready", "watch", "allocate", "gameserver", "setlabel", "setannotation", "health", "health", "shutdown"}
+	assert.True(t, EqualSets(a, a))
+	assert.True(t, EqualSets(a, b))
+	assert.True(t, EqualSets(b, a))
+	assert.True(t, EqualSets(b, b))
+	a[0] = "rady"
+	assert.False(t, EqualSets(a, b))
+	assert.False(t, EqualSets(b, a))
+	a[0] = "ready"
+	b[1] = "halth"
+	assert.False(t, EqualSets(a, b))
+	assert.False(t, EqualSets(b, a))
+}
+
 func TestLocalSDKWithGameServer(t *testing.T) {
 	ctx := context.Background()
 	e := &sdk.Empty{}

--- a/sdks/nodejs/spec/agonesSDK.spec.js
+++ b/sdks/nodejs/spec/agonesSDK.spec.js
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 const EventEmitter = require('events');
 
 const messages = require('../lib/sdk_pb');

--- a/sdks/nodejs/src/agonesSDK.js
+++ b/sdks/nodejs/src/agonesSDK.js
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 const grpc = require('grpc');
 
 const messages = require('../lib/sdk_pb');

--- a/sdks/nodejs/src/index.js
+++ b/sdks/nodejs/src/index.js
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 const AgonesSDK = require('./agonesSDK');
 
 module.exports = AgonesSDK;

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -121,7 +121,7 @@ relinquish control to an external service which likely doesn't have as much info
 
 ## Writing your own SDK
 
-If there isn't a SDK for the language and platform you are looking for, you have several options:
+If there isn't an SDK for the language and platform you are looking for, you have several options:
 
 ### gRPC Client Generation
 
@@ -136,6 +136,33 @@ the [REST]({{< relref "rest.md" >}}) HTTP+JSON interface. This could be written 
 the {{< ghlink href="sdk.swagger.json" >}}Swagger/OpenAPI Spec{{< /ghlink >}}.
 
 Finally, if you build something that would be usable by the community, please submit a pull request!
+
+## SDK Conformance Test
+
+There is a tool `SDK server Conformance` checker which will run Local SDK server and record all requests your client is performing.
+
+In order to check that SDK is working properly you should write simple SDK test client which would use all methods of your SDK.
+
+Also to test that SDK cliet is receiving valid Gameserver data, your binary should set the same `Label` value as creation timestamp which you will receive as a result of GameServer() call and `Annotation` value same as gameserver UID received by Watch gameserver callback.
+
+Complete list of endpoints which should be called by your test client is the following:
+```
+ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch
+```
+
+In order to run this test SDK server locally use:
+```
+SECONDS=30 make run-sdk-conformance-local
+```
+
+Docker container would timeout in 30 seconds and give your the comparison of received requests and expected requests
+
+For instance you could run go sdk conformance test and see how the process goes: 
+```
+SDK_FOLDER=go make run-sdk-conformance-test
+```
+
+In order to add test client for your SDK, write `jstest.sh` and `Dockerfile`. Refer to {{< ghlink href="build/build-sdk-images/go/Dockerfile" >}}Golang SDK testing directory structure{{< /ghlink >}}.
 
 ## Building the Tools
 

--- a/test/sdk/go/sdk-client-test.go
+++ b/test/sdk/go/sdk-client-test.go
@@ -1,0 +1,97 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"strconv"
+	"time"
+
+	pkgSdk "agones.dev/agones/pkg/sdk"
+	goSdk "agones.dev/agones/sdks/go"
+)
+
+const attempts = 10
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+	log.Println("Client is starting")
+	time.Sleep(100 * time.Millisecond)
+	var sdk *goSdk.SDK
+	var err error
+	for i := 0; i < attempts; i++ {
+		sdk, err = goSdk.NewSDK()
+		if err != nil {
+			log.Printf("Could not connect to sdk: %v\n", err)
+		} else {
+			log.Println("SDK initialised")
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		log.Fatalf("Could not connect to sdk: %v\n", err)
+	}
+
+	c := make(chan string)
+
+	once := true
+	err = sdk.WatchGameServer(func(gs *pkgSdk.GameServer) {
+		log.Println("Received GameServer update")
+		log.Println(gs)
+		uid := gs.ObjectMeta.Uid
+		if once {
+			c <- uid
+			once = false
+		}
+	})
+	if err != nil {
+		log.Fatalf("Error on watch GameServer %s", err)
+	}
+	err = sdk.Ready()
+	if err != nil {
+		log.Fatalf("Could not send ready message %s", err)
+	}
+	err = sdk.Allocate()
+	if err != nil {
+		log.Fatalf("Err sending allocate request %s", err)
+	}
+	err = sdk.Health()
+	if err != nil {
+		log.Fatalf("Could not send Health check: %s", err)
+	}
+	gs, err := sdk.GameServer()
+	if err != nil {
+		log.Fatalf("Could not get gameserver parameters: %s", err)
+	}
+	log.Println(gs)
+
+	err = sdk.SetLabel("creationTimestamp", strconv.FormatInt(gs.ObjectMeta.CreationTimestamp, 10))
+	if err != nil {
+		log.Fatalf("Could not set label: %s", err)
+	}
+	if err != nil {
+		log.Fatalf("Error received on watch gameserver %s", err)
+	}
+	uid := <-c
+	err = sdk.SetAnnotation("UID", uid)
+	if err != nil {
+		log.Fatalf("Could not set annotation: %s", err)
+	}
+	err = sdk.Shutdown()
+	if err != nil {
+		log.Fatalf("Could not shutdown GameServer%s", err)
+	}
+}

--- a/test/sdk/nodejs/package.json
+++ b/test/sdk/nodejs/package.json
@@ -1,0 +1,8 @@
+{
+		"dependencies": {
+				"agones": "../../../sdks/nodejs"
+		},
+		"scripts": {
+				"testSDK": "node ./testSDKClient.js"
+		}
+}

--- a/test/sdk/nodejs/testSDKClient.js
+++ b/test/sdk/nodejs/testSDKClient.js
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const AgonesSDK = require("agones");
+const agonesSDK = new AgonesSDK();
+
+const connect = async function() {
+  var UID = ""
+  try {
+    var once = true;
+    agonesSDK.watchGameServer((result) => {
+        console.log("watch", result);
+        UID = result.objectMeta.uid.toString();
+        if (once) {
+          console.log("Setting annotation ", UID)
+          agonesSDK.setAnnotation("annotation", UID);
+          once = false;
+        }
+      });
+    await agonesSDK.ready();
+    setTimeout(() => {
+      console.log("send allocate request");
+      agonesSDK.allocate();
+    }, 1000);
+
+
+    let result = await agonesSDK.getGameServer();
+    await agonesSDK.setLabel("label", 
+      result.objectMeta.creationTimestamp.toString());
+    console.log("gameServer", result);
+    console.log("creation Timestamp", result.objectMeta.creationTimestamp)
+    result = await agonesSDK.health();
+    console.log("health", result);
+
+    setTimeout(() => {
+      console.log("send shutdown request");
+      agonesSDK.shutdown();
+    }, 1000);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+connect();


### PR DESCRIPTION
Add test mode for SDK-server.
Local SDK server (Sidecar) now could record client requests.
Added test clients and make targets to test Golang and NodeJS SDKs.

For #672.