### PR TITLE
Add events to SDK state change operations

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -730,7 +730,7 @@ func (c *Controller) syncGameServerRequestReadyState(gs *v1alpha1.GameServer) (*
 	if addressPopulated {
 		c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Address and port populated")
 	}
-	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "SDK.Ready() executed")
+	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "SDK.Ready() complete")
 	return gs, nil
 }
 

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -951,7 +951,7 @@ func TestControllerSyncGameServerRequestReadyState(t *testing.T) {
 		assert.Nil(t, err, "should not error")
 		assert.True(t, gsUpdated, "GameServer wasn't updated")
 		assert.Equal(t, v1alpha1.GameServerStateReady, gs.Status.State)
-		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "SDK.Ready() executed")
+		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "SDK.Ready() complete")
 	})
 
 	t.Run("GameServer without an Address, but RequestReady State", func(t *testing.T) {
@@ -995,7 +995,7 @@ func TestControllerSyncGameServerRequestReadyState(t *testing.T) {
 		assert.Equal(t, gs.Status.Address, ipFixture)
 
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "Address and port populated")
-		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "SDK.Ready() executed")
+		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "SDK.Ready() complete")
 	})
 
 	for _, s := range []v1alpha1.GameServerState{"Unknown", v1alpha1.GameServerStateUnhealthy} {

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -57,7 +57,8 @@ func TestSidecarRun(t *testing.T) {
 				sc.Ready(ctx, &sdk.Empty{}) // nolint: errcheck
 			},
 			expected: expected{
-				state: v1alpha1.GameServerStateRequestReady,
+				state:      v1alpha1.GameServerStateRequestReady,
+				recordings: []string{"Normal " + string(v1alpha1.GameServerStateRequestReady)},
 			},
 		},
 		"shutdown": {
@@ -65,7 +66,8 @@ func TestSidecarRun(t *testing.T) {
 				sc.Shutdown(ctx, &sdk.Empty{}) // nolint: errcheck
 			},
 			expected: expected{
-				state: v1alpha1.GameServerStateShutdown,
+				state:      v1alpha1.GameServerStateShutdown,
+				recordings: []string{"Normal " + string(v1alpha1.GameServerStateShutdown)},
 			},
 		},
 		"unhealthy": {
@@ -75,7 +77,7 @@ func TestSidecarRun(t *testing.T) {
 			},
 			expected: expected{
 				state:      v1alpha1.GameServerStateUnhealthy,
-				recordings: []string{string(v1alpha1.GameServerStateUnhealthy)},
+				recordings: []string{"Warning " + string(v1alpha1.GameServerStateUnhealthy)},
 			},
 		},
 		"label": {
@@ -844,7 +846,13 @@ func TestSDKServerAllocate(t *testing.T) {
 }
 
 func defaultSidecar(m agtesting.Mocks) (*SDKServer, error) {
-	return NewSDKServer("test", "default", m.KubeClient, m.AgonesClient)
+	server, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient)
+	if err != nil {
+		return server, err
+	}
+
+	server.recorder = m.FakeRecorder
+	return server, err
 }
 
 func waitForMessage(sc *SDKServer) error {


### PR DESCRIPTION
This gives more visibility into SDK operations when describing a GameServer.