### PR TITLE
Cpp clang-format

### DIFF
--- a/build/build-sdk-images/cpp/Dockerfile
+++ b/build/build-sdk-images/cpp/Dockerfile
@@ -15,25 +15,16 @@ ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
 RUN apt-get update && \
-    apt-get install -y zip wget && \
+    apt-get install -y zip wget clang-format && \
     apt-get clean
 
-ADD https://cmake.org/files/v3.14/cmake-3.14.1-Linux-x86_64.sh /cmake-3.14.1-Linux-x86_64.sh
+RUN wget -q https://cmake.org/files/v3.14/cmake-3.14.1-Linux-x86_64.sh -O /cmake-3.14.1-Linux-x86_64.sh
 RUN mkdir /opt/cmake
 RUN sh /cmake-3.14.1-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
 RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 RUN cmake --version
 
-WORKDIR /usr/local
-ENV GO_VERSION=1.12
-ENV GO111MODULE=on
-ENV GOPATH /go
-RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir -p ${GOPATH}
-
 WORKDIR /go/src/agones.dev/agones
-
-ENV PATH /usr/local/go/bin:/go/bin:$PATH
 
 # code generation scripts
 COPY *.sh /root/

--- a/build/build-sdk-images/cpp/build.sh
+++ b/build/build-sdk-images/cpp/build.sh
@@ -17,4 +17,4 @@
 set -ex
 
 cd ./sdks/cpp
-make build install archive VERSION=$VERSION
+make build verify install archive VERSION=$VERSION

--- a/examples/cpp-simple/Dockerfile
+++ b/examples/cpp-simple/Dockerfile
@@ -16,7 +16,7 @@ FROM gcc:8 as builder
 
 WORKDIR /project
 
-ADD https://cmake.org/files/v3.14/cmake-3.14.1-Linux-x86_64.sh /cmake-3.14.1-Linux-x86_64.sh
+RUN wget -q https://cmake.org/files/v3.14/cmake-3.14.1-Linux-x86_64.sh -O /cmake-3.14.1-Linux-x86_64.sh
 RUN mkdir /opt/cmake
 RUN sh /cmake-3.14.1-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
 RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -64,6 +64,7 @@ option(AGONES_FORCE_GRPC_VERSION "Build Agones C++ SDK only with supported gRPC 
 option(AGONES_BUILD_ONLY_PREREQUISITIES "Build only prerequisites of Agones" OFF)
 option(AGONES_ZLIB_STATIC "Use static version of ZLIB" ON)
 option(AGONES_BUILD_THIRDPARTY_DEBUG "Build debug version of thirdparty libraries (MSVC only)" OFF)
+option(AGONES_CLANG_FORMAT "Apply clang-format (if found) as a pre-build step" OFF)
 set(AGONES_THIRDPARTY_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}" CACHE STRING "Path for installing third-party OpenSSL and gRPC, if they are not found with find_package")
 set(AGONES_OPENSSL_CONFIG_STRING "VC-WIN64A" CACHE STRING "See https://github.com/openssl/openssl/blob/master/INSTALL for details")
 
@@ -186,3 +187,42 @@ install(
 
 unset(_INCLUDE_DIRS)
 unset(_CMAKE_CONFIG_DESTINATION)
+
+# clang-format
+find_program(
+    CLANG_FORMAT_APP
+    NAMES "clang-format"
+    DOC "Path to clang-format"
+)
+if (NOT CLANG_FORMAT_APP)
+    message(STATUS "clang-format not found.")
+else()
+    message(STATUS "clang-format found: ${CLANG_FORMAT_APP}")
+    
+    set(CLANGFORMAT_INPUT)
+    foreach(relpath ${SDK_FILES})
+        get_filename_component(fullpath "${CMAKE_CURRENT_LIST_DIR}/${relpath}" ABSOLUTE)
+        list(APPEND CLANGFORMAT_INPUT ${fullpath})
+    endforeach()
+ 
+    # format
+    add_custom_target(
+        clang-format-apply
+        COMMAND ${CLANG_FORMAT_APP} -i --style=file --fallback-style=Google ${CLANGFORMAT_INPUT}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    if (${AGONES_CLANG_FORMAT})
+        add_dependencies(${PROJECT_NAME} "clang-format-apply")
+    endif()
+    
+    # verification
+    set(CLANGFORMAT_WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+    get_filename_component(AGONES_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+    get_filename_component(AGONES_TEMP "${CMAKE_CURRENT_BINARY_DIR}/clang-format/temp" ABSOLUTE)
+    configure_file("cmake/clang-verify.in" "clang-format/CMakeLists.txt" @ONLY)
+    add_custom_target(
+        clang-format-verify
+        COMMAND ${CMAKE_COMMAND} .
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/clang-format"
+    )    
+endif()

--- a/sdks/cpp/Makefile
+++ b/sdks/cpp/Makefile
@@ -26,7 +26,10 @@ build:
 	-mkdir $(build_path)
 	cd $(build_path) && cmake .. -DCMAKE_BUILD_TYPE=Release -DAGONES_SILENT_OUTPUT=ON -G "Unix Makefiles" -Wno-dev -DCMAKE_INSTALL_PREFIX=.install
 	cd $(build_path) && cmake --build . --target install -- -s
-	
+    
+verify:
+	cd $(build_path)/clang-format && cmake . -DAGONES_SILENT_OUTPUT=ON
+    
 install:
 	cp -r $(build_path)/.install $(install_path)
 	

--- a/sdks/cpp/cmake/agonesConfig.cmake.in
+++ b/sdks/cpp/cmake/agonesConfig.cmake.in
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set(agones_VERSION @agones_VERSION@)
 
 @PACKAGE_INIT@ 

--- a/sdks/cpp/cmake/clang-verify.in
+++ b/sdks/cpp/cmake/clang-verify.in
@@ -1,0 +1,74 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 3.13.0)
+
+option(AGONES_SILENT_OUTPUT "Show only warnings/error messages" OFF)
+if (AGONES_SILENT_OUTPUT)
+    function(message)
+        list(GET ARGV 0 MessageType)
+        list(REMOVE_AT ARGV 0)
+        if (MessageType STREQUAL FATAL_ERROR OR
+            MessageType STREQUAL SEND_ERROR OR
+            MessageType STREQUAL WARNING OR
+            MessageType STREQUAL AUTHOR_WARNING OR
+            NOT ${AGONES_SILENT_OUTPUT}
+            )
+            _message(${MessageType} "${ARGV}")
+        endif()
+    endfunction()
+
+    set(CMAKE_INSTALL_MESSAGE NEVER)
+    set(CMAKE_VERBOSE_MAKEFILE OFF)
+    set_property(GLOBAL PROPERTY RULE_MESSAGES OFF)
+    set_property(GLOBAL PROPERTY TARGET_MESSAGES OFF)
+endif(AGONES_SILENT_OUTPUT)
+
+set(files @CLANGFORMAT_INPUT@)
+set(workingdir @CLANGFORMAT_WORKING_DIR@)
+set(root @AGONES_ROOT@)
+set(temp @AGONES_TEMP@)
+
+find_package(Git REQUIRED)
+find_program(
+    CLANG_FORMAT_APP
+    NAMES "clang-format"
+    DOC "Path to clang-format"
+)
+if (NOT CLANG_FORMAT_APP)
+    message(FATAL_ERROR "Could not find clang-format")
+endif()
+
+file(MAKE_DIRECTORY ${temp})
+foreach(source_file ${files})
+    file(COPY ${source_file} DESTINATION ${temp})
+    file(RELATIVE_PATH source_relative ${root} ${source_file})
+    get_filename_component(filename ${source_file} NAME ABSOLUTE)
+    get_filename_component(source_file_temp "${temp}/${filename}" ABSOLUTE)
+
+    execute_process(
+        COMMAND ${CLANG_FORMAT_APP} -i --style=file --fallback-style=Google ${source_file_temp}
+        WORKING_DIRECTORY ${workingdir}
+    )
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} diff --exit-code --quiet --no-index "${source_file}" "${source_file_temp}"
+        WORKING_DIRECTORY ${root}
+        RESULT_VARIABLE result
+    )
+    
+    file(REMOVE ${source_file_temp})
+    if (NOT ${result} EQUAL 0)
+        message(FATAL_ERROR "clang-format code style check failed for: ${source_relative}")
+    endif()
+endforeach()

--- a/sdks/cpp/sources.cmake
+++ b/sdks/cpp/sources.cmake
@@ -1,27 +1,35 @@
 set(SOURCE_FILES
-  src/agones/sdk.cc
-  src/agones/sdk.grpc.pb.cc
-  src/agones/sdk.pb.cc
-  
-  src/google/annotations.pb.cc
-  src/google/http.pb.cc
+    src/agones/sdk.cc
 )
 
 set(HEADER_FILES
-  include/agones/sdk.h
-  include/agones/sdk.grpc.pb.h
-  include/agones/sdk.pb.h
+    include/agones/sdk.h
 )
 
-set(GOOGLE_HEADER_FILES
-  include/google/api/annotations.pb.h
-  include/google/api/http.pb.h
+set(GENERATED_SOURCE_FILES
+    src/agones/sdk.grpc.pb.cc
+    src/agones/sdk.pb.cc
+    src/google/annotations.pb.cc
+    src/google/http.pb.cc
+)
+
+set(GENERATED_HEADER_FILES
+    include/agones/sdk.grpc.pb.h
+    include/agones/sdk.pb.h
+    include/google/api/annotations.pb.h
+    include/google/api/http.pb.h
 )
 
 set(ALL_FILES
-  ${SOURCE_FILES}
-  ${HEADER_FILES}
-  ${GOOGLE_HEADER_FILES}
-  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h"
-  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_global.h"
+    ${SOURCE_FILES}
+    ${HEADER_FILES}
+    ${GENERATED_SOURCE_FILES}
+    ${GENERATED_HEADER_FILES}
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_global.h"
+)
+
+set(SDK_FILES
+    ${SOURCE_FILES}
+    ${HEADER_FILES}
 )


### PR DESCRIPTION
PR for #713 issue.
Added support of clang-format as a pre-build step (optional, useful for SDK contributors)
Added clang-format code style verification as a build step. Build will fail if SDK code is not following google code style (not applied for generated files).
Waiting for #803 to be merged in...