### PR TITLE
Flaky: Allocator bad tls certificate

### DIFF
--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -57,6 +57,10 @@ spec:
       heritage: {{ .Release.Service }}
   template:
     metadata:
+      annotations:
+{{- if .Values.agones.allocator.generateTLS }}
+        revision/tls-cert: {{ .Release.Revision | quote }}
+{{- end }}
       labels:
         multicluster.agones.dev/role: allocator
         app: {{ template "agones.name" . }}

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -994,6 +994,7 @@ spec:
       heritage: Tiller
   template:
     metadata:
+      annotations:
       labels:
         multicluster.agones.dev/role: allocator
         app: agones


### PR DESCRIPTION
This should fix the bad tls e2e test failures, as it will force a reload of the allocator deployment - which will load the most up to date generated ssl certificate.

This is the same implementation that is in place for the controller as well for its webhook ssl certificates.