### PR TITLE
Flaky - e2e cp: cannot stat

### DIFF
--- a/build/e2e-image/entrypoint.sh
+++ b/build/e2e-image/entrypoint.sh
@@ -17,8 +17,8 @@ set -e
 
 export SHELL="/bin/bash"
 export KUBECONFIG="/root/.kube/config"
-mkdir -p /go/src/agones.dev/agones/ /root/.kube/
-cp -r /workspace/. /go/src/agones.dev/agones/
+mkdir -p /go/src/agones.dev/ /root/.kube/
+ln -s /workspace /go/src/agones.dev/agones
 cd /go/src/agones.dev/agones/build
 if [ "$1" = 'local' ]
 then


### PR DESCRIPTION
Remove the `cp -r` as files can change under it, and it causes e2e to fail.

Use a symlink, which is both faster, and also won't fail as files move/delete/etc with the testing.