### PR TITLE
Update the dev-gameserver example to use the current udp-server container image.

### DIFF
--- a/examples/simple-udp/dev-gameserver.yaml
+++ b/examples/simple-udp/dev-gameserver.yaml
@@ -31,4 +31,4 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.5
+        image: gcr.io/agones-images/udp-server:0.14

--- a/site/content/en/docs/Guides/local-game-server.md
+++ b/site/content/en/docs/Guides/local-game-server.md
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.5
+        image: gcr.io/agones-images/udp-server:0.14
 ```
 {{% /feature %}}
 


### PR DESCRIPTION
Your recent PRs bumping the udp-server container image seem to have missed this file. I've jumped straight to 0.14 (as in https://github.com/googleforgames/agones/pull/928). 