### PR TITLE
Update GKE documentation to 1.12

### DIFF
--- a/build/includes/google-cloud.mk
+++ b/build/includes/google-cloud.mk
@@ -64,8 +64,6 @@ gcloud-auth-cluster: $(ensure-build-image)
 	docker run --rm $(common_mounts) $(build_tag) gcloud config set container/cluster $(GCP_CLUSTER_NAME)
 	docker run --rm $(common_mounts) $(build_tag) gcloud config set compute/zone $(GCP_CLUSTER_ZONE)
 	docker run --rm $(common_mounts) $(build_tag) gcloud container clusters get-credentials $(GCP_CLUSTER_NAME)
-	-docker run --rm $(common_mounts) $(build_tag) bash -c 'echo - n $$(gcloud config get-value account) | md5sum | cut -b-32 > /tmp/hash && \
-	kubectl create clusterrolebinding cluster-admin-binding-$$(cat /tmp/hash) --clusterrole cluster-admin --user $$(gcloud config get-value account)'
 
 # authenticate our docker configuration so that you can do a docker push directly
 # to the gcr.io repository

--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -96,6 +96,7 @@ To install `gcloud` and `kubectl`, perform the following steps:
 
 A [cluster][cluster] consists of at least one *cluster master* machine and multiple worker machines called *nodes*: [Compute Engine virtual machine][vms] instances that run the Kubernetes processes necessary to make them part of the cluster.
 
+{{% feature expiryVersion="0.12.0" %}}
 ```bash
 gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.11 \
   --tags=game-server \
@@ -104,12 +105,30 @@ gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.11 \
   --num-nodes=3 \
   --machine-type=n1-standard-2
 ```
+{{% /feature %}}
+{{% feature publishVersion="0.12.0" %}}
+```bash
+gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.12 \
+  --tags=game-server \
+  --scopes=gke-default \
+  --num-nodes=3 \
+  --machine-type=n1-standard-2
+```
+{{% /feature %}}
+
 
 Flag explanations:
 
+{{% feature expiryVersion="0.12.0" %}}
 * cluster-version: Agones requires Kubernetes version 1.11.
+{{% /feature %}}
+{{% feature publishVersion="0.12.0" %}}
+* cluster-version: Agones requires Kubernetes version 1.12.
+{{% /feature %}}
 * tags: Defines the tags that will be attached to new nodes in the cluster. This is to grant access through ports via the firewall created in the next step.
+{{% feature expiryVersion="0.12.0" %}}
 * no-enable-basic-auth/password: Disables basic auth scheme for the cluster (this is the default starting with version 1.12).
+{{% /feature %}}
 * scopes: Defines the Oauth scopes required by the nodes.
 * num-nodes: The number of nodes to be created in each of the cluster's zones. Default: 3
 * machine-type: The type of machine to use for nodes. Default: n1-standard-2. Depending on the needs of you game, you may wish to [have a bigger machines](https://cloud.google.com/compute/docs/machine-types).
@@ -154,7 +173,9 @@ gcloud compute firewall-rules create game-server-firewall \
   --description "Firewall to allow game server udp traffic"
 ```
 
+{{% feature expiryVersion="0.12.0" %}}
 Continue to [Enabling creation of RBAC resources](#enabling-creation-of-rbac-resources)
+{{% /feature %}}
 
 ## Setting up a Minikube cluster
 


### PR DESCRIPTION
Part of #717.

Notes:
1. As in https://github.com/googleforgames/agones/pull/895, the role binding is no longer required with Kubernetes 1.12+ so I've removed the part. 
1. I've removed the flag to disable basic auth now that it is just setting the default behavior. 