### PR TITLE
Update Dockerfile for Rust simple

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -112,9 +112,10 @@ ensure-build-sdk-image:
 # Run SDK conformance Sidecar server in docker in order to run
 # SDK client test against it. Useful for test development
 run-sdk-conformance-local: TIMEOUT ?= 30
+run-sdk-conformance-local: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch
 run-sdk-conformance-local: ensure-agones-sdk-image
 	docker run -e "ADDRESS=" -p 59357:59357 \
-	 -e "TEST=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch" -e "TIMEOUT=$(TIMEOUT)" $(sidecar_tag)
+	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" $(sidecar_tag)
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
 run-sdk-conformance-no-build: TIMEOUT ?= 30

--- a/examples/rust-simple/Dockerfile
+++ b/examples/rust-simple/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.25.0 as builder
+FROM rust:1.36.0 as builder
 RUN useradd -m build
 
 # Rust SDK depends on https://github.com/pingcap/grpc-rs and it requires CMake and Go
@@ -42,12 +42,10 @@ ENV PATH $PATH:/usr/local/go/bin
 # SDK
 COPY sdk/src /home/builder/agones/sdks/rust/src
 COPY sdk/Cargo.toml /home/builder/agones/sdks/rust/
-COPY sdk/Cargo.lock /home/builder/agones/sdks/rust/
 
 # Example
 COPY src /home/builder/agones/examples/rust-simple/src
 COPY Cargo.toml /home/builder/agones/examples/rust-simple/
-COPY Cargo.lock /home/builder/agones/examples/rust-simple/
 COPY Makefile /home/builder/agones/examples/rust-simple/
 
 WORKDIR /home/builder/agones/examples/rust-simple

--- a/examples/rust-simple/Makefile
+++ b/examples/rust-simple/Makefile
@@ -25,7 +25,7 @@
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = rust-simple-server:0.1
+server_tag = rust-simple-server:0.2
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___
@@ -34,21 +34,40 @@ server_tag = rust-simple-server:0.1
 #    |_|\__,_|_|  \__, |\___|\__|___/
 #                 |___/
 
-# build the library
+# Build the example Gameserver
+# alias for 'build-server'
 build: build-server
 
-# Build the server
+# Build the server binary
 build-server:
 	cargo build --release
 
 # Build a docker image for the server, and tag it
 build-image:
-	# Docker does not allow to copy outside files, 
+	# Docker does not allow to copy outside files
 	mkdir -p $(project_path)sdk
 	cp -rf $(project_path)../../sdks/rust/src $(project_path)sdk/src
 	cp -rf $(project_path)../../sdks/rust/Cargo.* $(project_path)sdk
 	docker build $(project_path) --tag=$(server_tag)
 
+# Run Rust Gameserver binary
+# Could be tested with:
+# cd ../../build; make run-sdk-conformance-local TIMEOUT=120 TESTS=ready,watch,health,gameserver,shutdown
+run:
+	./target/release/rust-simple
+
+# Run docker image
+# Could be tested with:
+# cd ../../build; make run-sdk-conformance-local TIMEOUT=120 TESTS=ready,watch,health,gameserver,shutdown
+run-image:
+	docker run --network=host $(server_tag)
+
+# When you used 'build' or 'build-server' locally without docker
 clean:
 	cargo clean
+	rm -rf $(project_path)sdk
+
+# If you are building with docker clean files in /sdk directory,
+# clean leftover files after building an image with Docker
+clean-docker:
 	rm -rf $(project_path)sdk

--- a/examples/rust-simple/README.md
+++ b/examples/rust-simple/README.md
@@ -8,9 +8,89 @@ It will
 - Every 10 seconds, write a log saying "Hi! I'm a Game Server"
 - After 60 seconds, call `SDK::Shutdown()` to shut the server down.
 
+## Running locally (without Docker)
+
+This will build example server which will run for 100 seconds:
+```
+make build
+```
+
+In a separate terminal run next command:
+```
+cd ../../build; make run-sdk-conformance-local TIMEOUT=120 TESTS=ready,watch,health,gameserver
+```
+This will start an SDK-server in a docker, which will be running for 120 seconds.
+
+Run the Rust Simple Gameserver binary:
+```
+make run
+```
+
+You will see the following output:
+```
+Rust Game Server has started!
+Creating SDK instance
+Setting a label
+Starting to watch GameServer updates...
+Health ping sent
+Setting an annotation
+...
+```
+
+Clean the resulting `sdk` directory and `target` folder:
+```
+make clean
+```
+
+
+## Running locally with Docker
+
+Build the container locally:
+```
+make build-image
+```
+
+In a separate terminal run next command:
+```
+cd ../../build; make run-sdk-conformance-local TIMEOUT=120 TESTS=ready,watch,health,gameserver
+```
+This will start an SDK-server in a docker, which will be running for 120 seconds.
+
+Run next make targets:
+```
+make run-image
+```
+
+You will see the following output:
+```
+docker run --network=host rust-simple-server:0.2
+Rust Game Server has started!
+Creating SDK instance
+Setting a label
+Starting to watch GameServer updates...
+Health ping sent
+Setting an annotation
+GameServer Update, name: local
+GameServer Update, state: Ready
+Marking server as ready...
+...marked Ready
+Getting GameServer details...
+GameServer name: local
+Running for 0 seconds
+Health ping sent
+Health ping sent
+Health ping sent
+Health ping sent
+Running for 10 seconds
+```
+Clean the resulting `sdk` directory:
+```
+make clean-docker
+```
+
 ## Running by minikube
 
-First of all, you have to configure Agones on minikude. Check out [these instructions](https://agones.dev/site/docs/installation/#setting-up-a-minikube-cluster).
+First of all, you have to configure Agones on minikube. Check out [these instructions](https://agones.dev/site/docs/installation/#setting-up-a-minikube-cluster).
 
 ```
 $ eval $(minikube docker-env)

--- a/examples/rust-simple/gameserver.yaml
+++ b/examples/rust-simple/gameserver.yaml
@@ -26,5 +26,5 @@ spec:
     spec:
       containers:
       - name: rust-simple
-        image: gcr.io/agones-images/rust-simple-server:0.1
+        image: gcr.io/agones-images/rust-simple-server:0.2
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Update Rust version to avoid errors on build and remove Cargo.lock copy
step. Added comments on how to use it when run locally.
We don't need to add Cargo.lock command when we build using docker.
Closes #935.