### PR TITLE
C# SDK and .NET Core Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ build/local-includes/*
 !build/local-includes/README.md
 /release
 debug.test
+/sdks/csharp/AgonesClient/obj
+/sdks/csharp/AgonesClient/Properties
+/sdks/csharp/packages
+/sdks/csharp/AgonesTestCore/obj

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,5 @@ build/local-includes/*
 /release
 debug.test
 /sdks/csharp/AgonesClient/obj
-/sdks/csharp/AgonesClient/Properties
 /sdks/csharp/packages
 /sdks/csharp/AgonesTestCore/obj

--- a/sdks/csharp/AgonesClient.sln
+++ b/sdks/csharp/AgonesClient.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.421
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgonesClient", "AgonesClient\AgonesClient.csproj", "{F503DE5D-933B-4191-8853-EFE5B93E4329}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AgonesTestCore", "AgonesTestCore\AgonesTestCore.csproj", "{53D0329D-F396-4804-AD9C-0326F5D69889}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F503DE5D-933B-4191-8853-EFE5B93E4329}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F503DE5D-933B-4191-8853-EFE5B93E4329}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F503DE5D-933B-4191-8853-EFE5B93E4329}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F503DE5D-933B-4191-8853-EFE5B93E4329}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53D0329D-F396-4804-AD9C-0326F5D69889}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53D0329D-F396-4804-AD9C-0326F5D69889}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53D0329D-F396-4804-AD9C-0326F5D69889}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D0329D-F396-4804-AD9C-0326F5D69889}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D431AFE0-2C65-46E9-B418-021302F5D1C5}
+	EndGlobalSection
+EndGlobal

--- a/sdks/csharp/AgonesClient/AgonesClient.cs
+++ b/sdks/csharp/AgonesClient/AgonesClient.cs
@@ -1,0 +1,225 @@
+﻿using Agones.Models;
+using Agones.Utility;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Agones
+{
+	/// <summary>
+	/// The delegate type used to receive info when watching a game server
+	/// </summary>
+	/// <param name="serverInfo"></param>
+	public delegate void GameServerInfoHandler(GameServerInfo serverInfo);
+
+	/// <summary>
+	/// Agones Client used to interface with the agones sidecar
+	/// </summary>
+	public static class AgonesClient
+	{
+		const string BaseUrl = "http://localhost:59358/";
+
+		static HttpClient httpClient;
+		
+		/// <summary>
+		/// The logger that is used for all agones client logging
+		/// </summary>
+		public static ILogger Logger { get; set; } = new ConsoleLogger()
+		{
+			Prefix = "[AGONES] - "
+		};
+
+		static AgonesClient()
+		{
+			httpClient = new HttpClient()
+			{
+				BaseAddress = new Uri(BaseUrl)
+			};
+
+			httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+		}
+
+		/// <summary>
+		/// Mark the Game Server as Allocated
+		/// It is usually preferred that this happens through a GameServerAllocation
+		/// in a top down manner
+		/// </summary>
+		/// <returns></returns>
+		public static async Task Allocate()
+		{
+			Logger.Log(LogLevel.Trace, "Allocating");
+
+			var response = await httpClient.PostAsync("allocate", null);
+
+			HandleEmptyResponse(response);
+		}
+
+		/// <summary>
+		/// Mark the server as ready to receive players
+		/// </summary>
+		/// <returns></returns>
+		public static async Task Ready()
+		{
+			Logger.Log(LogLevel.Trace, "Ready");
+
+			var response = await httpClient.PostAsync("ready", null);
+
+			HandleEmptyResponse(response);
+		}
+
+		/// <summary>
+		/// Call periodically to inform Agones of the servers health
+		/// </summary>
+		/// <returns></returns>
+		public static async Task Health()
+		{
+			Logger.Log(LogLevel.Trace, "Health Check");
+
+			var response = await httpClient.PostAsync("health", null);
+
+			HandleEmptyResponse(response);
+		}
+
+		/// <summary>
+		/// Call to shutdown the game server
+		/// </summary>
+		/// <returns></returns>
+		public static async Task Shutdown()
+		{
+			Logger.Log(LogLevel.Trace, "Shutting Down");
+
+			var response = await httpClient.PostAsync("shutdown", null);
+
+			HandleEmptyResponse(response);
+		}
+
+		/// <summary>
+		/// Set a Label on the Game Servers metadata
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		public static async Task SetLabel(string key, string value)
+		{
+			Logger.Log(LogLevel.Trace, "Setting Label: {0} to: {1}", key, value);
+
+			var response = await httpClient.PutAsJsonAsync("metadata/label", new { key, value });
+
+			HandleEmptyResponse(response);
+		}
+
+		/// <summary>
+		/// Set an Annotation on the Game Servers metadata
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		public static async Task SetAnnotation(string key, string value)
+		{
+			Logger.Log(LogLevel.Trace, "Setting Annotation: {0} to: {1}", key, value);
+
+			var response = await httpClient.PutAsJsonAsync("metadata/annotation", new { key, value });
+
+			HandleEmptyResponse(response);
+		}
+
+		/// <summary>
+		/// Get a object describing the Game Server
+		/// </summary>
+		/// <returns></returns>
+		public static async Task<GameServerInfo> GetGameServer()
+		{
+			Logger.Log(LogLevel.Trace, "Getting Game Server Info");
+
+			var response = await httpClient.GetAsync("gameserver");
+
+			return await HandleResponse<GameServerInfo>(response);
+		}
+
+		/// <summary>
+		/// Receive a callback whenever the game server info changes, this can
+		/// be useful to monitor for status or metadata changes
+		/// </summary>
+		/// <param name="handler"></param>
+		public static void WatchGameServer(GameServerInfoHandler handler)
+		{
+			Logger.Log(LogLevel.Trace, "Watching for Game Server Info changes");
+
+			Task.Run(() => StartObserving(new Uri(BaseUrl + "watch/gameserver"), handler));
+		}
+
+		static async void StartObserving(Uri watchUri, GameServerInfoHandler handler)
+		{
+			using (var client = new WebClient())
+			using (var stream = await client.OpenReadTaskAsync(watchUri))
+			using (var reader = new StreamReader(stream))
+			{
+				while (true)
+				{
+					try
+					{
+						var nextLine = await reader.ReadLineAsync();
+
+						if (string.IsNullOrEmpty(nextLine))
+						{
+							Logger.Log(LogLevel.Info, "Received empty line while watching game server, stopped watch");
+
+							break;
+						}
+
+						var watchResult = JsonConvert.DeserializeObject<GameServerInfoWatchResult>(nextLine);
+
+						handler(watchResult.GameServerInfo);
+					}
+					catch (IOException e)
+					{
+						Logger.Log(LogLevel.Error, e, "IOException while watching game server");
+
+						break;
+					}
+					catch (Exception e)
+					{
+						Logger.Log(LogLevel.Error, e, "Exception while watching game server");
+
+						break;
+					}
+				}
+			}
+		}
+
+		static void HandleEmptyResponse(HttpResponseMessage response)
+		{
+			if (response.IsSuccessStatusCode)
+			{
+				return;
+			}
+			else
+			{
+				throw CreateHttpException(response);
+			}
+		}
+
+		static async Task<T> HandleResponse<T>(HttpResponseMessage response)
+		{
+			if (response.IsSuccessStatusCode)
+			{
+				return await response.Content.ReadAsAsync<T>();
+			}
+			else
+			{
+				throw CreateHttpException(response);
+			}
+		}
+
+		static Exception CreateHttpException(HttpResponseMessage response)
+		{
+			Logger.Log(LogLevel.Error, "Encountered HTTP Exception, Status: {0}", response.StatusCode);
+
+			return new Exception("Agones Request Failed with status code: " + response.StatusCode);
+		}
+	}
+}

--- a/sdks/csharp/AgonesClient/AgonesClient.csproj
+++ b/sdks/csharp/AgonesClient/AgonesClient.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F503DE5D-933B-4191-8853-EFE5B93E4329}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AgonesClient</RootNamespace>
+    <AssemblyName>AgonesClient</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AgonesClient.cs" />
+    <Compile Include="ConsoleLogger.cs" />
+    <Compile Include="CustomUnixDateTimeConverter.cs" />
+    <Compile Include="GameServerInfo.cs" />
+    <Compile Include="ILogger.cs" />
+    <Compile Include="IPAddressJsonConverter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/sdks/csharp/AgonesClient/ConsoleLogger.cs
+++ b/sdks/csharp/AgonesClient/ConsoleLogger.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Agones.Utility
+{
+	public class ConsoleLogger : ILogger
+	{
+		public string Prefix { get; set; }
+
+		public void Log(LogLevel level, Exception exception, string message, params object[] args)
+		{
+			Log(level, message, args);
+
+			Log(LogLevel.Error, exception.ToString());
+		}
+
+		public void Log(LogLevel level, string message, params object[] args)
+		{
+			switch (level)
+			{
+				case LogLevel.Trace:
+					Console.ForegroundColor = ConsoleColor.DarkGray;
+					break;
+
+				case LogLevel.Debug:
+					Console.ForegroundColor = ConsoleColor.Gray;
+					break;
+
+				case LogLevel.Warning:
+					Console.ForegroundColor = ConsoleColor.DarkYellow;
+					break;
+
+				case LogLevel.Error:
+					Console.ForegroundColor = ConsoleColor.Red;
+					break;
+
+				case LogLevel.Info:
+				default:
+					Console.ForegroundColor = ConsoleColor.White;
+					break;
+			}
+
+			Console.WriteLine(Prefix + message, args);
+
+			Console.ForegroundColor = ConsoleColor.White;
+		}
+	}
+}

--- a/sdks/csharp/AgonesClient/CustomUnixDateTimeConverter.cs
+++ b/sdks/csharp/AgonesClient/CustomUnixDateTimeConverter.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace Agones.Utility
+{
+	public class CustomUnixDateTimeConverter : DateTimeConverterBase
+	{
+		static readonly DateTime EpochStartTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var milliseconds = long.Parse((string)reader.Value);
+
+			return EpochStartTime.AddSeconds(milliseconds);
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var current = (DateTime)value;
+
+			var sinceEpochStart = current - EpochStartTime;
+
+			long milliseconds = (long)sinceEpochStart.TotalSeconds;
+
+			writer.WriteRawValue(milliseconds.ToString());
+		}
+	}
+}

--- a/sdks/csharp/AgonesClient/GameServerInfo.cs
+++ b/sdks/csharp/AgonesClient/GameServerInfo.cs
@@ -1,0 +1,107 @@
+﻿using Agones.Utility;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Agones.Models
+{
+	public class GameServerInfoWatchResult
+	{
+		[JsonProperty("result")]
+		public GameServerInfo GameServerInfo { get; set; }
+	}
+
+	public class GameServerInfo
+	{
+		[JsonProperty("object_meta")]
+		public GameServerInfoMetaData MetaData { get; set; }
+
+		[JsonProperty("status")]
+		public GameServerInfoStatus Status { get; set; }
+	}
+
+	public class GameServerInfoMetaData
+	{
+		[JsonProperty("name")]
+		public string Name { get; set; }
+
+		[JsonProperty("namespace")]
+		public string Namespace { get; set; }
+
+		[JsonProperty("uid")]
+		public string UID { get; set; }
+
+		[JsonProperty("resource_version")]
+		public string ResourceVersion { get; set; }
+
+		[JsonProperty("creation_timestamp")]
+		//[JsonConverter(typeof(UnixDateTimeConverter))] //Use this one if you dont want to support negative unix timestamps
+		[JsonConverter(typeof(CustomUnixDateTimeConverter))]
+		public DateTime CreationTime { get; set; }
+
+		[JsonProperty("annotations")]
+		public Dictionary<string, string> Annotations { get; set; }
+
+		[JsonProperty("labels")]
+		public Dictionary<string, string> Labels { get; set; }
+
+		public override bool Equals(object obj)
+		{
+			var data = obj as GameServerInfoMetaData;
+
+			return data != null &&
+				   Name == data.Name &&
+				   Namespace == data.Namespace &&
+				   UID == data.UID &&
+				   ResourceVersion == data.ResourceVersion &&
+				   CreationTime == data.CreationTime &&
+				   EqualityComparer<Dictionary<string, string>>.Default.Equals(Annotations, data.Annotations) &&
+				   EqualityComparer<Dictionary<string, string>>.Default.Equals(Labels, data.Labels);
+		}
+
+		public override int GetHashCode()
+		{
+			var hashCode = -1011602838;
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Namespace);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(UID);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ResourceVersion);
+			hashCode = hashCode * -1521134295 + CreationTime.GetHashCode();
+			hashCode = hashCode * -1521134295 + EqualityComparer<Dictionary<string, string>>.Default.GetHashCode(Annotations);
+			hashCode = hashCode * -1521134295 + EqualityComparer<Dictionary<string, string>>.Default.GetHashCode(Labels);
+
+			return hashCode;
+		}
+	}
+
+	public enum GameServerState
+	{
+		Scheduled,
+		Ready,
+		Allocated,
+		Shutdown
+	}
+
+	public class GameServerInfoStatus
+	{
+		public class PortConfig
+		{
+			[JsonProperty("name")]
+			public string Name { get; set; }
+
+			[JsonProperty("port")]
+			public int Port { get; set; }
+		}
+
+		[JsonProperty("state"), JsonConverter(typeof(StringEnumConverter))]
+		public GameServerState State { get; set; }
+
+		[JsonProperty("address"), JsonConverter(typeof(IPAddressJsonConverter))]
+		public IPAddress Address { get; set; }
+
+		[JsonProperty("ports")]
+		public IEnumerable<PortConfig> Ports { get; set; }
+	}
+}

--- a/sdks/csharp/AgonesClient/ILogger.cs
+++ b/sdks/csharp/AgonesClient/ILogger.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Agones.Utility
+{
+	public enum LogLevel
+	{
+		Trace,
+		Debug,
+		Info,
+		Warning,
+		Error
+	}
+
+	public interface ILogger
+	{
+		string Prefix { get; set; }
+
+		void Log(LogLevel level, string message, params object[] args);
+
+		void Log(LogLevel level, Exception exception, string message, params object[] args);
+	}
+}

--- a/sdks/csharp/AgonesClient/IPAddressJsonConverter.cs
+++ b/sdks/csharp/AgonesClient/IPAddressJsonConverter.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Net;
+
+namespace Agones.Utility
+{
+	public class IPAddressJsonConverter : JsonConverter
+	{
+		public override bool CanConvert(Type objectType)
+		{
+			return (objectType == typeof(IPAddress));
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(value.ToString());
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			return IPAddress.Parse((string)reader.Value);
+		}
+	}
+}

--- a/sdks/csharp/AgonesClient/Properties/AssemblyInfo.cs
+++ b/sdks/csharp/AgonesClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AgonesClient")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AgonesClient")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f503de5d-933b-4191-8853-efe5b93e4329")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/sdks/csharp/AgonesClient/app.config
+++ b/sdks/csharp/AgonesClient/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/sdks/csharp/AgonesClient/packages.config
+++ b/sdks/csharp/AgonesClient/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+</packages>

--- a/sdks/csharp/AgonesTestCore/AgonesTestCore.csproj
+++ b/sdks/csharp/AgonesTestCore/AgonesTestCore.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgonesClient\AgonesClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/csharp/AgonesTestCore/Program.cs
+++ b/sdks/csharp/AgonesTestCore/Program.cs
@@ -1,0 +1,61 @@
+﻿using Agones;
+using Newtonsoft.Json;
+using System;
+using System.Threading.Tasks;
+
+namespace AgonesTestCore
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			Console.WriteLine("Starting Agones Test");
+
+			Run().Wait();
+		}
+
+		async static Task Run()
+		{
+			var serverInfo = await AgonesClient.GetGameServer();
+
+			Console.WriteLine("Starting server: {0}", serverInfo.MetaData?.Name);
+
+			await AgonesClient.Ready();
+
+			bool isPingingHealth = true;
+
+			_ = Task.Run(async () =>
+			{
+				while (isPingingHealth)
+				{
+					await AgonesClient.Health();
+
+					await Task.Delay(2000);
+				}
+			});
+
+			AgonesClient.WatchGameServer(info =>
+			{
+				Console.WriteLine("Info Changed:\n" + JsonConvert.SerializeObject(info, Formatting.Indented));
+			});
+
+			await Task.Delay(5000);
+
+			await AgonesClient.SetLabel("server-id", 12345.ToString());
+
+			await Task.Delay(5000);
+
+			await AgonesClient.SetLabel("player-count", 5.ToString());
+
+			await Task.Delay(5000);
+
+			await AgonesClient.Shutdown();
+
+			isPingingHealth = false;
+
+			Console.WriteLine("The End...");
+
+			Console.ReadLine();
+		}
+	}
+}


### PR DESCRIPTION
I added a full implementation of the Agones REST API in C#. I saw there was already an existing Unity SDK however it was using specific Unity webrequests which wont work in other C# codebases. 
This SDK works in Unity as well as .NET Core and Framework. I includes the visual studio files, if you want me to remove them and just keep it as code files only I am happy to remove them. 
I have included a basic .NET Core example which uses all the features of the API. 