### PR TITLE
Compliance tests for Reserve(seconds).

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -111,18 +111,18 @@ ensure-build-sdk-image:
 
 # Run SDK conformance Sidecar server in docker in order to run
 # SDK client test against it. Useful for test development
-SECONDS ?= 30
+run-sdk-conformance-local: TIMEOUT ?= 30
 run-sdk-conformance-local: ensure-agones-sdk-image
 	docker run -e "ADDRESS=" -p 59357:59357 \
-	 -e "TEST=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch" -e "TIMEOUT=$(SECONDS)" $(sidecar_tag)
+	 -e "TEST=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch" -e "TIMEOUT=$(TIMEOUT)" $(sidecar_tag)
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
-SECONDS ?= 30
-run-sdk-conformance-no-build: ensure-agones-sdk-image
+run-sdk-conformance-no-build: TIMEOUT ?= 30
+run-sdk-conformance-no-build: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	sleep 2s && DOCKER_RUN_ARGS="--network=host $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \
 	docker run -p 59357:59357 -e "ADDRESS=" \
-	 -e "TEST=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch" -e "TIMEOUT=$(SECONDS)" --net=host  $(sidecar_tag)
+	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" --net=host  $(sidecar_tag)
 
 
 # Run SDK conformance test for a specific SDK_FOLDER
@@ -134,5 +134,5 @@ run-sdk-conformance-test:
 # Run a conformance test for all SDKs supported
 run-sdk-conformance-tests:
 	$(MAKE) run-sdk-conformance-test SDK_FOLDER=node
-	$(MAKE) run-sdk-conformance-test SDK_FOLDER=go
+	$(MAKE) run-sdk-conformance-test SDK_FOLDER=go TESTS=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
 	$(MAKE) run-sdk-conformance-test SDK_FOLDER=rust

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -283,6 +283,7 @@ func (l *LocalSDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameS
 // Reserve moves this GameServer to the Reserved state for the Duration specified
 func (l *LocalSDKServer) Reserve(_ context.Context, d *sdk.Duration) (*sdk.Empty, error) {
 	logrus.WithField("duration", d).Info("Reserve request has been received!")
+	l.recordRequest("reserve")
 	return &sdk.Empty{}, nil
 }
 

--- a/test/sdk/go/sdk-client-test.go
+++ b/test/sdk/go/sdk-client-test.go
@@ -90,8 +90,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not set annotation: %s", err)
 	}
+	if err = sdk.Reserve(5 * time.Second); err != nil {
+		log.Fatalf("Could not send Reserve command: %s", err)
+	}
 	err = sdk.Shutdown()
 	if err != nil {
-		log.Fatalf("Could not shutdown GameServer%s", err)
+		log.Fatalf("Could not shutdown GameServer: %s", err)
 	}
 }

--- a/test/sdk/nodejs/.gitignore
+++ b/test/sdk/nodejs/.gitignore
@@ -1,0 +1,16 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+node_modules/
+package-lock.json


### PR DESCRIPTION
Currently only running in the golang test, as that's the only one that implements SDK.Reserve(seconds).

Added a couple of cleanup items in the conformance test makefile as well.

Work on #660 