### PR TITLE
Flaky: TestGameServerPassthroughPort

### DIFF
--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -70,6 +70,7 @@ var (
 
 // SDKServer is a gRPC server, that is meant to be a sidecar
 // for a GameServer that will update the game server status on SDK requests
+// nolint: maligned
 type SDKServer struct {
 	logger             *logrus.Entry
 	gameServerName     string
@@ -94,6 +95,7 @@ type SDKServer struct {
 	gsAnnotations      map[string]string
 	gsState            stablev1alpha1.GameServerState
 	gsUpdateMutex      sync.RWMutex
+	gsWaitForSync      sync.WaitGroup
 }
 
 // NewSDKServer creates a SDKServer that sets up an
@@ -126,6 +128,7 @@ func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interf
 		gsLabels:           map[string]string{},
 		gsAnnotations:      map[string]string{},
 		gsUpdateMutex:      sync.RWMutex{},
+		gsWaitForSync:      sync.WaitGroup{},
 	}
 
 	s.informerFactory = factory
@@ -162,6 +165,8 @@ func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interf
 		}
 	})
 
+	// we haven't synced yet
+	s.gsWaitForSync.Add(1)
 	s.workerqueue = workerqueue.NewWorkerQueue(
 		s.syncGameServer,
 		s.logger,
@@ -183,11 +188,15 @@ func (s *SDKServer) initHealthLastUpdated(healthInitialDelay time.Duration) {
 // Will block until stop is closed
 func (s *SDKServer) Run(stop <-chan struct{}) error {
 	s.informerFactory.Start(stop)
-	cache.WaitForCacheSync(stop, s.gameServerSynced)
+	if !cache.WaitForCacheSync(stop, s.gameServerSynced) {
+		return errors.New("failed to wait for caches to sync")
+	}
+	// we have the gameserver details now
+	s.gsWaitForSync.Done()
 
-	gs, err := s.gameServerLister.GameServers(s.namespace).Get(s.gameServerName)
+	gs, err := s.gameServer()
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving gameserver %s/%s", s.namespace, s.gameServerName)
+		return err
 	}
 
 	// grab configuration details
@@ -278,6 +287,9 @@ func (s *SDKServer) updateState() error {
 }
 
 func (s *SDKServer) gameServer() (*stablev1alpha1.GameServer, error) {
+	// this ensure that if we get requests for the gameserver before the cache has been synced,
+	// they will block here until it's ready
+	s.gsWaitForSync.Wait()
 	gs, err := s.gameServerLister.GameServers(s.namespace).Get(s.gameServerName)
 	return gs, errors.Wrapf(err, "could not retrieve GameServer %s/%s", s.namespace, s.gameServerName)
 }

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -283,6 +283,7 @@ func TestSDKServerSyncGameServer(t *testing.T) {
 			defer close(stop)
 			sc.informerFactory.Start(stop)
 			assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
+			sc.gsWaitForSync.Done()
 
 			err = sc.syncGameServer(v.key)
 			assert.Nil(t, err)
@@ -345,6 +346,7 @@ func TestSidecarUpdateState(t *testing.T) {
 			defer close(stop)
 			sc.informerFactory.Start(stop)
 			assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
+			sc.gsWaitForSync.Done()
 
 			err = sc.updateState()
 			assert.Nil(t, err)
@@ -577,6 +579,7 @@ func TestSDKServerGetGameServer(t *testing.T) {
 
 	sc.informerFactory.Start(stop)
 	assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
+	sc.gsWaitForSync.Done()
 
 	result, err := sc.GetGameServer(context.Background(), &sdk.Empty{})
 	assert.Nil(t, err)
@@ -648,6 +651,7 @@ func TestSDKServerUpdateEventHandler(t *testing.T) {
 
 	sc.informerFactory.Start(stop)
 	assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
+	sc.gsWaitForSync.Done()
 
 	stream := newGameServerMockStream()
 	asyncWatchGameServer(t, sc, stream)
@@ -695,6 +699,7 @@ func TestSDKServerAllocate(t *testing.T) {
 		assert.Nil(t, err)
 		sc.informerFactory.Start(stop)
 		assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
+		sc.gsWaitForSync.Done()
 		return m, sc, stop
 	}
 


### PR DESCRIPTION
TestGameServerPassthroughPort exposed a pretty nasty race condition in the sdk sidecar server, in which a request for GameServer information could come in just before it had cached its details, resulting in a
"Not found" response.

This uses a WaitGroup to requests for GameServer information until such time as it is initially loaded.