### PR TITLE
Explicitly disable creation of the client certificate on GKE

### DIFF
--- a/build/cluster.tf
+++ b/build/cluster.tf
@@ -78,9 +78,14 @@ resource "google_container_cluster" "primary" {
   provider = "google-beta"
 
   # Setting an empty username and password explicitly disables basic auth
+  # TODO(roberthbailey): Remove the entire master_auth block when switching to 1.12.
   master_auth {
     username = "${local.username}"
     password = "${var.password}"
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
   }
   enable_legacy_abac = "${lookup(var.cluster, "legacyAbac")}"
   node_pool = [
@@ -175,18 +180,6 @@ resource "google_compute_firewall" "default" {
 resource "google_compute_network" "default" {
   project = "${lookup(var.cluster, "project")}"
   name    = "agones-network-${lookup(var.cluster, "name")}"
-}
-
-
-
-# The following outputs allow authentication and connectivity to the GKE Cluster
-# by using certificate-based authentication.
-output "client_certificate" {
-  value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
-}
-
-output "client_key" {
-  value = "${google_container_cluster.primary.master_auth.0.client_key}"
 }
 
 output "cluster_ca_certificate" {

--- a/build/modules/gke/cluster.tf
+++ b/build/modules/gke/cluster.tf
@@ -55,9 +55,14 @@ resource "google_container_cluster" "primary" {
   project  = "${lookup(var.cluster, "project")}"
   provider = "google-beta"
   # Setting an empty username and password explicitly disables basic auth
+  # TODO(roberthbailey): Remove the entire master_auth block when switching to 1.12.
   master_auth {
     username = "${local.username}"
     password = "${var.password}"
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
   }
   remove_default_node_pool = true
   enable_legacy_abac = "${lookup(var.cluster, "legacyAbac")}"

--- a/build/modules/gke/outputs.tf
+++ b/build/modules/gke/outputs.tf
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The following outputs allow authentication and connectivity to the GKE Cluster
-# by using certificate-based authentication.
-output "client_certificate" {
-  value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
-}
-
-output "client_key" {
-  value = "${google_container_cluster.primary.master_auth.0.client_key}"
-}
-
 output "cluster_ca_certificate" {
   value = "${base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)}"
 }


### PR DESCRIPTION
This is the default behavior starting with 1.12, which we are switching over to soon. Also remove the output variables for client key and client certificate as they aren't used. 

Part of #717. 

/assign @aLekSer 