### PR TITLE
Add allocations metrics

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -54,7 +54,7 @@ STRESS_TEST_LEVEL ?= 20
 
 # kind cluster name to use
 KIND_PROFILE ?= agones
-KIND_CONTAINER_NAME=kind-$(KIND_PROFILE)-control-plane
+KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/udp-server:0.14

--- a/build/grafana/dashboard-allocations.yaml
+++ b/build/grafana/dashboard-allocations.yaml
@@ -40,21 +40,294 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 8,
-      "iteration": 1549050426140,
+      "iteration": 1564432641328,
       "links": [],
       "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorPostfix": false,
+          "colorPrefix": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "format": "s",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "hideTimeOverride": false,
+          "id": 16,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(agones_gameserver_allocations_duration_seconds_sum[$interval]))\n/\nsum(rate(agones_gameserver_allocations_duration_seconds_count[$interval]))",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0.5,3,10",
+          "timeFrom": "30m",
+          "timeShift": null,
+          "title": "Average latency",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "format": "reqps",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          },
+          "id": 14,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.2.4",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(agones_gameserver_allocations_duration_seconds_count{status!=\"Allocated\"}[$interval]))",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": "30m",
+          "timeShift": null,
+          "title": "Allocation Errors rate",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
         {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
+          "fill": 4,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 12,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5,sum(rate(agones_gameserver_allocations_duration_seconds_bucket{fleet_name=~\"$fleet\"}[$interval])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "50%",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.9,sum(rate(agones_gameserver_allocations_duration_seconds_bucket{fleet_name=~\"$fleet\"}[$interval])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "90%",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99,sum(rate(agones_gameserver_allocations_duration_seconds_bucket{fleet_name=~\"$fleet\"}[$interval])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "99%",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "GameServer Allocations Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "",
           "fill": 1,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 0
+            "y": 8
           },
           "id": 8,
           "legend": {
@@ -74,27 +347,28 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {},
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "agones_fleet_allocations_count{fleet_name=~\"$fleet\"}",
+              "expr": "sum(rate(agones_gameserver_allocations_duration_seconds_count{fleet_name=~\"$fleet\"}[$interval])) by (status)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "used {{fleet_name}}",
+              "legendFormat": "{{status}}",
               "refId": "A"
             },
             {
-              "expr": "agones_gameservers_count{fleet_name=~\"$fleet\",type=\"Ready\"}",
+              "expr": "",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "free {{fleet_name}}",
+              "legendFormat": "",
               "refId": "B"
             },
             {
@@ -109,7 +383,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "GameServer allocations count by fleet",
+          "title": "GameServer allocations rate by status",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -156,7 +430,7 @@ data:
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 0
+            "y": 8
           },
           "id": 10,
           "legend": {
@@ -176,17 +450,18 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {},
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(agones_fleet_allocations_count{fleet_name=~\"$fleet\"}[$interval])",
+              "expr": "sum(rate(agones_gameserver_allocations_duration_seconds_count{fleet_name=~\"$fleet\",}[$interval])) by (fleet_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{fleet_name}}",
@@ -233,10 +508,98 @@ data:
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "fill": 2,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "id": 18,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(agones_gameserver_allocations_duration_seconds_count{status=\"Allocated\"}[$interval])) by (node_name)",
+              "format": "heatmap",
+              "intervalFactor": 1,
+              "legendFormat": "{{node_name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Allocations rate per node",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "refresh": "10s",
-      "schemaVersion": 16,
+      "schemaVersion": 18,
       "style": "dark",
       "tags": [
         "agones",
@@ -346,7 +709,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-30m",
+        "from": "now-5m",
         "to": "now"
       },
       "timepicker": {
@@ -377,5 +740,5 @@ data:
       "timezone": "",
       "title": "Agones  Allocations",
       "uid": "TfUv6ylmk",
-      "version": 13
+      "version": 1
     }

--- a/build/grafana/dashboard-allocator-usage.yaml
+++ b/build/grafana/dashboard-allocator-usage.yaml
@@ -103,7 +103,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(process_open_fds{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"})",
+              "expr": "sum(process_open_fds{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"})",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -184,7 +184,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "max(go_memstats_last_gc_time_seconds{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"} * 1000)",
+              "expr": "max(go_memstats_last_gc_time_seconds{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"} * 1000)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -245,21 +245,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(process_resident_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}) by (kubernetes_pod_name)",
+              "expr": "sum(process_resident_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"}) by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "resident - {{kubernetes_pod_name}}",
               "refId": "A"
             },
             {
-              "expr": "sum(process_virtual_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"})by (kubernetes_pod_name)",
+              "expr": "sum(process_virtual_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"})by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "virtual - {{kubernetes_pod_name}}",
               "refId": "B"
             },
             {
-              "expr": "sum(go_memstats_alloc_bytes{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"})by (kubernetes_pod_name)",
+              "expr": "sum(go_memstats_alloc_bytes{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"})by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "go alloc - {{kubernetes_pod_name}}",
@@ -345,14 +345,14 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "go_goroutines{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}",
+              "expr": "go_goroutines{app=\"agones\",kubernetes_pod_name=~\"agones-allocator.*\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "go routines",
               "refId": "A"
             },
             {
-              "expr": "go_threads{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}",
+              "expr": "go_threads{app=\"agones\",kubernetes_pod_name=~\"agones-allocator.*\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "threads",
@@ -440,7 +440,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum (irate (process_cpu_seconds_total{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}[1m])) by (kubernetes_pod_name)",
+              "expr": "sum (irate (process_cpu_seconds_total{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"}[1m])) by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{kubernetes_pod_name}}",
@@ -526,7 +526,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": " avg(rate(go_gc_duration_seconds_sum{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}[5m]) / rate(go_gc_duration_seconds_count{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}[5m]))",
+              "expr": " avg(rate(go_gc_duration_seconds_sum{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"}[5m]) / rate(go_gc_duration_seconds_count{app=\"agones\",kubernetes_pod_name=~\"agones-allocator-.*\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "duration",

--- a/build/grafana/dashboard-allocator-usage.yaml
+++ b/build/grafana/dashboard-allocator-usage.yaml
@@ -16,12 +16,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: agones-controller-usage
+  name: agones-allocator-usage
   namespace: metrics
   labels:
      grafana_dashboard: "1"
 data:
-  dashboard-agones-controller-usage.json: |
+  dashboard-agones-allocator-usage.json: |
     {
       "annotations": {
         "list": [
@@ -39,6 +39,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
+      "id": 10,
       "links": [],
       "panels": [
         {
@@ -102,7 +103,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "process_open_fds{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}",
+              "expr": "sum(process_open_fds{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"})",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -110,7 +111,7 @@ data:
             }
           ],
           "thresholds": "",
-          "title": "Controller Open File Descriptor Count",
+          "title": "Allocators Open File Descriptor Count",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -183,7 +184,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "go_memstats_last_gc_time_seconds{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"} * 1000",
+              "expr": "max(go_memstats_last_gc_time_seconds{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"} * 1000)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -244,24 +245,24 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "process_resident_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}",
+              "expr": "sum(process_resident_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}) by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "resident",
+              "legendFormat": "resident - {{kubernetes_pod_name}}",
               "refId": "A"
             },
             {
-              "expr": "process_virtual_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}",
+              "expr": "sum(process_virtual_memory_bytes{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"})by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "virtual",
+              "legendFormat": "virtual - {{kubernetes_pod_name}}",
               "refId": "B"
             },
             {
-              "expr": "go_memstats_alloc_bytes{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}",
+              "expr": "sum(go_memstats_alloc_bytes{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"})by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "go alloc",
+              "legendFormat": "go alloc - {{kubernetes_pod_name}}",
               "refId": "C"
             }
           ],
@@ -269,7 +270,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Controller Memory Used",
+          "title": "Allocators Memory Used",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -362,7 +363,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Controller Go Routines & Threads Count",
+          "title": "Allocators Go Routines & Threads Count",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -439,7 +440,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum (irate (process_cpu_seconds_total{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}[1m])) by (kubernetes_pod_name)",
+              "expr": "sum (irate (process_cpu_seconds_total{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}[1m])) by (kubernetes_pod_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{kubernetes_pod_name}}",
@@ -450,7 +451,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Controller CPU Used (% of core)",
+          "title": "Allocators CPU Used (% of core)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -525,7 +526,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": " rate(go_gc_duration_seconds_sum{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}[5m]) / rate(go_gc_duration_seconds_count{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"}[5m])",
+              "expr": " avg(rate(go_gc_duration_seconds_sum{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}[5m]) / rate(go_gc_duration_seconds_count{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator-.*\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "duration",
@@ -577,10 +578,7 @@ data:
       "refresh": "5s",
       "schemaVersion": 18,
       "style": "dark",
-      "tags": [
-        "controller",
-        "agones"
-      ],
+      "tags": [],
       "templating": {
         "list": []
       },
@@ -614,7 +612,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Agones Controller Resource Usage",
-      "uid": "ktm3s0Umk",
-      "version": 1
+      "title": "Agones Allocator Resource",
+      "uid": "GpQUU7VZk",
+      "version": 3
     }

--- a/build/grafana/dashboard-status.yaml
+++ b/build/grafana/dashboard-status.yaml
@@ -26,7 +26,6 @@ data:
       "annotations": {
         "list": [
           {
-            "$$hashKey": "object:188",
             "builtIn": 1,
             "datasource": "-- Grafana --",
             "enable": true,
@@ -41,7 +40,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1546913780919,
+      "iteration": 1561322336031,
       "links": [],
       "panels": [
         {
@@ -53,7 +52,6 @@ data:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": null,
           "format": "dateTimeFromNow",
           "gauge": {
             "maxValue": 100,
@@ -74,12 +72,10 @@ data:
           "mappingType": 1,
           "mappingTypes": [
             {
-              "$$hashKey": "object:335",
               "name": "value to text",
               "value": 1
             },
             {
-              "$$hashKey": "object:336",
               "name": "range to text",
               "value": 2
             }
@@ -87,6 +83,7 @@ data:
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
+          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -122,7 +119,6 @@ data:
           "valueFontSize": "80%",
           "valueMaps": [
             {
-              "$$hashKey": "object:338",
               "op": "=",
               "text": "N/A",
               "value": "null"
@@ -139,7 +135,6 @@ data:
             "#d44a3a",
             "#299c46"
           ],
-          "datasource": null,
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -160,12 +155,10 @@ data:
           "mappingType": 1,
           "mappingTypes": [
             {
-              "$$hashKey": "object:390",
               "name": "value to text",
               "value": 1
             },
             {
-              "$$hashKey": "object:391",
               "name": "range to text",
               "value": 2
             }
@@ -173,6 +166,7 @@ data:
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
+          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -193,8 +187,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "$$hashKey": "object:323",
-              "expr": "up{app=\"agones\"} OR on() vector(0)",
+              "expr": "up{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"} OR on() vector(0)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -209,13 +202,269 @@ data:
           "valueFontSize": "80%",
           "valueMaps": [
             {
-              "$$hashKey": "object:393",
               "op": "=",
               "text": "UP",
               "value": "1"
             },
             {
-              "$$hashKey": "object:786",
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "format": "dateTimeFromNow",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 19,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "max((process_start_time_seconds{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator.*\"}) * 1000)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "Allocators Uptime",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#d44a3a",
+            "#d44a3a",
+            "#299c46"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 8
+          },
+          "id": 20,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "#0a50a1",
+            "full": false,
+            "lineColor": "#052b51",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(up{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator.*\"}) OR on() vector(0)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "timeFrom": null,
+          "title": "Allocators Live Pod",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "1"
+            },
+            {
+              "op": "=",
+              "text": "DOWN",
+              "value": "0"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#d44a3a",
+            "#d44a3a",
+            "#299c46"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 8
+          },
+          "id": 21,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "#0a50a1",
+            "full": false,
+            "lineColor": "#052b51",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "count(up{app=\"agones\",kubernetes_pod_name=~\"gameserver-allocator.*\"}) OR on() vector(0)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "timeFrom": null,
+          "title": "Allocators Total Pods",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "UP",
+              "value": "1"
+            },
+            {
               "op": "=",
               "text": "DOWN",
               "value": "0"
@@ -232,7 +481,6 @@ data:
             "#299c46",
             "#d44a3a"
           ],
-          "datasource": null,
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -245,7 +493,7 @@ data:
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 8
+            "y": 16
           },
           "id": 2,
           "interval": null,
@@ -253,20 +501,18 @@ data:
           "mappingType": 1,
           "mappingTypes": [
             {
-              "$$hashKey": "object:982",
               "name": "value to text",
               "value": 1
             },
             {
-              "$$hashKey": "object:983",
               "name": "range to text",
               "value": 2
             }
           ],
           "maxDataPoints": 100,
-          "minSpan": 1,
           "nullPointMode": "connected",
           "nullText": null,
+          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -283,8 +529,8 @@ data:
           "scopedVars": {
             "healthcheck": {
               "selected": true,
-              "text": "fleet-workerqueue",
-              "value": "fleet-workerqueue"
+              "text": "agones-client",
+              "value": "agones-client"
             }
           },
           "sparkline": {
@@ -296,8 +542,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "$$hashKey": "object:930",
-              "expr": "agones_healthcheck_status{check=\"$healthcheck\"} OR on() vector(1)",
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -307,18 +552,15 @@ data:
           ],
           "thresholds": "0,1",
           "title": "health check - $healthcheck",
-          "transparent": false,
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
-              "$$hashKey": "object:985",
               "op": "=",
               "text": "OK",
               "value": "0"
             },
             {
-              "$$hashKey": "object:986",
               "op": "=",
               "text": "NOK",
               "value": "1"
@@ -335,7 +577,6 @@ data:
             "#299c46",
             "#d44a3a"
           ],
-          "datasource": null,
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -348,28 +589,26 @@ data:
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 8
+            "y": 16
           },
-          "id": 15,
+          "id": 10,
           "interval": null,
           "links": [],
           "mappingType": 1,
           "mappingTypes": [
             {
-              "$$hashKey": "object:982",
               "name": "value to text",
               "value": 1
             },
             {
-              "$$hashKey": "object:983",
               "name": "range to text",
               "value": 2
             }
           ],
           "maxDataPoints": 100,
-          "minSpan": 1,
           "nullPointMode": "connected",
           "nullText": null,
+          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -383,7 +622,105 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1546913780919,
+          "repeatIteration": 1561322336031,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "fleet-workerqueue",
+              "value": "fleet-workerqueue"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 12,
+            "y": 16
+          },
+          "id": 11,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1561322336031,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -401,8 +738,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "$$hashKey": "object:930",
-              "expr": "agones_healthcheck_status{check=\"$healthcheck\"} OR on() vector(1)",
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -412,18 +748,15 @@ data:
           ],
           "thresholds": "0,1",
           "title": "health check - $healthcheck",
-          "transparent": false,
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
-              "$$hashKey": "object:985",
               "op": "=",
               "text": "OK",
               "value": "0"
             },
             {
-              "$$hashKey": "object:986",
               "op": "=",
               "text": "NOK",
               "value": "1"
@@ -440,7 +773,6 @@ data:
             "#299c46",
             "#d44a3a"
           ],
-          "datasource": null,
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -452,29 +784,27 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 12,
-            "y": 8
+            "x": 18,
+            "y": 16
           },
-          "id": 16,
+          "id": 12,
           "interval": null,
           "links": [],
           "mappingType": 1,
           "mappingTypes": [
             {
-              "$$hashKey": "object:982",
               "name": "value to text",
               "value": 1
             },
             {
-              "$$hashKey": "object:983",
               "name": "range to text",
               "value": 2
             }
           ],
           "maxDataPoints": 100,
-          "minSpan": 1,
           "nullPointMode": "connected",
           "nullText": null,
+          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -488,7 +818,301 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1546913780919,
+          "repeatIteration": 1561322336031,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "gameserver-creation-workerqueue",
+              "value": "gameserver-creation-workerqueue"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 0,
+            "y": 25
+          },
+          "id": 13,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1561322336031,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "gameserver-deletion-workerqueue",
+              "value": "gameserver-deletion-workerqueue"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 6,
+            "y": 25
+          },
+          "id": 14,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1561322336031,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "gameserver-health-workerqueue",
+              "value": "gameserver-health-workerqueue"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 12,
+            "y": 25
+          },
+          "id": 15,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1561322336031,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -506,8 +1130,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "$$hashKey": "object:930",
-              "expr": "agones_healthcheck_status{check=\"$healthcheck\"} OR on() vector(1)",
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -517,18 +1140,15 @@ data:
           ],
           "thresholds": "0,1",
           "title": "health check - $healthcheck",
-          "transparent": false,
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
-              "$$hashKey": "object:985",
               "op": "=",
               "text": "OK",
               "value": "0"
             },
             {
-              "$$hashKey": "object:986",
               "op": "=",
               "text": "NOK",
               "value": "1"
@@ -545,7 +1165,6 @@ data:
             "#299c46",
             "#d44a3a"
           ],
-          "datasource": null,
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -558,28 +1177,26 @@ data:
             "h": 9,
             "w": 6,
             "x": 18,
-            "y": 8
+            "y": 25
           },
-          "id": 17,
+          "id": 16,
           "interval": null,
           "links": [],
           "mappingType": 1,
           "mappingTypes": [
             {
-              "$$hashKey": "object:982",
               "name": "value to text",
               "value": 1
             },
             {
-              "$$hashKey": "object:983",
               "name": "range to text",
               "value": 2
             }
           ],
           "maxDataPoints": 100,
-          "minSpan": 1,
           "nullPointMode": "connected",
           "nullText": null,
+          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -593,7 +1210,105 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1546913780919,
+          "repeatIteration": 1561322336031,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "gameserverallocation-gameserver-workerqueue",
+              "value": "gameserverallocation-gameserver-workerqueue"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 0,
+            "y": 34
+          },
+          "id": 17,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1561322336031,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -611,8 +1326,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "$$hashKey": "object:930",
-              "expr": "agones_healthcheck_status{check=\"$healthcheck\"} OR on() vector(1)",
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -622,18 +1336,113 @@ data:
           ],
           "thresholds": "0,1",
           "title": "health check - $healthcheck",
-          "transparent": false,
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
-              "$$hashKey": "object:985",
               "op": "=",
               "text": "OK",
               "value": "0"
             },
             {
-              "$$hashKey": "object:986",
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 6,
+            "y": 34
+          },
+          "id": 18,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1561322336031,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "https",
+              "value": "https"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
               "op": "=",
               "text": "NOK",
               "value": "1"
@@ -643,7 +1452,7 @@ data:
         }
       ],
       "refresh": "10s",
-      "schemaVersion": 16,
+      "schemaVersion": 18,
       "style": "dark",
       "tags": [
         "agones",
@@ -654,15 +1463,22 @@ data:
           {
             "allValue": null,
             "current": {
-              "text": "fleet-workerqueue + fleetautoscaler-workerqueue + gameserver-workerqueue + gameserverset-workerqueue",
+              "text": "agones-client + fleet-workerqueue + fleetautoscaler-workerqueue + gameserver-creation-workerqueue + gameserver-deletion-workerqueue + gameserver-health-workerqueue + gameserver-workerqueue + gameserverallocation-gameserver-workerqueue + gameserverset-workerqueue + https",
               "value": [
+                "agones-client",
                 "fleet-workerqueue",
                 "fleetautoscaler-workerqueue",
+                "gameserver-creation-workerqueue",
+                "gameserver-deletion-workerqueue",
+                "gameserver-health-workerqueue",
                 "gameserver-workerqueue",
-                "gameserverset-workerqueue"
+                "gameserverallocation-gameserver-workerqueue",
+                "gameserverset-workerqueue",
+                "https"
               ]
             },
             "datasource": "Prometheus",
+            "definition": "",
             "hide": 0,
             "includeAll": false,
             "label": null,
@@ -672,6 +1488,7 @@ data:
             "query": "label_values(agones_healthcheck_status, check)\t",
             "refresh": 2,
             "regex": "",
+            "skipUrlSync": false,
             "sort": 0,
             "tagValuesQuery": "",
             "tags": [],

--- a/build/grafana/dashboard-status.yaml
+++ b/build/grafana/dashboard-status.yaml
@@ -40,7 +40,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1561322336031,
+      "id": 10,
+      "iteration": 1563127715245,
       "links": [],
       "panels": [
         {
@@ -529,8 +530,8 @@ data:
           "scopedVars": {
             "healthcheck": {
               "selected": true,
-              "text": "agones-client",
-              "value": "agones-client"
+              "text": "allocator-agones-client",
+              "value": "allocator-agones-client"
             }
           },
           "sparkline": {
@@ -591,7 +592,7 @@ data:
             "x": 6,
             "y": 16
           },
-          "id": 10,
+          "id": 22,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -622,7 +623,105 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
+          "repeatPanelId": 2,
+          "scopedVars": {
+            "healthcheck": {
+              "selected": true,
+              "text": "allocator-https",
+              "value": "allocator-https"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{check}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0,1",
+          "title": "health check - $healthcheck",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "OK",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "NOK",
+              "value": "1"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#299c46",
+            "#d44a3a"
+          ],
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 12,
+            "y": 16
+          },
+          "id": 23,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -686,10 +785,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 12,
+            "x": 18,
             "y": 16
           },
-          "id": 11,
+          "id": 24,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -720,7 +819,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -784,10 +883,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 18,
-            "y": 16
+            "x": 0,
+            "y": 25
           },
-          "id": 12,
+          "id": 25,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -818,7 +917,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -882,10 +981,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 0,
+            "x": 6,
             "y": 25
           },
-          "id": 13,
+          "id": 26,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -916,7 +1015,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -980,10 +1079,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 6,
+            "x": 12,
             "y": 25
           },
-          "id": 14,
+          "id": 27,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -1014,7 +1113,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -1078,10 +1177,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 12,
+            "x": 18,
             "y": 25
           },
-          "id": 15,
+          "id": 28,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -1112,7 +1211,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -1176,10 +1275,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 18,
-            "y": 25
+            "x": 0,
+            "y": 34
           },
-          "id": 16,
+          "id": 29,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -1210,7 +1309,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -1274,10 +1373,10 @@ data:
           "gridPos": {
             "h": 9,
             "w": 6,
-            "x": 0,
+            "x": 6,
             "y": 34
           },
-          "id": 17,
+          "id": 30,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -1308,7 +1407,7 @@ data:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
+          "repeatIteration": 1563127715245,
           "repeatPanelId": 2,
           "scopedVars": {
             "healthcheck": {
@@ -1351,108 +1450,10 @@ data:
             }
           ],
           "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "#299c46",
-            "#d44a3a"
-          ],
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 6,
-            "y": 34
-          },
-          "id": 18,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1561322336031,
-          "repeatPanelId": 2,
-          "scopedVars": {
-            "healthcheck": {
-              "selected": true,
-              "text": "https",
-              "value": "https"
-            }
-          },
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(agones_healthcheck_status{check=\"$healthcheck\"}) OR on() vector(1)",
-              "format": "time_series",
-              "instant": true,
-              "intervalFactor": 1,
-              "legendFormat": "{{check}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "0,1",
-          "title": "health check - $healthcheck",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "OK",
-              "value": "0"
-            },
-            {
-              "op": "=",
-              "text": "NOK",
-              "value": "1"
-            }
-          ],
-          "valueName": "current"
         }
       ],
       "refresh": "10s",
-      "schemaVersion": 18,
+      "schemaVersion": 16,
       "style": "dark",
       "tags": [
         "agones",
@@ -1463,9 +1464,10 @@ data:
           {
             "allValue": null,
             "current": {
-              "text": "agones-client + fleet-workerqueue + fleetautoscaler-workerqueue + gameserver-creation-workerqueue + gameserver-deletion-workerqueue + gameserver-health-workerqueue + gameserver-workerqueue + gameserverallocation-gameserver-workerqueue + gameserverset-workerqueue + https",
+              "text": "allocator-agones-client + allocator-https + fleet-workerqueue + fleetautoscaler-workerqueue + gameserver-creation-workerqueue + gameserver-deletion-workerqueue + gameserver-health-workerqueue + gameserver-workerqueue + gameserverallocation-gameserver-workerqueue + gameserverset-workerqueue",
               "value": [
-                "agones-client",
+                "allocator-agones-client",
+                "allocator-https",
                 "fleet-workerqueue",
                 "fleetautoscaler-workerqueue",
                 "gameserver-creation-workerqueue",
@@ -1473,8 +1475,7 @@ data:
                 "gameserver-health-workerqueue",
                 "gameserver-workerqueue",
                 "gameserverallocation-gameserver-workerqueue",
-                "gameserverset-workerqueue",
-                "https"
+                "gameserverset-workerqueue"
               ]
             },
             "datasource": "Prometheus",

--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -49,16 +49,10 @@ kind-install:
 
 # pushses the current dev version of agones to the kind single node cluster.
 kind-push:
-	BUNDLE_FILE=$$(mktemp -d)/agones.tar.gz; \
-	docker save \
-		$(sidecar_tag) \
-		$(controller_tag) \
-		$(ping_tag) \
-		$(allocator_tag) \
-		-o $$BUNDLE_FILE; \
-	docker cp $$BUNDLE_FILE $(KIND_CONTAINER_NAME):/agones.tar.gz; \
-	docker exec $(KIND_CONTAINER_NAME) docker load -i /agones.tar.gz; \
-	rm -f $$BUNDLE_FILE
+	kind load docker-image $(sidecar_tag) --name="$(KIND_PROFILE)"
+	kind load docker-image $(controller_tag) --name="$(KIND_PROFILE)"
+	kind load docker-image $(ping_tag) --name="$(KIND_PROFILE)"
+	kind load docker-image $(allocator_tag) --name="$(KIND_PROFILE)"
 
 # Runs e2e tests against our kind cluster
 kind-test-e2e:

--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -44,7 +44,7 @@ kind-shell: $(ensure-build-image)
 # you should build-images and kind-push first.
 kind-install:
 	$(MAKE) install DOCKER_RUN_ARGS="--network=host" ALWAYS_PULL_SIDECAR=false \
-		IMAGE_PULL_POLICY=IfNotPresent PING_SERVICE_TYPE=NodePort \
+		IMAGE_PULL_POLICY=IfNotPresent PING_SERVICE_TYPE=NodePort ALLOCATOR_SERVICE_TYPE=NodePort\
 		KUBECONFIG="$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")"
 
 # pushses the current dev version of agones to the kind single node cluster.

--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -54,6 +54,7 @@ kind-push:
 		$(sidecar_tag) \
 		$(controller_tag) \
 		$(ping_tag) \
+		$(allocator_tag) \
 		-o $$BUNDLE_FILE; \
 	docker cp $$BUNDLE_FILE $(KIND_CONTAINER_NAME):/agones.tar.gz; \
 	docker exec $(KIND_CONTAINER_NAME) docker load -i /agones.tar.gz; \

--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -23,10 +23,18 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
+	"agones.dev/agones/pkg/metrics"
 	"agones.dev/agones/pkg/util/runtime"
+	"github.com/heptiolabs/healthcheck"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats/view"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 )
@@ -38,24 +46,71 @@ var (
 const (
 	certDir = "/home/allocator/client-ca/"
 	tlsDir  = "/home/allocator/tls/"
-	port    = "8443"
+	sslPort = "8443"
+
+	enableStackdriverMetricsFlag = "stackdriver-exporter"
+	enablePrometheusMetricsFlag  = "prometheus-exporter"
+	projectIDFlag                = "gcp-project-id"
 )
+
+func init() {
+	registerMetricViews()
+}
 
 // A handler for the web server
 type handler func(w http.ResponseWriter, r *http.Request)
 
 func main() {
+	conf := parseEnvFlags()
+
+	// Stackdriver metrics
+	if conf.Stackdriver {
+		sd, err := metrics.RegisterStackdriverExporter(conf.GCPProjectID)
+		if err != nil {
+			logger.WithError(err).Fatal("Could not register stackdriver exporter")
+		}
+		// It is imperative to invoke flush before your main function exits
+		defer sd.Flush()
+	}
+
+	var health healthcheck.Handler
+
+	// Prometheus metrics
+	if conf.PrometheusMetrics {
+		registry := prom.NewRegistry()
+		metricHandler, err := metrics.RegisterPrometheusExporter(registry)
+		if err != nil {
+			logger.WithError(err).Fatal("Could not register prometheus exporter")
+		}
+		http.Handle("/metrics", metricHandler)
+		health = healthcheck.NewMetricsHandler(registry, "agones")
+	} else {
+		health = healthcheck.NewHandler()
+	}
+	metrics.SetReportingPeriod(conf.PrometheusMetrics, conf.Stackdriver)
+
+	// http.DefaultServerMux is used for http connection, not for https
+	http.Handle("/", health)
+
 	agonesClient, err := getAgonesClient()
 	if err != nil {
 		logger.WithError(err).Fatal("could not create agones client")
 	}
+	// This will test the connection to agones on each readiness probe
+	// so if one of the allocator pod can't reach Kubernetes it will be removed
+	// from the Kubernetes service.
+	health.AddReadinessCheck("allocator-agones-client", func() error {
+		_, err := agonesClient.ServerVersion()
+		return err
+	})
 
 	h := httpHandler{
 		agonesClient: agonesClient,
 	}
 
-	// TODO: add liveness probe
-	http.HandleFunc("/v1alpha1/gameserverallocation", h.postOnly(h.allocateHandler))
+	// mux for https server
+	httpsMux := http.NewServeMux()
+	httpsMux.HandleFunc("/v1alpha1/gameserverallocation", h.postOnly(h.allocateHandler))
 
 	caCertPool, err := getCACertPool(certDir)
 	if err != nil {
@@ -67,11 +122,30 @@ func main() {
 		ClientCAs:  caCertPool,
 	}
 	srv := &http.Server{
-		Addr:      ":" + port,
+		Addr:      ":" + sslPort,
 		TLSConfig: cfg,
+		// add http OC metrics (opencensus.io/http/server/*)
+		Handler: &ochttp.Handler{
+			Handler: httpsMux,
+		},
 	}
 
-	err = srv.ListenAndServeTLS(tlsDir+"tls.crt", tlsDir+"tls.key")
+	go func() {
+		var err error
+		lock := sync.Mutex{}
+		// force a pod restart if the https server exits.
+		health.AddLivenessCheck("allocator-https", func() error {
+			lock.Lock()
+			defer lock.Unlock()
+			return err
+		})
+		exitErr := srv.ListenAndServeTLS(tlsDir+"tls.crt", tlsDir+"tls.key")
+		lock.Lock()
+		err = exitErr
+		lock.Unlock()
+		logger.WithError(err).Fatal("allocation service crashed")
+	}()
+	err = http.ListenAndServe(":8080", http.DefaultServeMux)
 	logger.WithError(err).Fatal("allocation service crashed")
 }
 
@@ -88,7 +162,6 @@ func getAgonesClient() (*versioned.Clientset, error) {
 	if err != nil {
 		return nil, errors.New("Could not create the agones api clientset")
 	}
-
 	return agonesClient, nil
 }
 
@@ -163,4 +236,40 @@ func httpCode(err error) int {
 		code = int(t.Status().Code)
 	}
 	return code
+}
+
+type config struct {
+	PrometheusMetrics bool
+	Stackdriver       bool
+	GCPProjectID      string
+}
+
+func parseEnvFlags() config {
+
+	viper.SetDefault(enablePrometheusMetricsFlag, true)
+	viper.SetDefault(enableStackdriverMetricsFlag, false)
+	viper.SetDefault(projectIDFlag, "")
+
+	pflag.Bool(enablePrometheusMetricsFlag, viper.GetBool(enablePrometheusMetricsFlag), "Flag to activate metrics of Agones. Can also use PROMETHEUS_EXPORTER env variable.")
+	pflag.Bool(enableStackdriverMetricsFlag, viper.GetBool(enableStackdriverMetricsFlag), "Flag to activate stackdriver monitoring metrics for Agones. Can also use STACKDRIVER_EXPORTER env variable.")
+	pflag.String(projectIDFlag, viper.GetString(projectIDFlag), "GCP ProjectID used for Stackdriver, if not specified ProjectID from Application Default Credentials would be used. Can also use GCP_PROJECT_ID env variable.")
+	pflag.Parse()
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	runtime.Must(viper.BindEnv(enablePrometheusMetricsFlag))
+	runtime.Must(viper.BindEnv(enableStackdriverMetricsFlag))
+	runtime.Must(viper.BindEnv(projectIDFlag))
+	runtime.Must(viper.BindPFlags(pflag.CommandLine))
+
+	return config{
+		PrometheusMetrics: viper.GetBool(enablePrometheusMetricsFlag),
+		Stackdriver:       viper.GetBool(enableStackdriverMetricsFlag),
+		GCPProjectID:      viper.GetString(projectIDFlag),
+	}
+}
+
+func registerMetricViews() {
+	if err := view.Register(ochttp.DefaultServerViews...); err != nil {
+		logger.WithError(err).Error("could not register view")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 h1:zNBQb37RGLmJybyMcs983HfUfpkw9OTFD9tbBfAViHE=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
+github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -97,6 +97,10 @@ spec:
           httpGet:
             path: /live
             port: 8080
+          initialDelaySeconds: {{ .Values.agones.allocator.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.agones.allocator.healthCheck.periodSeconds }}
+          failureThreshold: {{ .Values.agones.allocator.healthCheck.failureThreshold }}
+          timeoutSeconds: {{ .Values.agones.allocator.healthCheck.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /ready

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -66,6 +66,12 @@ spec:
         app: {{ template "agones.name" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+{{- if and (.Values.agones.metrics.prometheusServiceDiscovery) (.Values.agones.metrics.prometheusEnabled) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+{{- end }}
     spec:
       {{- if .Values.agones.allocator.affinity }}
       affinity:
@@ -87,6 +93,21 @@ spec:
       - name: agones-allocator
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.allocator.name}}:{{ default .Values.agones.image.tag .Values.agones.image.allocator.tag }}"
         imagePullPolicy: {{ .Values.agones.image.controller.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+        env:
+        - name: PROMETHEUS_EXPORTER
+          value: {{ .Values.agones.metrics.prometheusEnabled | quote }}
+        - name: STACKDRIVER_EXPORTER
+          value: {{ .Values.agones.metrics.stackdriverEnabled | quote }}
+        - name: GCP_PROJECT_ID
+          value: {{ .Values.agones.metrics.stackdriverProjectID | quote }}
         ports:
         - name: https
           containerPort: 8443

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -97,6 +97,11 @@ agones:
       timeoutSeconds: 1
   allocator:
     install: true
+    healthCheck:
+      initialDelaySeconds: 3
+      periodSeconds: 3
+      failureThreshold: 3
+      timeoutSeconds: 1
     tolerations:
     - key: "agones.dev/agones-system"
       operator: "Equal"

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1000,6 +1000,10 @@ spec:
         app: agones
         release: agones-manual
         heritage: Tiller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
     spec:
       affinity:
         nodeAffinity:
@@ -1028,6 +1032,25 @@ spec:
       - name: agones-allocator
         image: "gcr.io/agones-images/agones-allocator:1.0.0"
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+        env:
+        - name: PROMETHEUS_EXPORTER
+          value: "true"
+        - name: STACKDRIVER_EXPORTER
+          value: "false"
+        - name: GCP_PROJECT_ID
+          value: ""
         ports:
         - name: https
           containerPort: 8443

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -333,7 +333,7 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 	return c.serialisation(r, w, out, scheme.Codecs)
 }
 
-func (c *Controller) recordAllocationCount(rCtx context.Context, in, out *v1alpha1.GameServerAllocation, allocErr error) error {
+func (c *Controller) recordAllocationCount(rCtx context.Context, in, out *allocationv1.GameServerAllocation, allocErr error) error {
 	tags := []tag.Mutator{
 		tag.Insert(keyMultiCluster, strconv.FormatBool(in.Spec.MultiClusterSetting.Enabled)),
 		tag.Insert(keyClusterName, "none"),
@@ -356,12 +356,12 @@ func (c *Controller) recordAllocationCount(rCtx context.Context, in, out *v1alph
 			tags = append(tags, tag.Update(keyNodeName, out.Status.NodeName))
 		}
 		// sets the fleet name tag if possible
-		if out.Status.State == v1alpha1.GameServerAllocationAllocated {
+		if out.Status.State == allocationv1.GameServerAllocationAllocated {
 			gs, err := c.gameServerLister.GameServers(out.Namespace).Get(out.Status.GameServerName)
 			if err != nil {
 				return err
 			}
-			fleetName := gs.Labels[stablev1alpha1.FleetNameLabel]
+			fleetName := gs.Labels[agonesv1.FleetNameLabel]
 			if fleetName != "" {
 				tags = append(tags, tag.Update(keyFleetName, fleetName))
 			}

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -80,15 +80,15 @@ var (
 	keyStatus             = metrics.MustTagKey("status")
 	keySchedulingStrategy = metrics.MustTagKey("scheduling_strategy")
 
-	gameServerAllocationsTotalStats = stats.Int64("gameserver_allocations/total", "The total of gameserver allocations", "1")
+	gameServerAllocationsLatency = stats.Float64("gameserver_allocations/latency", "The duration of gameserver allocations", "s")
 )
 
 func init() {
 	runtime.Must(view.Register(&view.View{
-		Name:        "gameserver_allocations_total",
-		Measure:     gameServerAllocationsTotalStats,
-		Description: "The total of gameserver allocations created.",
-		Aggregation: view.Count(),
+		Name:        "gameserver_allocations_duration_seconds",
+		Measure:     gameServerAllocationsLatency,
+		Description: "The distribution of gameserver allocation requests latencies.",
+		Aggregation: view.Distribution(0, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2, 3),
 		TagKeys:     []tag.Key{keyFleetName, keyNodeName, keyClusterName, keyMultiCluster, keyStatus, keySchedulingStrategy},
 	}))
 }
@@ -270,7 +270,15 @@ func (c *Controller) loggerForGameServerAllocation(gsa *allocationv1.GameServerA
 
 // allocationHandler CRDHandler for allocating a gameserver. Only accepts POST
 // commands
-func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, namespace string) error {
+func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, namespace string) (err error) {
+	latency := c.newLatencyRecorder(r.Context())
+	defer func() {
+		if err != nil {
+			latency.setError()
+		}
+		latency.record()
+	}()
+
 	if r.Body != nil {
 		defer r.Body.Close() // nolint: errcheck
 	}
@@ -280,10 +288,11 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 	if r.Method != http.MethodPost {
 		log.Warn("allocation handler only supports POST")
 		http.Error(w, "Method not supported", http.StatusMethodNotAllowed)
-		return nil
+		latency.setError()
+		return
 	}
-
-	gsa, err := c.allocationDeserialization(r, namespace)
+	var gsa *allocationv1.GameServerAllocation
+	gsa, err = c.allocationDeserialization(r, namespace)
 	if err != nil {
 		return err
 	}
@@ -305,15 +314,16 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 		var gvks []schema.GroupVersionKind
 		gvks, _, err = apiserver.Scheme.ObjectKinds(status)
 		if err != nil {
-			return errors.Wrap(err, "could not find objectkinds for status")
+			err = errors.Wrap(err, "could not find objectkinds for status")
 		}
 
 		status.TypeMeta = metav1.TypeMeta{Kind: gvks[0].Kind, APIVersion: gvks[0].Version}
 
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		return c.serialisation(r, w, status, apiserver.Codecs)
+		err = c.serialisation(r, w, status, apiserver.Codecs)
+		return
 	}
-
+	latency.setRequest(gsa)
 	// If multi-cluster setting is enabled, allocate base on the multicluster allocation policy.
 	var out *allocationv1.GameServerAllocation
 	if gsa.Spec.MultiClusterSetting.Enabled {
@@ -322,57 +332,103 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 		out, err = c.allocateFromLocalCluster(gsa)
 	}
 
-	if metricErr := c.recordAllocationCount(r.Context(), gsa, out, err); metricErr != nil {
-		c.baseLogger.WithError(metricErr).Warn("failed to record allocation count metrics.")
-	}
-
 	if err != nil {
 		return err
 	}
-
-	return c.serialisation(r, w, out, scheme.Codecs)
+	latency.setResponse(out)
+	err = c.serialisation(r, w, out, scheme.Codecs)
+	return err
 }
 
-func (c *Controller) recordAllocationCount(rCtx context.Context, in, out *allocationv1.GameServerAllocation, allocErr error) error {
-	tags := []tag.Mutator{
-		tag.Insert(keyMultiCluster, strconv.FormatBool(in.Spec.MultiClusterSetting.Enabled)),
-		tag.Insert(keyClusterName, "none"),
-		tag.Insert(keySchedulingStrategy, string(in.Spec.Scheduling)),
-		tag.Insert(keyFleetName, "none"),
-		tag.Insert(keyNodeName, "none"),
-		tag.Insert(keyStatus, "none"),
-	}
+// default set of tags for latency metric
+var latencyTags = []tag.Mutator{
+	tag.Insert(keyMultiCluster, "none"),
+	tag.Insert(keyClusterName, "none"),
+	tag.Insert(keySchedulingStrategy, "none"),
+	tag.Insert(keyFleetName, "none"),
+	tag.Insert(keyNodeName, "none"),
+	tag.Insert(keyStatus, "none"),
+}
 
+type latencyRecorder struct {
+	ctx              context.Context
+	gameServerLister listerv1.GameServerLister
+	logger           *logrus.Entry
+	start            time.Time
+}
+
+// newLatencyRecorder creates a new gsa latency recorder.
+func (c *Controller) newLatencyRecorder(ctx context.Context) *latencyRecorder {
+	ctx, err := tag.New(ctx, latencyTags...)
+	if err != nil {
+		c.baseLogger.WithError(err).Warn("failed to tag latency recorder.")
+	}
+	return &latencyRecorder{
+		ctx:              ctx,
+		gameServerLister: c.gameServerLister,
+		logger:           c.baseLogger,
+		start:            time.Now(),
+	}
+}
+
+// mutate the current set of metric tags
+func (r *latencyRecorder) mutate(m ...tag.Mutator) {
+	var err error
+	r.ctx, err = tag.New(r.ctx, m...)
+	if err != nil {
+		r.logger.WithError(err).Warn("failed to mutate request context.")
+	}
+}
+
+// setStatus set the latency status tag.
+func (r *latencyRecorder) setStatus(status string) {
+	r.mutate(tag.Update(keyStatus, status))
+}
+
+// setError set the latency status tag as error.
+func (r *latencyRecorder) setError() {
+	r.mutate(tag.Update(keyStatus, "error"))
+}
+
+// setRequest set request metric tags.
+func (r *latencyRecorder) setRequest(in *allocationv1.GameServerAllocation) {
+	tags := []tag.Mutator{
+		tag.Update(keySchedulingStrategy, string(in.Spec.Scheduling)),
+	}
 	if in.ClusterName != "" {
 		tags = append(tags, tag.Update(keyClusterName, in.ClusterName))
 	}
+	tags = append(tags, tag.Update(keyMultiCluster, strconv.FormatBool(in.Spec.MultiClusterSetting.Enabled)))
+	r.mutate(tags...)
+}
 
-	if allocErr != nil {
-		tags = append(tags, tag.Update(keyStatus, "error"))
+// setResponse set response metric tags.
+func (r *latencyRecorder) setResponse(out *allocationv1.GameServerAllocation) {
+	if out == nil {
+		return
 	}
-	if out != nil {
-		tags = append(tags, tag.Update(keyStatus, string(out.Status.State)))
-		if out.Status.NodeName != "" {
-			tags = append(tags, tag.Update(keyNodeName, out.Status.NodeName))
+	r.setStatus(string(out.Status.State))
+	var tags []tag.Mutator
+	if out.Status.NodeName != "" {
+		tags = append(tags, tag.Update(keyNodeName, out.Status.NodeName))
+	}
+	// sets the fleet name tag if possible
+	if out.Status.State == allocationv1.GameServerAllocationAllocated {
+		gs, err := r.gameServerLister.GameServers(out.Namespace).Get(out.Status.GameServerName)
+		if err != nil {
+			r.logger.WithError(err).Warnf("failed to get gameserver:%s namespace:%s", out.Status.GameServerName, out.Namespace)
 		}
-		// sets the fleet name tag if possible
-		if out.Status.State == allocationv1.GameServerAllocationAllocated {
-			gs, err := c.gameServerLister.GameServers(out.Namespace).Get(out.Status.GameServerName)
-			if err != nil {
-				return err
-			}
-			fleetName := gs.Labels[agonesv1.FleetNameLabel]
-			if fleetName != "" {
-				tags = append(tags, tag.Update(keyFleetName, fleetName))
-			}
+		fleetName := gs.Labels[agonesv1.FleetNameLabel]
+		if fleetName != "" {
+			tags = append(tags, tag.Update(keyFleetName, fleetName))
 		}
 	}
-	ctx, err := tag.New(rCtx, tags...)
-	if err != nil {
-		return err
-	}
-	stats.Record(ctx, gameServerAllocationsTotalStats.M(1))
-	return nil
+	r.mutate(tags...)
+}
+
+// record the current allocation latency.
+func (r *latencyRecorder) record() {
+	stats.Record(r.ctx, gameServerAllocationsLatency.M(time.Since(r.start).Seconds()))
 }
 
 // allocateFromLocalCluster allocates gameservers from the local cluster.

--- a/pkg/metrics/kubernetes_client.go
+++ b/pkg/metrics/kubernetes_client.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	keyQueueName = mustTagKey("queue_name")
+	keyQueueName = MustTagKey("queue_name")
 
 	httpRequestTotalStats   = stats.Int64("http/request_total", "The total of HTTP requests.", "1")
 	httpRequestLatencyStats = stats.Float64("http/latency", "The duration of HTTP requests.", "s")

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -25,13 +25,13 @@ import (
 var (
 	logger = runtime.NewLoggerWithSource("metrics")
 
-	keyName       = mustTagKey("name")
-	keyFleetName  = mustTagKey("fleet_name")
-	keyType       = mustTagKey("type")
-	keyStatusCode = mustTagKey("status_code")
-	keyVerb       = mustTagKey("verb")
-	keyEndpoint   = mustTagKey("endpoint")
-	keyEmpty      = mustTagKey("empty")
+	keyName       = MustTagKey("name")
+	keyFleetName  = MustTagKey("fleet_name")
+	keyType       = MustTagKey("type")
+	keyStatusCode = MustTagKey("status_code")
+	keyVerb       = MustTagKey("verb")
+	keyEndpoint   = MustTagKey("endpoint")
+	keyEmpty      = MustTagKey("empty")
 )
 
 func recordWithTags(ctx context.Context, mutators []tag.Mutator, ms ...stats.Measurement) {
@@ -40,7 +40,7 @@ func recordWithTags(ctx context.Context, mutators []tag.Mutator, ms ...stats.Mea
 	}
 }
 
-func mustTagKey(key string) tag.Key {
+func MustTagKey(key string) tag.Key {
 	t, err := tag.NewKey(key)
 	if err != nil {
 		panic(err)

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -40,6 +40,7 @@ func recordWithTags(ctx context.Context, mutators []tag.Mutator, ms ...stats.Mea
 	}
 }
 
+// MustTagKey creates a new `tag.Key` from a string, panic if the key is not a valid.
 func MustTagKey(key string) tag.Key {
 	t, err := tag.NewKey(key)
 	if err != nil {

--- a/pkg/util/https/server.go
+++ b/pkg/util/https/server.go
@@ -20,6 +20,7 @@ import (
 	"agones.dev/agones/pkg/util/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"go.opencensus.io/plugin/ochttp"
 )
 
 // tls is a http server interface to enable easier testing
@@ -43,8 +44,10 @@ type Server struct {
 func NewServer(certFile, keyFile string) *Server {
 	mux := http.NewServeMux()
 	tls := &http.Server{
-		Addr:    ":8081",
-		Handler: mux,
+		Addr: ":8081",
+		Handler: &ochttp.Handler{
+			Handler: mux,
+		},
 	}
 
 	wh := &Server{

--- a/pkg/util/https/server.go
+++ b/pkg/util/https/server.go
@@ -20,7 +20,6 @@ import (
 	"agones.dev/agones/pkg/util/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/plugin/ochttp"
 )
 
 // tls is a http server interface to enable easier testing
@@ -44,10 +43,8 @@ type Server struct {
 func NewServer(certFile, keyFile string) *Server {
 	mux := http.NewServeMux()
 	tls := &http.Server{
-		Addr: ":8081",
-		Handler: &ochttp.Handler{
-			Handler: mux,
-		},
+		Addr:    ":8081",
+		Handler: mux,
 	}
 
 	wh := &Server{


### PR DESCRIPTION
This adds gameserver allocations metrics with a dashboard. The metrics tracks allocations count, rates and latency per nodes, fleet and status.

I've also added everything required to handle multi cluster allocations but nothing used in the dashboard yet.

I've fixed some issues with kind cluster and also took the time to add metrics and healthcheck for the allocator service. (with a grafana dashboard)

Documentation has been updated.

<img width="2490" alt="Screen Shot 2019-07-30 at 12 55 28 PM" src="https://user-images.githubusercontent.com/1053421/62149927-d482f180-b2ca-11e9-8d88-fda0c65464e0.png">


Closes #144 
