### PR TITLE
Rename gameserver-allocator resources to agones-allocator

### DIFF
--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 {{- if .Values.agones.allocator.install }}
-# Define a Service for the gameserver-allocator
+# Define a Service for the agones-allocator
 apiVersion: v1
 kind: Service
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: {{ .Release.Namespace }}
   labels:
     component: allocator
@@ -36,11 +36,11 @@ spec:
   type: {{ .Values.agones.allocator.http.serviceType }}
 
 ---
-# Deploy a pod to run the gameserver-allocator code
+# Deploy a pod to run the agones-allocator code
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: {{ .Release.Namespace }}
   labels:
     multicluster.agones.dev/role: allocator
@@ -71,7 +71,7 @@ spec:
       tolerations:
 {{ toYaml .Values.agones.allocator.tolerations | indent 8 }}
       {{- end }}
-      serviceAccountName: gameserver-allocator
+      serviceAccountName: agones-allocator
       volumes:
       - name: tls
         secret:
@@ -99,7 +99,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" $ }}
@@ -116,7 +116,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" $ }}
@@ -125,11 +125,11 @@ metadata:
     heritage: {{ $.Release.Service }}
 
 ---
-# Bind the gameserver-allocator ServiceAccount to the gameserver-allocator ClusterRole
+# Bind the agones-allocator ServiceAccount to the agones-allocator ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" $ }}
@@ -138,12 +138,12 @@ metadata:
     heritage: {{ $.Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gameserver-allocator
+  name: agones-allocator
  
 {{- end }}
 

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -950,11 +950,11 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Define a Service for the gameserver-allocator
+# Define a Service for the agones-allocator
 apiVersion: v1
 kind: Service
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: agones-system
   labels:
     component: allocator
@@ -973,11 +973,11 @@ spec:
   type: LoadBalancer
 
 ---
-# Deploy a pod to run the gameserver-allocator code
+# Deploy a pod to run the agones-allocator code
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: agones-system
   labels:
     multicluster.agones.dev/role: allocator
@@ -1015,7 +1015,7 @@ spec:
           operator: Equal
           value: "true"
         
-      serviceAccountName: gameserver-allocator
+      serviceAccountName: agones-allocator
       volumes:
       - name: tls
         secret:
@@ -1043,7 +1043,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: agones-system
   labels:
     app: agones
@@ -1060,7 +1060,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: agones-system
   labels:
     app: agones
@@ -1069,11 +1069,11 @@ metadata:
     heritage: Tiller
 
 ---
-# Bind the gameserver-allocator ServiceAccount to the gameserver-allocator ClusterRole
+# Bind the agones-allocator ServiceAccount to the agones-allocator ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: agones-system
   labels:
     app: agones
@@ -1082,12 +1082,12 @@ metadata:
     heritage: Tiller
 subjects:
 - kind: ServiceAccount
-  name: gameserver-allocator
+  name: agones-allocator
   namespace: agones-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gameserver-allocator
+  name: agones-allocator
 
 ---
 # Allocation CA

--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -324,6 +324,8 @@ Conditions:
 ```
 
 All this pods should be in a `RUNNING` state:
+
+{{% feature expiryVersion="1.0.0" %}}
 ```bash
 kubectl get pods --namespace agones-system
 
@@ -335,6 +337,21 @@ gameserver-allocator-6bd4d456f9-bbj76   1/1     Running   0          2m48s
 gameserver-allocator-6bd4d456f9-vlkhk   1/1     Running   0          2m48s
 gameserver-allocator-6bd4d456f9-x7t9h   1/1     Running   0          2m48s
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.0.0" %}}
+
+```bash
+kubectl get pods --namespace agones-system
+
+NAME                                 READY   STATUS    RESTARTS   AGE
+agones-allocator-5c988b7b8d-cgtbs    1/1     Running   0          8m47s
+agones-allocator-5c988b7b8d-hhhr5    1/1     Running   0          8m47s
+agones-allocator-5c988b7b8d-pv577    1/1     Running   0          8m47s
+agones-controller-7db45966db-56l66   1/1     Running   0          8m44s
+agones-ping-84c64f6c9d-bdlzh         1/1     Running   0          8m37s
+agones-ping-84c64f6c9d-sjgzz         1/1     Running   0          8m47s
+```
+{{% /feature %}}
 
 That's it! This creates the [Custom Resource Definitions][crds] that power Agones and allows us to define resources of type `GameServer`.
 

--- a/test/e2e/allocator_test.go
+++ b/test/e2e/allocator_test.go
@@ -37,7 +37,7 @@ func TestAllocator(t *testing.T) {
 	t.Parallel()
 
 	kubeCore := framework.KubeClient.CoreV1()
-	svc, err := kubeCore.Services("agones-system").Get("gameserver-allocator", metav1.GetOptions{})
+	svc, err := kubeCore.Services("agones-system").Get("agones-allocator", metav1.GetOptions{})
 	if !assert.Nil(t, err) {
 		return
 	}


### PR DESCRIPTION
To keep consistency, renamed the gameserver-allocator k8s resources to being agones-allocator instead, which makes it consistent with the rest of the Agones system.

This also means that if Agones is installed in a non default namespace, it is easy to determine which resources belong to Agones.

This results in a display that looks like this:

```shell
root@f999578d0b48:/go/src/agones.dev/agones# kubectl get all --namespace=agones-system
NAME                                     READY   STATUS    RESTARTS   AGE
pod/agones-allocator-5c988b7b8d-cgtbs    1/1     Running   0          2m3s
pod/agones-allocator-5c988b7b8d-hhhr5    1/1     Running   0          2m3s
pod/agones-allocator-5c988b7b8d-pv577    1/1     Running   0          2m3s
pod/agones-controller-7db45966db-56l66   1/1     Running   0          2m
pod/agones-ping-84c64f6c9d-bdlzh         1/1     Running   0          113s
pod/agones-ping-84c64f6c9d-sjgzz         1/1     Running   0          2m3s

NAME                                TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)            AGE
service/agones-allocator            LoadBalancer   10.51.255.102   34.83.220.20    443:32480/TCP      2m4s
service/agones-controller-service   ClusterIP      10.51.253.115   <none>          443/TCP,8080/TCP   15h
service/agones-ping-http-service    LoadBalancer   10.51.244.211   34.83.210.242   80:32317/TCP       15h
service/agones-ping-udp-service     LoadBalancer   10.51.253.63    35.233.234.9    50000:30380/UDP    15h

NAME                                DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/agones-allocator    3         3         3            3           2m4s
deployment.apps/agones-controller   1         1         1            1           15h
deployment.apps/agones-ping         2         2         2            2           15h

NAME                                           DESIRED   CURRENT   READY   AGE
replicaset.apps/agones-allocator-5c988b7b8d    3         3         3       2m4s
replicaset.apps/agones-controller-7db45966db   1         1         1       2m1s
replicaset.apps/agones-controller-96967c45f    0         0         0       15h
replicaset.apps/agones-ping-7d75f87b6c         0         0         0       15h
replicaset.apps/agones-ping-84c64f6c9d         2         2         2       2m4s
```