### PR TITLE
Reserve() SDK implementation

### DIFF
--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -15,6 +15,7 @@
 package sdkserver
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -35,7 +36,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -58,14 +58,6 @@ const (
 
 var (
 	_ sdk.SDKServer = &SDKServer{}
-
-	defaultTimeout = 30 * time.Second
-	defaultBackoff = wait.Backoff{
-		Duration: 100 * time.Millisecond,
-		Factor:   1,
-		Jitter:   0.1,
-		Steps:    5,
-	}
 )
 
 // SDKServer is a gRPC server, that is meant to be a sidecar
@@ -96,6 +88,8 @@ type SDKServer struct {
 	gsState            stablev1alpha1.GameServerState
 	gsUpdateMutex      sync.RWMutex
 	gsWaitForSync      sync.WaitGroup
+	reserveTimer       *time.Timer
+	gsReserveDuration  *time.Duration
 }
 
 // NewSDKServer creates a SDKServer that sets up an
@@ -205,6 +199,10 @@ func (s *SDKServer) Run(stop <-chan struct{}) error {
 	s.healthTimeout = time.Duration(gs.Spec.Health.PeriodSeconds) * time.Second
 	s.initHealthLastUpdated(time.Duration(gs.Spec.Health.InitialDelaySeconds) * time.Second)
 
+	if gs.Status.State == stablev1alpha1.GameServerStateReserved && gs.Status.ReservedUntil != nil {
+		s.resetReserveAfter(context.Background(), time.Until(gs.Status.ReservedUntil.Time))
+	}
+
 	// start health checking running
 	if !s.health.Disabled {
 		s.logger.Info("Starting GameServer health checking")
@@ -275,6 +273,14 @@ func (s *SDKServer) updateState() error {
 
 	s.gsUpdateMutex.RLock()
 	gs.Status.State = s.gsState
+
+	// if we are setting the Reserved status, check for the duration, and set that too
+	if gs.Status.State == stablev1alpha1.GameServerStateReserved && s.gsReserveDuration != nil {
+		n := metav1.NewTime(time.Now().Add(*s.gsReserveDuration))
+		gs.Status.ReservedUntil = &n
+	} else {
+		gs.Status.ReservedUntil = nil
+	}
 	s.gsUpdateMutex.RUnlock()
 
 	_, err = gameServers.Update(gs)
@@ -282,14 +288,26 @@ func (s *SDKServer) updateState() error {
 		return errors.Wrapf(err, "could not update GameServer %s/%s to state %s", s.namespace, s.gameServerName, gs.Status.State)
 	}
 
+	message := "SDK state change"
 	level := corev1.EventTypeNormal
 	// post state specific work here
 	switch gs.Status.State {
 	case stablev1alpha1.GameServerStateUnhealthy:
 		level = corev1.EventTypeWarning
+	case stablev1alpha1.GameServerStateReserved:
+		s.gsUpdateMutex.RLock()
+		hasDuration := s.gsReserveDuration != nil
+		if hasDuration {
+			message += fmt.Sprintf(", for %v", s.gsReserveDuration.String())
+		}
+		s.gsUpdateMutex.RUnlock()
+		// unfortunate complexity due to mutex locking, resetReserveAfter has it's own mutex
+		if hasDuration {
+			s.resetReserveAfter(context.Background(), *s.gsReserveDuration)
+		}
 	}
 
-	s.recorder.Event(gs, level, string(gs.Status.State), "SDK state change")
+	s.recorder.Event(gs, level, string(gs.Status.State), message)
 
 	return nil
 }
@@ -363,58 +381,23 @@ func (s *SDKServer) enqueueState(state stablev1alpha1.GameServerState) {
 // the workqueue so it can be updated
 func (s *SDKServer) Ready(ctx context.Context, e *sdk.Empty) (*sdk.Empty, error) {
 	s.logger.Info("Received Ready request, adding to queue")
+	s.stopReserveTimer()
 	s.enqueueState(stablev1alpha1.GameServerStateRequestReady)
 	return e, nil
 }
 
-// Allocate set the GameServer to Allocate, as longs as it's not in UnHealthy,
-// Shutdown or has a DeletionTimeStamp(). Times out after 30 seconds if it cannot
-// complete the operation due to contention issues.
-func (s *SDKServer) Allocate(context.Context, *sdk.Empty) (*sdk.Empty, error) {
-	s.logger.Info("Received self Allocate request")
-
-	now := s.clock.Now()
-	err := wait.ExponentialBackoff(defaultBackoff, func() (done bool, err error) {
-		gs, err := s.gameServer()
-		if err != nil {
-			return true, err
-		}
-
-		if !gs.ObjectMeta.DeletionTimestamp.IsZero() {
-			return true, nil
-		}
-
-		switch gs.Status.State {
-		case stablev1alpha1.GameServerStateUnhealthy:
-			return true, errors.New("cannot Allocate an Unhealthy GameServer")
-
-		case stablev1alpha1.GameServerStateShutdown:
-			return true, errors.New("cannot Allocate a Shutdown GameServer")
-		}
-
-		gsCopy := gs.DeepCopy()
-		gsCopy.Status.State = stablev1alpha1.GameServerStateAllocated
-		_, err = s.gameServerGetter.GameServers(s.namespace).Update(gsCopy)
-
-		// if a contention, and we are under the timeout period.
-		if k8serrors.IsConflict(err) {
-			if s.clock.Since(now) > defaultTimeout {
-				return true, errors.New("Allocation request timed out")
-			}
-
-			return false, nil
-		}
-
-		return true, errors.Wrap(err, "could not update gameserver to Allocated")
-	})
-
-	return &sdk.Empty{}, errors.WithStack(err)
+// Allocate enters an Allocate state change into the workqueue, so it can be updated
+func (s *SDKServer) Allocate(ctx context.Context, e *sdk.Empty) (*sdk.Empty, error) {
+	s.stopReserveTimer()
+	s.enqueueState(stablev1alpha1.GameServerStateAllocated)
+	return e, nil
 }
 
 // Shutdown enters the Shutdown state change for this GameServer into
 // the workqueue so it can be updated
 func (s *SDKServer) Shutdown(ctx context.Context, e *sdk.Empty) (*sdk.Empty, error) {
 	s.logger.Info("Received Shutdown request, adding to queue")
+	s.stopReserveTimer()
 	s.enqueueState(stablev1alpha1.GameServerStateShutdown)
 	return e, nil
 }
@@ -486,9 +469,53 @@ func (s *SDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameServer
 }
 
 // Reserve moves this GameServer to the Reserved state for the Duration specified
-// TODO: implement this functionality
-func (s *SDKServer) Reserve(_ context.Context, d *sdk.Duration) (*sdk.Empty, error) {
-	return &sdk.Empty{}, errors.New("not implemented")
+func (s *SDKServer) Reserve(ctx context.Context, d *sdk.Duration) (*sdk.Empty, error) {
+	s.stopReserveTimer()
+
+	e := &sdk.Empty{}
+
+	s.logger.Info("Received Reserve request, adding to queue")
+	s.enqueueState(stablev1alpha1.GameServerStateReserved)
+
+	// 0 is forever.
+	if d.Seconds == 0 {
+		return e, nil
+	}
+
+	duration := time.Duration(d.Seconds) * time.Second
+	s.gsUpdateMutex.Lock()
+	s.gsReserveDuration = &duration
+	defer s.gsUpdateMutex.Unlock()
+
+	return e, nil
+}
+
+// resetReserveAfter will run a function after duration to move the GameServer
+// back to being Ready
+func (s *SDKServer) resetReserveAfter(ctx context.Context, duration time.Duration) {
+	s.gsUpdateMutex.Lock()
+	defer s.gsUpdateMutex.Unlock()
+	if s.reserveTimer != nil {
+		s.reserveTimer.Stop()
+	}
+
+	s.reserveTimer = time.AfterFunc(duration, func() {
+		_, err := s.Ready(ctx, &sdk.Empty{})
+		if err != nil {
+			s.logger.WithError(errors.WithStack(err)).Error("error returning to Ready after reserved")
+		}
+	})
+}
+
+// stopReserveTimer stops the reserve timer, if it is not nil
+func (s *SDKServer) stopReserveTimer() {
+	s.gsUpdateMutex.Lock()
+	defer s.gsUpdateMutex.Unlock()
+
+	if s.reserveTimer != nil {
+		s.reserveTimer.Stop()
+	}
+	s.gsReserveDuration = nil
 }
 
 // sendGameServerUpdate sends a watch game server event

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -23,14 +23,11 @@ import (
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	"agones.dev/agones/pkg/sdk"
 	agtesting "agones.dev/agones/pkg/testing"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -112,7 +109,18 @@ func TestSidecarRun(t *testing.T) {
 				assert.NoError(t, err)
 			},
 			expected: expected{
-				state: v1alpha1.GameServerStateAllocated,
+				state:      v1alpha1.GameServerStateAllocated,
+				recordings: []string{string(v1alpha1.GameServerStateAllocated)},
+			},
+		},
+		"reserved": {
+			f: func(sc *SDKServer, ctx context.Context) {
+				_, err := sc.Reserve(ctx, &sdk.Duration{Seconds: 10})
+				assert.NoError(t, err)
+			},
+			expected: expected{
+				state:      v1alpha1.GameServerStateReserved,
+				recordings: []string{string(v1alpha1.GameServerStateReserved)},
 			},
 		},
 	}
@@ -290,7 +298,6 @@ func TestSDKServerSyncGameServer(t *testing.T) {
 			err = sc.syncGameServer(v.key)
 			assert.Nil(t, err)
 			assert.True(t, updated, "should have updated")
-
 		})
 	}
 }
@@ -678,176 +685,185 @@ func TestSDKServerUpdateEventHandler(t *testing.T) {
 	assert.Equal(t, fixture.ObjectMeta.Name, sdkGS.ObjectMeta.Name)
 }
 
-func TestSDKServerAllocate(t *testing.T) {
+func TestSDKServerReserveTimeoutOnRun(t *testing.T) {
 	t.Parallel()
+	m := agtesting.NewMocks()
 
-	defaultGs := &v1alpha1.GameServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-		Status: v1alpha1.GameServerStatus{
-			State: v1alpha1.GameServerStateReady,
-		},
-	}
+	updated := make(chan v1alpha1.GameServerStatus, 1)
 
-	setup := func(t *testing.T, fixture *v1alpha1.GameServer) (agtesting.Mocks, *SDKServer, chan struct{}) {
-		m := agtesting.NewMocks()
-		m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			return true, &v1alpha1.GameServerList{Items: []v1alpha1.GameServer{*fixture}}, nil
-		})
-		stop := make(chan struct{})
-		sc, err := defaultSidecar(m)
+	m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		n := metav1.NewTime(metav1.Now().Add(time.Second))
+
+		gs := v1alpha1.GameServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test", Namespace: "default",
+			},
+			Status: v1alpha1.GameServerStatus{
+				State:         v1alpha1.GameServerStateReserved,
+				ReservedUntil: &n,
+			},
+		}
+		gs.ApplyDefaults()
+		return true, &v1alpha1.GameServerList{Items: []v1alpha1.GameServer{gs}}, nil
+	})
+	m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua := action.(k8stesting.UpdateAction)
+		gs := ua.GetObject().(*v1alpha1.GameServer)
+
+		updated <- gs.Status
+
+		return true, gs, nil
+	})
+
+	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient)
+	assert.NoError(t, err)
+	stop := make(chan struct{})
+	sc.informerFactory.Start(stop)
+	assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		err = sc.Run(stop)
 		assert.Nil(t, err)
-		sc.informerFactory.Start(stop)
-		assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
-		sc.gsWaitForSync.Done()
-		return m, sc, stop
+		wg.Done()
+	}()
+
+	select {
+	case status := <-updated:
+		assert.Equal(t, v1alpha1.GameServerStateRequestReady, status.State)
+		assert.Nil(t, status.ReservedUntil)
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "should have been an update")
 	}
 
-	t.Run("works perfectly", func(t *testing.T) {
-		m, sc, stop := setup(t, defaultGs.DeepCopy())
-		defer close(stop)
+	close(stop)
+	wg.Wait()
+}
 
-		done := make(chan struct{}, 10)
-		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			ua := action.(k8stesting.UpdateAction)
-			gs := ua.GetObject().(*v1alpha1.GameServer)
-			assert.Equal(t, v1alpha1.GameServerStateAllocated, gs.Status.State)
+func TestSDKServerReserveTimeout(t *testing.T) {
+	t.Parallel()
+	m := agtesting.NewMocks()
 
-			defer func() {
-				done <- struct{}{}
-			}()
+	state := make(chan v1alpha1.GameServerStatus, 100)
+	defer close(state)
 
-			return true, gs, nil
-		})
-
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.NoError(t, err)
-
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			assert.Fail(t, "should be updated")
+	m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		gs := v1alpha1.GameServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test", Namespace: "default",
+			},
+			Spec: v1alpha1.GameServerSpec{Health: v1alpha1.Health{Disabled: true}},
 		}
+		gs.ApplyDefaults()
+		return true, &v1alpha1.GameServerList{Items: []v1alpha1.GameServer{gs}}, nil
 	})
 
-	t.Run("contention on first build", func(t *testing.T) {
-		m, sc, stop := setup(t, defaultGs.DeepCopy())
-		defer close(stop)
+	m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua := action.(k8stesting.UpdateAction)
+		gs := ua.GetObject().(*v1alpha1.GameServer)
 
-		done := make(chan struct{}, 10)
-		count := 0
+		state <- gs.Status
 
-		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			ua := action.(k8stesting.UpdateAction)
-			defer func() {
-				done <- struct{}{}
-			}()
+		return true, gs, nil
+	})
 
-			count++
-			if count == 1 {
-				return true, nil, k8serrors.NewConflict(schema.ParseGroupResource(""), "gameservers", errors.New("contention"))
-			}
+	sc, err := defaultSidecar(m)
 
-			gs := ua.GetObject().(*v1alpha1.GameServer)
-			assert.Equal(t, v1alpha1.GameServerStateAllocated, gs.Status.State)
-			return true, gs, nil
-		})
+	assert.NoError(t, err)
+	stop := make(chan struct{})
+	sc.informerFactory.Start(stop)
+	assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
 
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.NoError(t, err)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
+	go func() {
+		err = sc.Run(stop)
+		assert.Nil(t, err)
+		wg.Done()
+	}()
+
+	assertStateChange := func(expected v1alpha1.GameServerState, timeout time.Duration, additional func(status v1alpha1.GameServerStatus)) {
 		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			assert.Fail(t, "have contention")
+		case current := <-state:
+			assert.Equal(t, expected, current.State)
+			additional(current)
+		case <-time.After(timeout):
+			assert.Fail(t, "should have gone to Reserved by now")
 		}
+	}
+	noAdditional := func(status v1alpha1.GameServerStatus) {}
 
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			assert.Fail(t, "should be updated")
-		}
+	// 3 seconds
+	_, err = sc.Reserve(context.Background(), &sdk.Duration{Seconds: 3})
+	assert.NoError(t, err)
+
+	assertStateChange(v1alpha1.GameServerStateReserved, 2*time.Second, func(status v1alpha1.GameServerStatus) {
+		assert.Equal(t, time.Now().Add(3*time.Second).Round(time.Second), status.ReservedUntil.Time.Round(time.Second))
 	})
 
-	t.Run("timeout", func(t *testing.T) {
-		m, sc, stop := setup(t, defaultGs.DeepCopy())
-		defer close(stop)
-
-		now := time.Now()
-		fc := clock.NewFakeClock(now)
-		sc.clock = fc
-
-		done := make(chan struct{}, 10)
-
-		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			defer func() {
-				done <- struct{}{}
-			}()
-
-			// move past timeout
-			fc.Step(40 * time.Second)
-			return true, nil, k8serrors.NewConflict(schema.ParseGroupResource(""), "gameservers", errors.New("contention"))
-		})
-
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.EqualError(t, err, "Allocation request timed out")
-
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			assert.Fail(t, "have contention")
-		}
+	// wait for the game server to go back to being Ready
+	assertStateChange(v1alpha1.GameServerStateRequestReady, 4*time.Second, func(status v1alpha1.GameServerStatus) {
+		assert.Nil(t, status.ReservedUntil)
 	})
 
-	t.Run("unhealthy gameserver", func(t *testing.T) {
-		gs := defaultGs.DeepCopy()
-		gs.Status.State = v1alpha1.GameServerStateUnhealthy
-		_, sc, stop := setup(t, gs.DeepCopy())
-		defer close(stop)
+	// now test for being able to escape the Reserved state when requesting another state
 
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.EqualError(t, err, "cannot Allocate an Unhealthy GameServer")
+	// test ready
+	_, err = sc.Reserve(context.Background(), &sdk.Duration{Seconds: 3})
+	assert.NoError(t, err)
+	assertStateChange(v1alpha1.GameServerStateReserved, 2*time.Second, noAdditional)
+
+	_, err = sc.Ready(context.Background(), &sdk.Empty{})
+	assert.NoError(t, err)
+	assertStateChange(v1alpha1.GameServerStateRequestReady, 2*time.Second, func(status v1alpha1.GameServerStatus) {
+		assert.Nil(t, status.ReservedUntil)
 	})
 
-	t.Run("Shutdown gameserver", func(t *testing.T) {
-		gs := defaultGs.DeepCopy()
-		gs.Status.State = v1alpha1.GameServerStateShutdown
-		_, sc, stop := setup(t, gs.DeepCopy())
-		defer close(stop)
+	select {
+	case current := <-state:
+		assert.Failf(t, "Should not get update:", string(current.State))
+	case <-time.After(4 * time.Second):
+	}
 
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.EqualError(t, err, "cannot Allocate a Shutdown GameServer")
+	// test allocated
+	_, err = sc.Reserve(context.Background(), &sdk.Duration{Seconds: 3})
+	assert.NoError(t, err)
+	assertStateChange(v1alpha1.GameServerStateReserved, 2*time.Second, noAdditional)
+
+	_, err = sc.Allocate(context.Background(), &sdk.Empty{})
+	assert.NoError(t, err)
+	assertStateChange(v1alpha1.GameServerStateAllocated, 2*time.Second, func(status v1alpha1.GameServerStatus) {
+		assert.Nil(t, status.ReservedUntil)
 	})
 
-	t.Run("Deleting gameserver", func(t *testing.T) {
-		gs := defaultGs.DeepCopy()
-		now := metav1.Now()
-		gs.ObjectMeta.DeletionTimestamp = &now
-		_, sc, stop := setup(t, gs.DeepCopy())
-		defer close(stop)
+	select {
+	case <-state:
+		assert.Fail(t, "Should not go back to RequestReady")
+	case <-time.After(4 * time.Second):
+	}
 
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.NoError(t, err)
+	// test shutdown
+	_, err = sc.Reserve(context.Background(), &sdk.Duration{Seconds: 3})
+	assert.NoError(t, err)
+	assertStateChange(v1alpha1.GameServerStateReserved, 2*time.Second, noAdditional)
+
+	_, err = sc.Shutdown(context.Background(), &sdk.Empty{})
+	assert.NoError(t, err)
+	assertStateChange(v1alpha1.GameServerStateShutdown, 2*time.Second, func(status v1alpha1.GameServerStatus) {
+		assert.Nil(t, status.ReservedUntil)
 	})
 
-	t.Run("Unexpected error", func(t *testing.T) {
-		m, sc, stop := setup(t, defaultGs.DeepCopy())
-		defer close(stop)
-		done := make(chan struct{}, 10)
+	select {
+	case current := <-state:
+		assert.Failf(t, "Should not get update:", string(current.State))
+	case <-time.After(4 * time.Second):
+	}
 
-		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			defer func() {
-				done <- struct{}{}
-			}()
-
-			return true, nil, errors.New("a bad thing happened")
-		})
-
-		_, err := sc.Allocate(context.Background(), &sdk.Empty{})
-		assert.Error(t, err)
-	})
+	close(stop)
+	wg.Wait()
 }
 
 func defaultSidecar(m agtesting.Mocks) (*SDKServer, error) {

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -79,8 +79,9 @@ func (s *SDK) Shutdown() error {
 	return errors.Wrapf(err, "could not send Shutdown message")
 }
 
-// Reserve marks the Game Server as Reserved, for a given duration
-// of which, the smallest unit is seconds)
+// Reserve marks the Game Server as Reserved for a given duration, at which point
+// it will return the GameServer to a Ready state.
+// Do note, the smallest unit available in the time.Duration argument is a second.
 func (s *SDK) Reserve(d time.Duration) error {
 	_, err := s.client.Reserve(s.ctx, &sdk.Duration{Seconds: int64(d.Seconds())})
 	return errors.Wrap(err, "could not send Reserve message")

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -79,6 +79,13 @@ func (s *SDK) Shutdown() error {
 	return errors.Wrapf(err, "could not send Shutdown message")
 }
 
+// Reserve marks the Game Server as Reserved, for a given duration
+// of which, the smallest unit is seconds)
+func (s *SDK) Reserve(d time.Duration) error {
+	_, err := s.client.Reserve(s.ctx, &sdk.Duration{Seconds: int64(d.Seconds())})
+	return errors.Wrap(err, "could not send Reserve message")
+}
+
 // Health sends a ping to the health
 // check to indicate that this server is healthy
 func (s *SDK) Health() error {

--- a/sdks/go/sdk_test.go
+++ b/sdks/go/sdk_test.go
@@ -45,6 +45,10 @@ func TestSDK(t *testing.T) {
 	assert.True(t, sm.ready)
 	assert.False(t, sm.shutdown)
 
+	err = s.Reserve(12 * time.Second)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 12, sm.reserved.Seconds)
+
 	err = s.Health()
 	assert.Nil(t, err)
 	assert.True(t, sm.hm.healthy)

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -123,6 +123,25 @@ For those scenarios, this SDK functionality exists.
 as it gives Agones control over how packed `GameServers` are scheduled within a cluster, whereas with `Allocate()` you
 relinquish control to an external service which likely doesn't have as much information as Agones.
 
+{{% feature publishVersion="0.12.0" %}}
+### Reserve(seconds)
+
+With some matchmaking scenarios and systems it is important to be able to ensure that a `GameServer` is unable to be deleted,
+but doesn't trigger a FleetAutoscaler scale up. This is where `Reserver()` is useful.
+
+`Reserve(seconds)` will move the `GameServer` into the Reserved state for the specified number of seconds (0 is forever), and then it will be
+moved back to `Ready` state. While in `Reserved` state, the `GameServer` cannot be deleted on scale down or `Fleet` update,
+and also cannot be Allocated. 
+
+This is often used wherein a game server process must self register itself with an external system, such as a matchmaker,
+that requires it to designate itself as available for a game session for a certain period. Once a game session has started,
+it can call `SDK.Allocate` to designate that players are currently active on it.
+
+Calling other state changing SDK commands such as `Ready` or `Allocate` turn off the timer to reset the `GameServer` back
+to the `Ready` state.
+
+{{% /feature %}}
+
 ## Writing your own SDK
 
 If there isn't an SDK for the language and platform you are looking for, you have several options:

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -127,17 +127,17 @@ relinquish control to an external service which likely doesn't have as much info
 ### Reserve(seconds)
 
 With some matchmaking scenarios and systems it is important to be able to ensure that a `GameServer` is unable to be deleted,
-but doesn't trigger a FleetAutoscaler scale up. This is where `Reserver()` is useful.
+but doesn't trigger a FleetAutoscaler scale up. This is where `Reserve(seconds)` is useful.
 
 `Reserve(seconds)` will move the `GameServer` into the Reserved state for the specified number of seconds (0 is forever), and then it will be
-moved back to `Ready` state. While in `Reserved` state, the `GameServer` cannot be deleted on scale down or `Fleet` update,
-and also cannot be Allocated. 
+moved back to `Ready` state. While in `Reserved` state, the `GameServer` will not be deleted on scale down or `Fleet` update,
+and also will not be Allocated.
 
-This is often used wherein a game server process must self register itself with an external system, such as a matchmaker,
+This is often used when a game server process must register itself with an external system, such as a matchmaker,
 that requires it to designate itself as available for a game session for a certain period. Once a game session has started,
-it can call `SDK.Allocate` to designate that players are currently active on it.
+it should call `SDK.Allocate()` to designate that players are currently active on it.
 
-Calling other state changing SDK commands such as `Ready` or `Allocate` turn off the timer to reset the `GameServer` back
+Calling other state changing SDK commands such as `Ready` or `Allocate` will turn off the timer to reset the `GameServer` back
 to the `Ready` state.
 
 {{% /feature %}}


### PR DESCRIPTION
This implements Reserve, with an implementation with the Go SDK.

It was also convenience to switch Allocate back to the standard async
implementation here, so that all the SDK commands are consistent in
their concurrency patterns.

Still to come:
- e2e tests
- sdk conformance test
- updates to gameserver lifecycle documentation