### PR TITLE
Fix ensure SDK image

### DIFF
--- a/build/includes/linux.mk
+++ b/build/includes/linux.mk
@@ -26,6 +26,9 @@
 # Get the sha for a file
 sha = $(shell sha256sum $(1) | head -c 10)
 
+# Get the sha of all files in a directory using wildcard in $(1)
+sha_dir = $(shell sha256sum  $(1) | cut -d' ' -f1 | sha256sum | head -c 10 )
+
 # Minikube executable
 MINIKUBE ?= minikube
 # Default minikube driver

--- a/build/includes/macos.mk
+++ b/build/includes/macos.mk
@@ -26,6 +26,9 @@
 # Get the sha for a file
 sha = $(shell shasum -a 256 $(1) | head -c 10)
 
+# Get the sha of all files in a directory using wildcard in $(1)
+sha_dir = $(shell shasum -a 256 $(1) | cut -d' ' -f1 | shasum -a 256 | head -c 10 )
+
 # Minikube executable
 MINIKUBE ?= minikube
 # Default minikube driver

--- a/build/includes/windows.mk
+++ b/build/includes/windows.mk
@@ -26,6 +26,9 @@
 # Get the sha for a file
 sha = $(shell sha256sum $(1) | head -c 10)
 
+# Get the sha of all files in a directory using wildcard in $(1)
+sha_dir = $(shell sha256sum  $(1) | cut -d' ' -f1 | sha256sum | head -c 10 )
+
 # Minikube executable
 MINIKUBE ?= minikube.exe
 # Default minikube driver


### PR DESCRIPTION
Use bash scripts hash instead of build image version.
Does not rebuild SDK images if image was found, previously rebuild was performed every time.