### PR TITLE
Update kind dev tooling to 1.12

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -298,7 +298,7 @@ Running end-to-end tests on minikube is done via the `make minikube-test-e2e` ta
 Because Kind runs on a docker on the host, some of the standard build and development Make targets
 need to be replaced by kind specific targets.
 
-If you have [go](https://golang.org/) and [docker](https://www.docker.com/) installed `go get sigs.k8s.io/kind` is all you need !
+First, [install Kind](https://github.com/kubernetes-sigs/kind#installation-and-usage).
 
 Next we will create the Agones Kind cluster. Run `make kind-test-cluster` to create the `agones` Kubernetes cluster.
 

--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -26,7 +26,7 @@ kind-test-cluster: DOCKER_RUN_ARGS+=--network=host
 kind-test-cluster: $(ensure-build-image)
 	@if [ -z $$(kind get clusters | grep $(KIND_PROFILE)) ]; then\
 		echo "Could not find $(KIND_PROFILE) cluster. Creating...";\
-		kind create cluster --name $(KIND_PROFILE) --image kindest/node:v1.11.3 --wait 5m;\
+		kind create cluster --name $(KIND_PROFILE) --image kindest/node:v1.12.9 --wait 5m;\
 	fi
 	$(MAKE) setup-test-cluster KUBECONFIG="$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")" DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS)"
 


### PR DESCRIPTION
Part of #717.

A couple of notes:
1. The `go get` install instructions didn't work for me, so instead of trying to keep our instructions up to date I just replaced it with a link to the Kind docs (it turns out they switched to go modules, which was why). 
1. The current version of kind (v0.4.0) doesn't successfully create clusters at 1.11.3 any longer so that was broken. 
1. I tried to use 1.12.10 (the latest 1.12 release) but kind only seems to support 1.12.9.
