### PR TITLE
Local SDK Server: Add proper GS state handling

### DIFF
--- a/test/sdk/go/sdk-client-test.go
+++ b/test/sdk/go/sdk-client-test.go
@@ -51,6 +51,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not send ready message %s", err)
 	}
+	if err = sdk.Reserve(5 * time.Second); err != nil {
+		log.Fatalf("Could not send Reserve command: %s", err)
+	}
 	err = sdk.Allocate()
 	if err != nil {
 		log.Fatalf("Err sending allocate request %s", err)
@@ -76,9 +79,6 @@ func main() {
 	err = sdk.SetAnnotation("UID", uid)
 	if err != nil {
 		log.Fatalf("Could not set annotation: %s", err)
-	}
-	if err = sdk.Reserve(5 * time.Second); err != nil {
-		log.Fatalf("Could not send Reserve command: %s", err)
 	}
 	err = sdk.Shutdown()
 	if err != nil {

--- a/test/sdk/nodejs/testSDKClient.js
+++ b/test/sdk/nodejs/testSDKClient.js
@@ -32,10 +32,6 @@ const connect = async () => {
 			}
 		});
 		await agonesSDK.ready();
-		setTimeout(() => {
-			console.log('send allocate request');
-			agonesSDK.allocate();
-		}, 1000);
 
 		let result = await agonesSDK.getGameServer();
 		await agonesSDK.setLabel('label', result.objectMeta.creationTimestamp.toString());
@@ -45,6 +41,11 @@ const connect = async () => {
 		console.log('health', result);
 
 		await agonesSDK.reserve(5);
+
+		setTimeout(() => {
+			console.log('send allocate request');
+			agonesSDK.allocate();
+		}, 1000);
 
 		setTimeout(() => {
 			console.log('send shutdown request');


### PR DESCRIPTION
Update the state of local SDK GS according to calls which were made
by SDK client. Local sidecar now keeps track of the current state.
Part of #958 fix.
Added UTs for `localsdk.go`.

Need to add transition to Unhealthy state in a separate PR.