### PR TITLE
Docs: Centralise udp-server tag

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -90,6 +90,9 @@ release_branch = "release-0.11.0"
 # the main version. Never is rc.
 release_version = "0.11.0"
 
+# example tag
+example_image_tag = "gcr.io/agones-images/udp-server:0.11"
+
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.

--- a/site/content/en/docs/Advanced/limiting-resources.md
+++ b/site/content/en/docs/Advanced/limiting-resources.md
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.11
+        image: {{% example-image %}}
         resources:
           limit:
             cpu: "250m" #this is our limit here

--- a/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
+++ b/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
@@ -80,7 +80,7 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.11
+            image: {{% example-image %}}
 ```
 
 This is the *default* Fleet scheduling strategy. It is designed for dynamic Kubernetes environments, wherein you wish 
@@ -135,7 +135,7 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.11
+            image: {{% example-image %}}
 ```
 
 This Fleet scheduling strategy is designed for static Kubernetes environments, such as when you are running Kubernetes

--- a/site/content/en/docs/Advanced/service-accounts.md
+++ b/site/content/en/docs/Advanced/service-accounts.md
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: my-special-service-account # a custom service account
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.11
+        image: {{% example-image %}}
 ```
 
 If a service account is configured, the mounted key is not overwritten, as it assumed that you want to have full control

--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -111,7 +111,7 @@ Spec:
           Creation Timestamp:  <nil>
         Spec:
           Containers:
-            Image:  gcr.io/agones-images/udp-server:0.11
+            Image:  {{< example-image >}}
             Name:   simple-udp
             Resources:
 Status:
@@ -308,7 +308,7 @@ status:
           creationTimestamp: null
         spec:
           containers:
-          - image: gcr.io/agones-images/udp-server:0.11
+          - image: {{< example-image >}}
             name: simple-udp
             resources: {}
     status:

--- a/site/content/en/docs/Getting Started/create-gameserver.md
+++ b/site/content/en/docs/Getting Started/create-gameserver.md
@@ -107,7 +107,7 @@ Spec:
       Creation Timestamp:  <nil>
     Spec:
       Containers:
-        Image:  gcr.io/agones-images/udp-server:0.11
+        Image:  {{< example-image >}}
         Name:   simple-udp
         Resources:
           Limits:

--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -90,7 +90,7 @@ func main() {
 		Spec: v1alpha1.GameServerSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "udp-server", Image: "gcr.io/agones-images/udp-server:0.11"}},
+					Containers: []corev1.Container{{Name: "udp-server", Image: "{{% example-image %}}"}},
 				},
 			},
 		},
@@ -168,7 +168,7 @@ $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1
   ]
 }
 
-# list all gameservers in the default namesace
+# list all gameservers in the default namespace
 $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/gameservers
 {
     "apiVersion": "stable.agones.dev/v1alpha1",
@@ -178,7 +178,7 @@ $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/
             "kind": "GameServer",
             "metadata": {
                 "annotations": {
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"stable.agones.dev/v1alpha1\",\"kind\":\"GameServer\",\"metadata\":{\"annotations\":{},\"name\":\"simple-udp\",\"namespace\":\"default\"},\"spec\":{\"containerPort\":7654,\"hostPort\":7777,\"portPolicy\":\"static\",\"template\":{\"spec\":{\"containers\":[{\"image\":\"gcr.io/agones-images/udp-server:0.11\",\"name\":\"simple-udp\"}]}}}}\n"
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"stable.agones.dev/v1alpha1\",\"kind\":\"GameServer\",\"metadata\":{\"annotations\":{},\"name\":\"simple-udp\",\"namespace\":\"default\"},\"spec\":{\"containerPort\":7654,\"hostPort\":7777,\"portPolicy\":\"static\",\"template\":{\"spec\":{\"containers\":[{\"image\":\"{{% example-image %}}\",\"name\":\"simple-udp\"}]}}}}\n"
                 },
                 "clusterName": "",
                 "creationTimestamp": "2018-03-02T21:41:05Z",
@@ -210,7 +210,7 @@ $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/
                     "spec": {
                         "containers": [
                             {
-                                "image": "gcr.io/agones-images/udp-server:0.11",
+                                "image": "{{% example-image %}}",
                                 "name": "simple-udp",
                                 "resources": {}
                             }
@@ -317,7 +317,7 @@ $ curl -d '{"apiVersion":"stable.agones.dev/v1alpha1","kind":"FleetAllocation","
                     "spec": {
                         "containers": [
                             {
-                                "image": "gcr.io/agones-images/udp-server:0.11",
+                                "image": "{{% example-image %}}",
                                 "name": "simple-udp",
                                 "resources": {}
                             }

--- a/site/layouts/shortcodes/example-image.html
+++ b/site/layouts/shortcodes/example-image.html
@@ -1,0 +1,1 @@
+{{- $.Page.Site.Params.example_image_tag }}


### PR DESCRIPTION
Whenever the udp-server example gets updated, it results in a big find and replace operation. We can't get rid of that entirely, but we can fix it for the website and docs.