### PR TITLE
Update the container image version for the simple unity sdk.

### DIFF
--- a/examples/unity-simple/Makefile
+++ b/examples/unity-simple/Makefile
@@ -28,7 +28,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/unity-simple-server:0.1
+server_tag = $(REPOSITORY)/unity-simple-server:0.2
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___

--- a/examples/unity-simple/gameserver.yaml
+++ b/examples/unity-simple/gameserver.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: "stable.agones.dev/v1alpha1"
+apiVersion: "agones.dev/v1"
 kind: GameServer
 metadata:
   generateName: "unity-simple-server-"
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: unity-simple-server
-        image: gcr.io/agones-images/unity-simple-server:0.1
+        image: gcr.io/agones-images/unity-simple-server:0.2
       resources:
         requests:
           memory: "128Mi"


### PR DESCRIPTION
I went through the instructions at https://github.com/googleforgames/agones/blob/master/examples/unity-simple/README.md to verify that the new container image works with the updated SDK / apigroup rename. 