### PR TITLE
Last touches to the install guide regarding taints and tolerations

### DIFF
--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -3,14 +3,15 @@ title: "Install and configure Agones on Kubernetes"
 linkTitle: "Installation"
 weight: 4
 description: >
-  Follow this guide to create a cluster on Google Kubernetes Engine (GKE), Minikube or Azure Kubernetes Service (AKS), and install Agones.
+  Follow this guide to create a cluster on Google Kubernetes Engine (GKE), Minikube, Amazon Elastic Kubernetes Service (EKS), or Azure Kubernetes Service (AKS), and install Agones.
 ---
 
 In this quickstart, we will create a Kubernetes cluster, and populate it with the resource types that power Agones.
 
-_When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers
- are scheduled for better isolation and resiliency. See the sections below for instructions on how to do this in your
- preferred environment._
+> When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers
+> are scheduled for better isolation and resiliency. By default Agones prefers to be scheduled on nodes labeled with
+> `stable.agones.dev/agones-system=true` and tolerates the node taint `stable.agones.dev/agones-system=true:NoExecute`.
+> If no dedicated nodes are available, Agones will run on regular nodes.
 
 ## Usage Requirements
 
@@ -113,9 +114,9 @@ Flag explanations:
 * num-nodes: The number of nodes to be created in each of the cluster's zones. Default: 3
 * machine-type: The type of machine to use for nodes. Default: n1-standard-2. Depending on the needs of you game, you may wish to [have a bigger machines](https://cloud.google.com/compute/docs/machine-types).
 
-By default Agones prefers to be scheduled on nodes labeled with
-`stable.agones.dev/agones-system=true` and tolerates the node taint `stable.agones.dev/agones-system=true:NoExecute`.
-If no dedicated nodes are available, Agones will run on regular nodes, but that’s not recommended for production use.
+_Optional_: Create a dedicated node pool for the Agones controllers. If you choose to skip this step, the Agones
+controllers will share the default node pool with your game servers which is fine for kicking the tires but is not
+recommended for a production deployment.
 
 ```bash
 gcloud container node-pools create agones-system \


### PR DESCRIPTION
Move the bit about the node labels and tolerated taints up to the top of the installation page, as it applies to all environments.

Fixes https://github.com/googleforgames/agones/issues/491. 