### PR TITLE
Fix Hugo syntax - remove deprecation warning

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -436,8 +436,11 @@ Run the linter and tests
 #### `make site-server`
 Generate `https://agones.dev` website locally and host on `http://localhost:1313`
 
+#### `make hugo-test`
+Check the links in a website
+
 #### `make site-test`
-Check the links in website
+Check the links in a website, includes `test-gen-api-docs` target
 
 #### `make site-images`
 Create all the site images from dot and puml diagrams in /site/static/diagrams

--- a/build/includes/website.mk
+++ b/build/includes/website.mk
@@ -59,12 +59,15 @@ site-static-preview:
 site-deploy-preview: site-static-preview
 	$(MAKE) site-deploy SERVICE=preview
 
-site-test:
-	# generate actual html and run test against - provides a more accurate tests
-	$(MAKE) test-gen-api-docs
+hugo-test:
 	$(MAKE) site-static-preview
 	docker run --rm -t -e "TERM=xterm-256color" $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
 		"mkdir -p /tmp/website && cp -r $(mount_path)/site/public /tmp/website/site && htmltest -c $(mount_path)/site/htmltest.yaml /tmp/website"
+
+site-test:
+	# generate actual html and run test against - provides a more accurate tests
+	$(MAKE) test-gen-api-docs
+	$(MAKE) hugo-test
 
 # generate site images, if they don't exist
 site-images: $(site_path)/static/diagrams/gameserver-states.dot.png $(site_path)/static/diagrams/gameserver-lifecycle.puml.png $(site_path)/static/diagrams/gameserver-reserved.puml.png

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 {{ if eq (getenv "HUGO_ENV") "production" }}
 <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 {{ else }}

--- a/site/themes/docsy/layouts/partials/head.html
+++ b/site/themes/docsy/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 {{ if eq (getenv "HUGO_ENV") "production" }}
 <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 {{ else }}


### PR DESCRIPTION
Copy `hugo-test` part `site-test` as a separate, because `test-gen-api-docs` (second part of `site-test`) takes longer and sometimes it is needed to run `hugo-test` separately.
Get rid of next error message:
WARN 2019/08/09 11:52:37 Page's .Hugo is deprecated and will be removed
in a future release. Use the global hugo function.

Was fixed in original Docsy repo in this PR:
https://github.com/google/docsy/pull/84