### PR TITLE
Unreal Engine plugin - Health Ping Enabled to true by default

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/AgonesSettings.cpp
+++ b/sdks/unreal/Agones/Source/Agones/AgonesSettings.cpp
@@ -17,7 +17,7 @@
 UAgonesSettings::UAgonesSettings()
 	: Super()
 	, AgonesSidecarAddress("http://localhost:59358")
-	, bHealthPingEnabled(false)
+	, bHealthPingEnabled(true)
 	, HealthPingSeconds(5.0f)
 	, bDebugLogEnabled(false)
 {


### PR DESCRIPTION
Unreal Engine plugin - Health Ping Enabled to true by default #861
This flag should be enabled by default.