### PR TITLE
Gameserver status subresource

### DIFF
--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -53,5 +53,8 @@ spec:
   validation:
     openAPIV3Schema:
       {{- include "gameserver.validation" . | indent 6 }}
+  subresources:
+    # status enables the status subresource.
+    status: {}
 
 {{- end }}

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -59,7 +59,7 @@ rules:
   resources: ["fleets"]
   verbs: ["get", "list", "update", "watch"]
 - apiGroups: ["agones.dev"]
-  resources: ["fleets/status", "gameserversets/status"]
+  resources: ["gameservers/status", "fleets/status", "gameserversets/status"]
   verbs: ["update"]
 - apiGroups: ["multicluster.agones.dev"]
   resources: ["gameserverallocationpolicies"]

--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -43,6 +43,9 @@ rules:
 - apiGroups: ["agones.dev"]
   resources: ["gameservers"]
   verbs: ["list", "update", "watch"]
+- apiGroups: ["agones.dev"]
+  resources: ["gameservers/status"]
+  verbs: ["update"]
 ---
   {{- range .Values.gameservers.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -57,7 +57,7 @@ rules:
   resources: ["fleets"]
   verbs: ["get", "list", "update", "watch"]
 - apiGroups: ["agones.dev"]
-  resources: ["fleets/status", "gameserversets/status"]
+  resources: ["gameservers/status", "fleets/status", "gameserversets/status"]
   verbs: ["update"]
 - apiGroups: ["multicluster.agones.dev"]
   resources: ["gameserverallocationpolicies"]
@@ -161,6 +161,9 @@ rules:
 - apiGroups: ["agones.dev"]
   resources: ["gameservers"]
   verbs: ["list", "update", "watch"]
+- apiGroups: ["agones.dev"]
+  resources: ["gameservers/status"]
+  verbs: ["update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -621,6 +624,9 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 2147483648
+  subresources:
+    # status enables the status subresource.
+    status: {}
 
 ---
 # Source: agones/templates/crds/gameserverallocationpolicy.yaml

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -199,7 +199,17 @@ func (gs *GameServer) ApplyDefaults() {
 	gs.ObjectMeta.Finalizers = append(gs.ObjectMeta.Finalizers, agones.GroupName)
 
 	gs.Spec.ApplyDefaults()
-	gs.applyStateDefaults()
+}
+
+// ApplyStatusDefaults applies the default values to the Status subresource.
+func (gs *GameServer) ApplyStatusDefaults() {
+	if gs.Status.State == "" {
+		gs.Status.State = GameServerStateCreating
+		// ApplyStatusDefaults() should be called after applyPortDefaults()
+		if gs.HasPortPolicy(Dynamic) || gs.HasPortPolicy(Passthrough) {
+			gs.Status.State = GameServerStatePortAllocation
+		}
+	}
 }
 
 // ApplyDefaults applies default values to the GameServerSpec if they are not already populated
@@ -228,17 +238,6 @@ func (gss *GameServerSpec) applyHealthDefaults() {
 		}
 		if gss.Health.InitialDelaySeconds <= 0 {
 			gss.Health.InitialDelaySeconds = 5
-		}
-	}
-}
-
-// applyStateDefaults applies state defaults
-func (gs *GameServer) applyStateDefaults() {
-	if gs.Status.State == "" {
-		gs.Status.State = GameServerStateCreating
-		// applyStateDefaults() should be called after applyPortDefaults()
-		if gs.HasPortPolicy(Dynamic) || gs.HasPortPolicy(Passthrough) {
-			gs.Status.State = GameServerStatePortAllocation
 		}
 	}
 }

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -187,7 +187,7 @@ func (hc *HealthController) syncGameServer(key string) error {
 	gsCopy := gs.DeepCopy()
 	gsCopy.Status.State = agonesv1.GameServerStateUnhealthy
 
-	if _, err := hc.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gsCopy); err != nil {
+	if _, err := hc.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).UpdateStatus(gsCopy); err != nil {
 		return errors.Wrapf(err, "error updating GameServer %s to unhealthy", gs.ObjectMeta.Name)
 	}
 

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -500,7 +500,7 @@ func (c *Controller) deleteGameServers(gsSet *agonesv1.GameServerSet, toDelete [
 		// We should not delete the gameservers directly buy set their state to shutdown and let the gameserver controller to delete
 		gsCopy := gs.DeepCopy()
 		gsCopy.Status.State = agonesv1.GameServerStateShutdown
-		_, err := c.gameServerGetter.GameServers(gs.Namespace).Update(gsCopy)
+		_, err := c.gameServerGetter.GameServers(gs.Namespace).UpdateStatus(gsCopy)
 		if err != nil {
 			return errors.Wrapf(err, "error updating gameserver %s from status %s to Shutdown status.", gs.ObjectMeta.Name, gs.Status.State)
 		}

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -272,18 +272,19 @@ func (s *SDKServer) updateState() error {
 	}
 
 	s.gsUpdateMutex.RLock()
-	gs.Status.State = s.gsState
+	gsCopy := gs.DeepCopy()
+	gsCopy.Status.State = s.gsState
 
 	// If we are setting the Reserved status, check for the duration, and set that too.
-	if gs.Status.State == agonesv1.GameServerStateReserved && s.gsReserveDuration != nil {
+	if gsCopy.Status.State == agonesv1.GameServerStateReserved && s.gsReserveDuration != nil {
 		n := metav1.NewTime(time.Now().Add(*s.gsReserveDuration))
-		gs.Status.ReservedUntil = &n
+		gsCopy.Status.ReservedUntil = &n
 	} else {
-		gs.Status.ReservedUntil = nil
+		gsCopy.Status.ReservedUntil = nil
 	}
 	s.gsUpdateMutex.RUnlock()
 
-	_, err = gameServers.Update(gs)
+	gs, err = gameServers.UpdateStatus(gsCopy)
 	if err != nil {
 		return errors.Wrapf(err, "could not update GameServer %s/%s to state %s", s.namespace, s.gameServerName, gs.Status.State)
 	}

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -449,7 +449,7 @@ func TestReservedGameServerInFleet(t *testing.T) {
 	// mark one as reserved
 	gsCopy := gsList[0].DeepCopy()
 	gsCopy.Status.State = agonesv1.GameServerStateReserved
-	_, err = client.GameServers(defaultNs).Update(gsCopy)
+	_, err = client.GameServers(defaultNs).UpdateStatus(gsCopy)
 	assert.NoError(t, err)
 
 	// make sure counts are correct


### PR DESCRIPTION
This is a draft implementation. I'm not convinced this is a good idea
as it removes the essentially atomic/transactional nature of being able
to manipulate GameServer resources -- which because of Allocation, is
something that is ideal to have.

I expect that e2e tests will fail.