### PR TITLE
Add the missing functions to the C++ SDK (Allocated & Reserve)

### DIFF
--- a/sdks/cpp/include/agones/sdk.h
+++ b/sdks/cpp/include/agones/sdk.h
@@ -39,6 +39,13 @@ class SDK {
   // Marks the Game Server as ready to receive connections
   AGONES_EXPORT grpc::Status Ready();
 
+  // Self marks this gameserver as Allocated.
+  AGONES_EXPORT grpc::Status Allocate();
+
+  // Marks the Game Server as Reserved for a given number of seconds, at which
+  // point it will return the GameServer to a Ready state.
+  AGONES_EXPORT grpc::Status Reserve(std::chrono::seconds seconds);
+
   // Send Health ping. This is a synchronous request.
   AGONES_EXPORT bool Health();
 

--- a/sdks/cpp/src/agones/sdk.cc
+++ b/sdks/cpp/src/agones/sdk.cc
@@ -61,6 +61,29 @@ grpc::Status SDK::Ready() {
   return pimpl_->stub_->Ready(&context, request, &response);
 }
 
+grpc::Status SDK::Allocate() {
+  grpc::ClientContext context;
+  context.set_deadline(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                                    gpr_time_from_seconds(30, GPR_TIMESPAN)));
+  agones::dev::sdk::Empty request;
+  agones::dev::sdk::Empty response;
+
+  return pimpl_->stub_->Allocate(&context, request, &response);
+}
+
+grpc::Status SDK::Reserve(std::chrono::seconds seconds) {
+  grpc::ClientContext context;
+  context.set_deadline(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                                    gpr_time_from_seconds(30, GPR_TIMESPAN)));
+
+  agones::dev::sdk::Duration request;
+  request.set_seconds(seconds.count());
+
+  agones::dev::sdk::Empty response;
+
+  return pimpl_->stub_->Reserve(&context, request, &response);
+}
+
 bool SDK::Health() {
   agones::dev::sdk::Empty request;
   return pimpl_->health_->Write(request);

--- a/site/content/en/docs/Guides/Client SDKs/cpp.md
+++ b/site/content/en/docs/Guides/Client SDKs/cpp.md
@@ -21,7 +21,7 @@ appropriate for their system.
 
 We may consider these types of features in the future, depending on demand. 
 
-To begin working with the SDK, create an instance of it.
+To begin working with the SDK, create an instance of it:
 ```cpp
 agones::SDK *sdk = new agones::SDK();
 ```
@@ -34,7 +34,7 @@ and will return `false` if there was an issue connecting.
 bool ok = sdk->Connect();
 ```
 
-To send a [health check]({{< relref "_index.md#health" >}}) ping call `sdk->Health()`. This is a synchronous request that will
+To send a [health check]({{< relref "_index.md#health" >}}) call `sdk->Health()`. This is a synchronous request that will
 return `false` if it has failed in any way. Read [GameServer Health Checking]({{< relref "../health-checking.md" >}}) for more
 details on the game server health checking strategy.
 
@@ -46,19 +46,43 @@ To mark the game server as [ready to receive player connections]({{< relref "_in
 This will return a grpc::Status object, from which we can call `status.ok()` to determine
 if the function completed successfully.
 
-For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html)
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html).
 
 ```cpp
 grpc::Status status = sdk->Ready();
 if (!status.ok()) { ... }
 ```
 
-To mark that the [game session is completed]({{< relref "_index.md#shutdown" >}}) and the game server should be shut down call `sdk->Shutdown()`. 
-
+{{% feature publishVersion="0.12.0" %}}
+To mark the game server as [allocated]({{< relref "_index.md#allocate" >}}), call `sdk->Allocate()`.
 This will return a grpc::Status object, from which we can call `status.ok()` to determine
 if the function completed successfully.
 
-For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html)
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html).
+
+```cpp
+grpc::Status status = sdk->Allocate();
+if (!status.ok()) { ... }
+```
+
+<!--TODO: Change the link to a relref once 0.12.0 has been published so that this passes link checking -->
+To mark the game server as <a href="../#reserve-seconds" data-proofer-ignore>reserved</a>, call
+`sdk->Reserve(seconds)`. This will return a grpc::Status object, from which we can call `status.ok()` to determine
+if the function completed successfully.
+
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html).
+
+```cpp
+grpc::Status status = sdk->Reserve(std::chrono::seconds(N));
+if (!status.ok()) { ... }
+```
+{{% /feature %}}
+
+To mark that the [game session is completed]({{< relref "_index.md#shutdown" >}}) and the game server should be shut down call `sdk->Shutdown()`.
+This will return a grpc::Status object, from which we can call `status.ok()` to determine
+if the function completed successfully.
+
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html).
 
 ```cpp
 grpc::Status status = sdk->Shutdown();
@@ -67,11 +91,10 @@ if (!status.ok()) { ... }
 
 To [set a Label]({{< relref "_index.md#setlabel-key-value" >}}) on the backing `GameServer` call
 `sdk->SetLabel(key, value)`.
-
 This will return a grpc::Status object, from which we can call `status.ok()` to determine
 if the function completed successfully.
 
-For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html)
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html).
 
 ```cpp
 grpc::Status status = sdk->SetLabel("test-label", "test-value");
@@ -80,11 +103,10 @@ if (!status.ok()) { ... }
 
 To [set an Annotation]({{< relref "_index.md#setannotation-key-value" >}}) on the backing `GameServer` call
 `sdk->SetAnnotation(key, value)`.
-
 This will return a grpc::Status object, from which we can call `status.ok()` to determine
 if the function completed successfully.
 
-For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html)
+For more information you can also look at the [gRPC Status reference](https://grpc.io/grpc/cpp/classgrpc_1_1_status.html).
 
 ```cpp
 status = sdk->SetAnnotation("test-annotation", "test value");
@@ -94,7 +116,6 @@ if (!status.ok()) { ... }
 {{% feature expiryVersion="0.12.0" %}}
 To get the details on the [backing `GameServer`]({{< relref "_index.md#gameserver" >}}) call `sdk->GameServer(&gameserver)`,
 passing in a `stable::agones::dev::sdk::GameServer*` to push the results of the `GameServer` configuration into.
-
 This function will return a grpc::Status object, from which we can call `status.ok()` to determine
 if the function completed successfully.
 


### PR DESCRIPTION
Part of https://github.com/googleforgames/agones/issues/927.

Since the C++ SDK doesn't have any automated tests, I tested this manually by modifying the simple-cpp example to call Allocate / Reserve instead of Ready when starting up, and then verified that the gameserver made the expected state transitions. 