### PR TITLE
Adding clean target for SDK conformance tests

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -35,6 +35,7 @@ Table of Contents
         * [make build-sdks](#make-build-sdks)
         * [make build-sdk-cpp](#make-build-sdk-cpp)
         * [make run-sdk-conformance-tests](#make-run-sdk-conformance-tests)
+        * [make clean-sdk-conformance-tests](#make-clean-sdk-conformance-tests)
         * [make test](#make-test)
         * [make push](#make-push)
         * [make install](#make-install)
@@ -429,6 +430,9 @@ Build, run and clean conformance test for a specific Agones SDK.
 #### `make run-sdk-conformance-tests`
 Run SDK conformance test.
 Run SDK server (sidecar) in test mode (which would record all GRPC requests) versus all SDK test clients which should generate those requests. All methods are verified.
+
+#### `make clean-sdk-conformance-tests`
+Clean leftover binary and package files after running SDK conformance tests.
 
 #### `make test`
 Run the linter and tests

--- a/build/build-sdk-images/node/clean.sh
+++ b/build/build-sdk-images/node/clean.sh
@@ -14,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
 rm -rf /go/src/agones.dev/agones/test/sdk/nodejs/node_modules
-rm /go/src/agones.dev/agones/test/sdk/nodejs/package-lock.json
+rm -f /go/src/agones.dev/agones/test/sdk/nodejs/package-lock.json

--- a/build/build-sdk-images/rust/clean.sh
+++ b/build/build-sdk-images/rust/clean.sh
@@ -17,5 +17,5 @@
 set -ex
 cd /go/src/agones.dev/agones/test/sdk/rust
 cargo clean
-rm /go/src/agones.dev/agones/test/sdk/rust/Cargo.lock
+rm -f /go/src/agones.dev/agones/test/sdk/rust/Cargo.lock
 rm -rf /go/src/agones.dev/agones/test/sdk/rust/target

--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -144,3 +144,8 @@ run-sdk-conformance-tests:
 	$(MAKE) run-sdk-conformance-test SDK_FOLDER=node TESTS=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
 	$(MAKE) run-sdk-conformance-test SDK_FOLDER=go TESTS=ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
 	$(MAKE) run-sdk-conformance-test SDK_FOLDER=rust
+
+# Clean package directories and binary files left
+# after building conformance tests for all SDKs supported
+clean-sdk-conformance-tests:
+	$(MAKE) run-all-sdk-command COMMAND=clean


### PR DESCRIPTION
Need to have a predefined make target to clean output
after running SDK conformance tests.

For #996 .