### PR TITLE
Implement block on connect with Rust+Node.js SDK

### DIFF
--- a/sdks/nodejs/spec/agonesSDK.spec.js
+++ b/sdks/nodejs/spec/agonesSDK.spec.js
@@ -26,6 +26,31 @@ describe('agones', () => {
 		agonesSDK = new AgonesSDK();
 	});
 
+	describe('connect', () => {
+		it('calls the server and handles success', async () => {
+			spyOn(agonesSDK.client, 'waitForReady').and.callFake((deadline, callback) => {
+				let result = new messages.Empty();
+				callback(undefined, result);
+			});
+			let result = await agonesSDK.connect();
+			expect(agonesSDK.client.waitForReady).toHaveBeenCalled();
+			expect(result).toEqual(undefined);
+		});
+
+		it('calls the server and handles failure', async () => {
+			spyOn(agonesSDK.client, 'waitForReady').and.callFake((deadline, callback) => {
+				callback('error', undefined);
+			});
+			try {
+				await agonesSDK.connect();
+				fail();
+			} catch (error) {
+				expect(agonesSDK.client.waitForReady).toHaveBeenCalled();
+				expect(error).toEqual('error');
+			}
+		});
+	});
+
 	describe('allocate', () => {
 		it('calls the server and handles success', async () => {
 			spyOn(agonesSDK.client, 'allocate').and.callFake((request, callback) => {

--- a/sdks/nodejs/src/agonesSDK.js
+++ b/sdks/nodejs/src/agonesSDK.js
@@ -24,6 +24,18 @@ class AgonesSDK {
 		this.emitters = [];
 	}
 
+	async connect() {
+		return new Promise((resolve, reject) => {
+			this.client.waitForReady(Date.now() + 30000, (error) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			})
+		});
+	}
+
 	async close() {
 		if (this.healthStream !== undefined) {
 			this.healthStream.destroy();

--- a/site/content/en/docs/Guides/Client SDKs/nodejs.md
+++ b/site/content/en/docs/Guides/Client SDKs/nodejs.md
@@ -28,13 +28,23 @@ Add the agones dependency to `package.json`, replacing with the download locatio
 }
 ```
 
-To begin working with the SDK, create an instance of it. This will open a connection to the SDK server.
+To begin working with the SDK, create an instance of it. {{< feature expiryVersion="0.12.0" >}}This will open a connection to the SDK server.{{< /feature >}}
 
 ```javascript
 const AgonesSDK = require('agones');
 
 let agonesSDK = new AgonesSDK();
 ```
+
+{{% feature publishVersion="0.12.0" %}}
+
+To connect to the SDK server, either local or when running on Agones, run the `async` method `sdk.connect()`, which will
+`resolve` once connected or `reject` on error or if no connection can be made after 30 seconds.
+
+```javascript
+await agonesSDK.connect();
+```
+{{% /feature %}}
 
 To send a [health check]({{< relref "_index.md#health" >}}) ping call `health()`.
 

--- a/site/content/en/docs/Guides/Client SDKs/rust.md
+++ b/site/content/en/docs/Guides/Client SDKs/rust.md
@@ -46,6 +46,15 @@ if sdk.health().is_ok() {
 }
 ```
 
+{{% feature publishVersion="0.12.0" %}}
+
+To mark the [game session as ready]({{< relref "_index.md#ready" >}}) call `sdk.ready()`.
+
+```rust
+sdk.ready()?;
+```
+{{% /feature %}}
+
 To mark that the [game session is completed]({{< relref "_index.md#shutdown" >}}) and the game server should be shut down call `sdk.shutdown()`. 
 
 ```rust

--- a/test/sdk/nodejs/testSDKClient.js
+++ b/test/sdk/nodejs/testSDKClient.js
@@ -18,6 +18,9 @@ const agonesSDK = new AgonesSDK();
 const connect = async () => {
 	let UID = '';
 	try {
+		console.log("attempting to connect");
+		await agonesSDK.connect();
+		console.log("connected!");
 		let once = true;
 		agonesSDK.watchGameServer((result) => {
 			console.log('watch', result);

--- a/test/sdk/rust/.gitignore
+++ b/test/sdk/rust/.gitignore
@@ -1,0 +1,16 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/target/
+Cargo.lock

--- a/test/sdk/rust/src/main.rs
+++ b/test/sdk/rust/src/main.rs
@@ -111,7 +111,7 @@ fn run() -> Result<(), String> {
         thread::sleep(Duration::from_secs(5));
     }
 
-    println!("Shutting down after 20 seconds...");
+    println!("Shutting down...");
     sdk.shutdown()
         .map_err(|e| format!("Could not run Shutdown: {}. Exiting!", e))?;
     println!("...marked for Shutdown");


### PR DESCRIPTION
## Rust
- Uses a simple polling mechanism to confirm the connection is live
- Add `ready` to the SDK documentation.

## Node.js
- Implements a sdk.connect() function

## Make
- Tweaks the conformance tests to add a random delay to ensure future
  testing of SDK blocking.


Fixes #938