### PR TITLE
Remove / Expire FleetAllocation from documentation.

### DIFF
--- a/site/content/en/docs/Examples/_index.md
+++ b/site/content/en/docs/Examples/_index.md
@@ -13,7 +13,9 @@ These are full examples for each of the resource types of Agones
 
 - {{< ghlink href="examples/gameserver.yaml" >}}Full GameServer Configuration{{< /ghlink >}}
 - {{< ghlink href="examples/fleet.yaml" >}}Full Fleet Configuration{{< /ghlink >}}
+{{< feature expiryVersion="0.12.0" >}}
 - {{< ghlink href="examples/fleetallocation.yaml" >}}Full Fleet Allocation Configuration (deprecated) {{< /ghlink >}}
+{{< /feature >}}
 - {{< ghlink href="examples/gameserverallocation.yaml" >}}Full GameServer Allocation Configuration{{< /ghlink >}}
 - {{< ghlink href="examples/fleetautoscaler.yaml" >}}Full Autoscaler Configuration with Buffer Strategy{{< /ghlink >}}
 - {{< ghlink href="examples/webhookfleetautoscaler.yaml" >}}Full Autoscaler Configuration with Webhook Strategy{{< /ghlink >}}

--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -152,10 +152,9 @@ players access it (and therefore, it should not be deleted until they are finish
 > In production, you would likely do the following through a [Kubernetes API call]({{< ref "/docs/Guides/access-api.md" >}}), but we can also
 do this through `kubectl` as well, and ask it to return the response in yaml so that we can see what has happened.
 
+{{< feature expiryVersion="0.12.0" >}}
 #### GameServerAllocation
-
-> GameServerAllocation will eventually replace FleetAllocation, but is currently experimental, and likely to change in upcoming releases.
-  However, we welcome you to test it out in its current format and provide feedback.
+{{< /feature >}}
 
 We can do allocation of a GameServer for usage through a `GameServerAllocation`, which will both 
 return to us the details of a `GameServer` (assuming one is available), and also move it to the `Allocated` state,
@@ -231,6 +230,7 @@ simple-udp-sdhzn-wnhsw   Ready       192.168.122.205   7478   minikube  52m
 > `GameServerAllocations` are create only and not stored for performance reasons, so you won't be able to list
   them after they have been created - but you can see their effects on `GameServers`
 
+{{< feature expiryVersion="0.12.0" >}}
 #### FleetAllocation
 
 > Fleet Allocation is **deprecated** in version 0.10.0, and will be removed in the 0.12.0 release.
@@ -323,6 +323,7 @@ status:
 If you see the `status` section, you should see that there is a `GameServer`, and if you look at its
 `status > state` value, you can also see that it has been moved to `Allocated`. This means you have been successfully
 allocated a `GameServer` out of the fleet, and you can now connect your players to it!
+{{< /feature >}}
 
 A handy trick for checking to see how many `GameServers` you have `Allocated` vs `Ready`, run the following:
 

--- a/site/content/en/docs/Getting Started/create-fleetautoscaler.md
+++ b/site/content/en/docs/Getting Started/create-fleetautoscaler.md
@@ -97,18 +97,19 @@ If you're interested in more details for game server allocation, you should cons
 In here we are only interested in triggering allocations to see the autoscaler in action.
 
 ```
-kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/fleetallocation.yaml -o yaml
+kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/gameserverallocation.yaml -o yaml
 ```
 
 You should get in return the allocated game server details, which should end with something like:
 ```
-    status:
-      address: 10.30.64.99
-      nodeName: universal3
-      ports:
-      - name: default
-        port: 7131
-      state: Allocated
+status:
+  address: 34.94.118.237
+  gameServerName: simple-udp-v6jwb-6bzkz
+  nodeName: gke-test-cluster-default-f11755a7-5km3
+  ports:
+  - name: default
+    port: 7832
+  state: Allocated
 ```
 
 Note the address and port, you might need them later to connect to the server.
@@ -168,7 +169,7 @@ Since we've only got one allocation, we'll just grab the details of the IP and p
 only allocated `GameServer`: 
 
 ```
-kubectl get $(kubectl get fleetallocation -o name) -o jsonpath='{.status.GameServer.status.GameServer.status.ports[0].port}'
+kubectl get gameservers | grep Allocated | awk '{print $3":"$4 }'
 ```
 
 This should output your Game Server IP address and port. (eg `10.130.65.208:7936`)

--- a/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
+++ b/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
@@ -138,25 +138,25 @@ If you're interested in more details for game server allocation, you should cons
 Here we only interested in triggering allocations to see the autoscaler in action.
 
 ```
-kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/fleetallocation.yaml -o yaml
+kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/gameserverallocation.yaml -o yaml
 ```
 
 You should get in return the allocated game server details, which should end with something like:
 ```
-    status:
-      address: 35.247.13.175
-      nodeName: gke-test-cluster-default-1c5dec79-qrqv
-      ports:
-      - name: default
-        port: 7047
-      state: Allocated
+status:
+  address: 34.94.118.237
+  gameServerName: simple-udp-v6jwb-6bzkz
+  nodeName: gke-test-cluster-default-f11755a7-5km3
+  ports:
+  - name: default
+    port: 7832
 ```
 
 Note the address and port, you might need them later to connect to the server.
 
 Run the kubectl command one more time so that we have both servers allocated:
 ```
-kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/fleetallocation.yaml -o yaml
+kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/gameserverallocation.yaml -o yaml
 ```
 
 #### 6. Check new Autoscaler and Fleet status
@@ -364,7 +364,7 @@ If you're interested in more details for game server allocation, you should cons
 Here we only interested in triggering allocations to see the autoscaler in action.
 
 ```
-for i in {0..1} ; do kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/master/examples/simple-udp/fleetallocation.yaml -o yaml ; done
+for i in {0..1} ; do kubectl create -f https://raw.githubusercontent.com/googleforgames/agones/master/examples/simple-udp/gameserverallocation.yaml -o yaml ; done
 ```
 
 #### 7. Check new Autoscaler and Fleet status

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -98,7 +98,7 @@ This can be useful to track `GameServer > Status > State` changes, `metadata` ch
 
 In combination with this SDK, manipulating [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) and
 [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) can also be a useful way to communicate information through to running game server processes from outside those processes.
-This is especially useful when combined with `FleetAllocation` [applied metadata]({{< ref "/docs/Reference/fleet.md#fleet-allocation-specification" >}}).  
+This is especially useful when combined with `GameServerAllocation` [applied metadata]({{< ref "/docs/Reference/fleet.md#gameserver-allocation-specification" >}}).
 
 Since the GameServer contains an entire [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates)
 the returned object is limited to that configuration that was deemed useful. If there are

--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -234,7 +234,46 @@ $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/
     }
 }
 
-# allocate a gameserver from a fleet named 'simple-udp'
+# allocate a gameserver from a fleet named 'simple-udp', with GameServerAllocation
+
+$ curl -d '{"apiVersion":"allocation.agones.dev/v1alpha1","kind":"GameServerAllocation","spec":{"required":{"matchLabels":{"stable.agones.dev/fleet":"simple-udp"}}}}' -H "Content-Type: application/json" -X POST http://localhost:8001/apis/allocation.agones.dev/v1alpha1/namespaces/default/gameserverallocations
+
+{
+    "kind": "GameServerAllocation",
+    "apiVersion": "allocation.agones.dev/v1alpha1",
+    "metadata": {
+        "name": "simple-udp-v6jwb-cmdcv",
+        "namespace": "default",
+        "creationTimestamp": "2019-07-03T17:19:47Z"
+    },
+    "spec": {
+        "multiClusterSetting": {
+            "policySelector": {}
+        },
+        "required": {
+            "matchLabels": {
+                "stable.agones.dev/fleet": "simple-udp"
+            }
+        },
+        "scheduling": "Packed",
+        "metadata": {}
+    },
+    "status": {
+        "state": "Allocated",
+        "gameServerName": "simple-udp-v6jwb-cmdcv",
+        "ports": [
+            {
+                "name": "default",
+                "port": 7445
+            }
+        ],
+        "address": "34.94.118.237",
+        "nodeName": "gke-test-cluster-default-f11755a7-5km3"
+    }
+}
+
+{{% feature expiryVersion="0.12.0" %}}
+# allocate a gameserver from a fleet named 'simple-udp', with the deprecated FleetAllocation
 
 $ curl -d '{"apiVersion":"stable.agones.dev/v1alpha1","kind":"FleetAllocation","metadata":{"generateName":"simple-udp-", "namespace": "default"},"spec":{"fleetName":"simple-udp"}}' -H "Content-Type: application/json" -X POST http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/fleetallocations
 
@@ -339,6 +378,8 @@ $ curl -d '{"apiVersion":"stable.agones.dev/v1alpha1","kind":"FleetAllocation","
         }
     }
 }
+{{% /feature %}}
+
 ```
 
 You may wish to review the [Agones Kubernetes API]({{< ref "/docs/Reference/agones_crd_api_reference.html" >}}) for the full data structure reference.

--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -6,7 +6,7 @@ description: "A `Fleet` is a set of warm GameServers that are available to be al
 weight: 20
 ---
 
-To allocate a `GameServer` from a `Fleet`, use a `FleetAllocation`.
+To allocate a `GameServer` from a `Fleet`, use a `GameServerAllocation`.
 
 Like any other Kubernetes resource you describe a `Fleet`'s desired state via a specification written in YAML or JSON to the Kubernetes API. The Agones controller will then change the actual state to the desired state.
 
@@ -77,9 +77,6 @@ The `spec` field is the actual `Fleet` specification and it is composed as follo
 
 ## GameServer Allocation Specification
 
-> GameServerAllocation will eventually replace FleetAllocation, but is currently experimental, and likely to change in upcoming releases.
-  However, we welcome you to test it out in its current format and provide feedback.
-
 A `GameServerAllocation` is used to atomically allocate a GameServer out of a set of GameServers. 
 This could be a single Fleet, multiple Fleets, or a self managed group of GameServers.
 
@@ -142,6 +139,7 @@ The `spec` field is the actual `GameServerAllocation` specification and it is co
 - `metadata` is an optional list of custom labels and/or annotations that will be used to patch 
   the game server's metadata in the moment of allocation. This can be used to tell the server necessary session data
 
+{{< feature expiryVersion="0.12.0" >}}
 ## Fleet Allocation Specification
 
 > Fleet Allocation is **deprecated** in version 0.10.0, and will be removed in the 0.12.0 release.
@@ -175,6 +173,7 @@ The `spec` field is the actual `FleetAllocation` specification and it is compose
   when the `FleetAllocation` is created
 - `metadata` is an optional list of custom labels and/or annotations that will be used to patch 
   the game server's metadata in the moment of allocation. This can be used to tell the server necessary session data
+{{< /feature >}}
 
 ## Fleet Scale Subresource Specification
 

--- a/site/content/en/docs/Tutorials/allocator-service-go.md
+++ b/site/content/en/docs/Tutorials/allocator-service-go.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 To do this, we will implement a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) which allocates a
-Game Server on demand by calling the Create() method of the FleetAllocationInterface.  After creating the fleet
+Game Server on demand by calling the Create() method of the GameServerAllocationInterface.  After creating the fleet
 allocation, we will return the JSON encoded GameServerStatus of the allocated GameServer.
 
 The type of service we will be learning about could be used by a game client to connect directly to a dedicated Game Server, as part of a larger system, such as a matchmaker service, or in conjunction with a database of level transition data.  We will be using the service as a vehicle with which to execute the API calls found in our main.go file.
@@ -163,7 +163,7 @@ allocatorw3secret        kubernetes.io/tls                     2         15s
 
 
 ### 5. Create the Service Account
-This service will interact with Agones via the Agones API by using a [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) named fleet-allocator.  Specifically, the fleet-allocator service account is granted permissions to perform create operations against FleetAllocation objects, and get operations against Fleet objects.
+This service will interact with Agones via the Agones API by using a [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) named fleet-allocator.  Specifically, the fleet-allocator service account is granted permissions to perform create operations against GameServerAllocation objects, and get operations against Fleet objects.
 
 Create the service account by changing directories to your local agones/examples/allocator-service directory and running this command:
 ```


### PR DESCRIPTION
Hide FleetAllocation for 0.12, and also move more documentation to drive users more towards GameServerAllocations from the outset.