### PR TITLE
Refactor gameserverallocations to its components

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -71,9 +71,6 @@ const (
 	logSizeLimitMBFlag           = "log-size-limit-mb"
 	kubeconfigFlag               = "kubeconfig"
 	defaultResync                = 30 * time.Second
-	// topNGSForAllocation is used by the GameServerAllocation controller
-	// to reduce the contention while allocating gameservers.
-	topNGSForAllocation = 100
 )
 
 var (
@@ -193,8 +190,7 @@ func main() {
 	gsSetController := gameserversets.NewController(wh, health, gsCounter,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
 	fleetController := fleets.NewController(wh, health, kubeClient, extClient, agonesClient, agonesInformerFactory)
-	gasController := gameserverallocations.NewController(api, health, gsCounter, topNGSForAllocation,
-		kubeClient, kubeInformerFactory, agonesClient, agonesInformerFactory)
+	gasController := gameserverallocations.NewController(api, health, gsCounter, kubeClient, kubeInformerFactory, agonesClient, agonesInformerFactory)
 	fasController := fleetautoscalers.NewController(wh, health,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
 

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -1,0 +1,558 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameserverallocations
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
+	multiclusterv1alpha1 "agones.dev/agones/pkg/apis/multicluster/v1alpha1"
+	multiclusterinformerv1alpha1 "agones.dev/agones/pkg/client/informers/externalversions/multicluster/v1alpha1"
+	multiclusterlisterv1alpha1 "agones.dev/agones/pkg/client/listers/multicluster/v1alpha1"
+	"agones.dev/agones/pkg/util/apiserver"
+	"agones.dev/agones/pkg/util/logfields"
+	"agones.dev/agones/pkg/util/runtime"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	informercorev1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+var (
+	// ErrNoGameServerReady is returned when there are no Ready GameServers
+	// available
+	ErrNoGameServerReady = errors.New("Could not find a Ready GameServer")
+	// ErrConflictInGameServerSelection is returned when the candidate gameserver already allocated
+	ErrConflictInGameServerSelection = errors.New("The Gameserver was already allocated")
+)
+
+const (
+	secretClientCertName = "tls.crt"
+	secretClientKeyName  = "tls.key"
+	secretCaCertName     = "ca.crt"
+
+	// Instead of selecting the top one, controller selects a random one
+	// from the topNGameServerCount of Ready gameservers
+	// to reduce the contention while allocating gameservers.
+	topNGameServerDefaultCount = 100
+)
+
+const (
+	maxBatchQueue         = 100
+	maxBatchBeforeRefresh = 100
+	batchWaitTime         = 500 * time.Millisecond
+)
+
+var allocationRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// Allocator handles game server allocation
+type Allocator struct {
+	baseLogger             *logrus.Entry
+	allocationPolicyLister multiclusterlisterv1alpha1.GameServerAllocationPolicyLister
+	allocationPolicySynced cache.InformerSynced
+	secretLister           corev1lister.SecretLister
+	secretSynced           cache.InformerSynced
+	recorder               record.EventRecorder
+	pendingRequests        chan request
+	readyGameServerCache   *ReadyGameServerCache
+	topNGameServerCount    int
+}
+
+// request is an async request for allocation
+type request struct {
+	gsa      *allocationv1.GameServerAllocation
+	response chan response
+}
+
+// response is an async response for a matching request
+type response struct {
+	request request
+	gs      *agonesv1.GameServer
+	err     error
+}
+
+// NewAllocator creates an instance off Allocator
+func NewAllocator(policyInformer multiclusterinformerv1alpha1.GameServerAllocationPolicyInformer, secretInformer informercorev1.SecretInformer,
+	kubeClient kubernetes.Interface, readyGameServerCache *ReadyGameServerCache) *Allocator {
+	ah := &Allocator{
+		pendingRequests:        make(chan request, maxBatchQueue),
+		allocationPolicyLister: policyInformer.Lister(),
+		allocationPolicySynced: policyInformer.Informer().HasSynced,
+		secretLister:           secretInformer.Lister(),
+		secretSynced:           secretInformer.Informer().HasSynced,
+		readyGameServerCache:   readyGameServerCache,
+		topNGameServerCount:    topNGameServerDefaultCount,
+	}
+
+	ah.baseLogger = runtime.NewLoggerWithType(ah)
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(ah.baseLogger.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	ah.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "GameServerAllocation-Allocator"})
+
+	return ah
+}
+
+// Start initiates the listeners.
+func (c *Allocator) Start(stop <-chan struct{}) error {
+	if err := c.Sync(stop); err != nil {
+		return err
+	}
+
+	if err := c.readyGameServerCache.Start(stop); err != nil {
+		return err
+	}
+
+	// workers and logic for batching allocations
+	go c.ListenAndAllocate(maxBatchQueue, stop)
+
+	return nil
+}
+
+// Sync waits for cache to sync
+func (c *Allocator) Sync(stop <-chan struct{}) error {
+	c.baseLogger.Info("Wait for Allocator cache sync")
+	if !cache.WaitForCacheSync(stop, c.secretSynced, c.allocationPolicySynced) {
+		return errors.New("failed to wait for caches to sync")
+	}
+	return nil
+}
+
+// Allocate CRDHandler for allocating a gameserver.
+func (c *Allocator) Allocate(gsa *allocationv1.GameServerAllocation, stop <-chan struct{}) (k8sruntime.Object, error) {
+	// server side validation
+	if causes, ok := gsa.Validate(); !ok {
+		status := &metav1.Status{
+			Status:  metav1.StatusFailure,
+			Message: fmt.Sprintf("GameServerAllocation is invalid: Invalid value: %#v", gsa),
+			Reason:  metav1.StatusReasonInvalid,
+			Details: &metav1.StatusDetails{
+				Kind:   "GameServerAllocation",
+				Group:  allocationv1.SchemeGroupVersion.Group,
+				Causes: causes,
+			},
+			Code: http.StatusUnprocessableEntity,
+		}
+
+		var gvks []schema.GroupVersionKind
+		gvks, _, err := apiserver.Scheme.ObjectKinds(status)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not find objectkinds for status")
+		}
+
+		status.TypeMeta = metav1.TypeMeta{Kind: gvks[0].Kind, APIVersion: gvks[0].Version}
+		return status, nil
+	}
+
+	// If multi-cluster setting is enabled, allocate base on the multicluster allocation policy.
+	var out *allocationv1.GameServerAllocation
+	var err error
+	if gsa.Spec.MultiClusterSetting.Enabled {
+		out, err = c.applyMultiClusterAllocation(gsa, stop)
+	} else {
+		out, err = c.allocateFromLocalCluster(gsa, stop)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (c *Allocator) loggerForGameServerAllocationKey(key string) *logrus.Entry {
+	return logfields.AugmentLogEntry(c.baseLogger, logfields.GameServerAllocationKey, key)
+}
+
+func (c *Allocator) loggerForGameServerAllocation(gsa *allocationv1.GameServerAllocation) *logrus.Entry {
+	gsaName := "NilGameServerAllocation"
+	if gsa != nil {
+		gsaName = gsa.Namespace + "/" + gsa.Name
+	}
+	return c.loggerForGameServerAllocationKey(gsaName).WithField("gsa", gsa)
+}
+
+// allocateFromLocalCluster allocates gameservers from the local cluster.
+func (c *Allocator) allocateFromLocalCluster(gsa *allocationv1.GameServerAllocation, stop <-chan struct{}) (*allocationv1.GameServerAllocation, error) {
+	var gs *agonesv1.GameServer
+	err := Retry(allocationRetry, func() error {
+		var err error
+		gs, err = c.allocate(gsa, stop)
+		return err
+	})
+
+	if err != nil && err != ErrNoGameServerReady && err != ErrConflictInGameServerSelection {
+		c.readyGameServerCache.Resync()
+		return nil, err
+	}
+
+	if err == ErrNoGameServerReady {
+		gsa.Status.State = allocationv1.GameServerAllocationUnAllocated
+	} else if err == ErrConflictInGameServerSelection {
+		gsa.Status.State = allocationv1.GameServerAllocationContention
+	} else {
+		gsa.ObjectMeta.Name = gs.ObjectMeta.Name
+		gsa.Status.State = allocationv1.GameServerAllocationAllocated
+		gsa.Status.GameServerName = gs.ObjectMeta.Name
+		gsa.Status.Ports = gs.Status.Ports
+		gsa.Status.Address = gs.Status.Address
+		gsa.Status.NodeName = gs.Status.NodeName
+	}
+
+	c.loggerForGameServerAllocation(gsa).Info("game server allocation")
+	return gsa, nil
+}
+
+// applyMultiClusterAllocation retrieves allocation policies and iterate on policies.
+// Then allocate gameservers from local or remote cluster accordingly.
+func (c *Allocator) applyMultiClusterAllocation(gsa *allocationv1.GameServerAllocation, stop <-chan struct{}) (result *allocationv1.GameServerAllocation, err error) {
+	selector := labels.Everything()
+	if len(gsa.Spec.MultiClusterSetting.PolicySelector.MatchLabels)+len(gsa.Spec.MultiClusterSetting.PolicySelector.MatchExpressions) != 0 {
+		selector, err = metav1.LabelSelectorAsSelector(&gsa.Spec.MultiClusterSetting.PolicySelector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	policies, err := c.allocationPolicyLister.GameServerAllocationPolicies(gsa.ObjectMeta.Namespace).List(selector)
+	if err != nil {
+		return nil, err
+	} else if len(policies) == 0 {
+		return nil, errors.New("no multi-cluster allocation policy is specified")
+	}
+
+	it := multiclusterv1alpha1.NewConnectionInfoIterator(policies)
+	for {
+		connectionInfo := it.Next()
+		if connectionInfo == nil {
+			break
+		}
+		if connectionInfo.ClusterName == gsa.ObjectMeta.ClusterName {
+			result, err = c.allocateFromLocalCluster(gsa, stop)
+			c.baseLogger.Error(err)
+		} else {
+			result, err = c.allocateFromRemoteCluster(*gsa, connectionInfo, gsa.ObjectMeta.Namespace)
+			c.baseLogger.Error(err)
+		}
+		if result != nil {
+			return result, nil
+		}
+	}
+	return nil, err
+}
+
+// allocateFromRemoteCluster allocates gameservers from a remote cluster by making
+// an http call to allocation service in that cluster.
+func (c *Allocator) allocateFromRemoteCluster(gsa allocationv1.GameServerAllocation, connectionInfo *multiclusterv1alpha1.ClusterConnectionInfo, namespace string) (*allocationv1.GameServerAllocation, error) {
+	var gsaResult allocationv1.GameServerAllocation
+
+	// TODO: handle converting error to apiserver error
+	// TODO: cache the client
+	client, err := c.createRemoteClusterRestClient(namespace, connectionInfo.SecretName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Forward the game server allocation request to another cluster,
+	// and disable multicluster settings to avoid the target cluster
+	// forward the allocation request again.
+	gsa.Spec.MultiClusterSetting.Enabled = false
+	body, err := json.Marshal(gsa)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Retry on transient error --> response.StatusCode >= 500
+	for i, endpoint := range connectionInfo.AllocationEndpoints {
+		response, err := client.Post(endpoint, "application/json", bytes.NewBuffer(body))
+		if err != nil {
+			return nil, err
+		}
+		defer response.Body.Close() // nolint: errcheck
+
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return nil, err
+		}
+		if response.StatusCode >= 500 && (i+1) < len(connectionInfo.AllocationEndpoints) {
+			// If there is a server error try a different endpoint
+			c.baseLogger.WithError(err).WithField("endpoint", endpoint).Warn("The request sent failed, trying next endpoint")
+			continue
+		}
+		if response.StatusCode >= 400 {
+			// For error responses return the body without deserializing to an object.
+			return nil, errors.New(string(data))
+		}
+
+		err = json.Unmarshal(data, &gsaResult)
+		if err != nil {
+			return nil, err
+		}
+		break
+	}
+	return &gsaResult, nil
+}
+
+// createRemoteClusterRestClient creates a rest client with proper certs to make a remote call.
+func (c *Allocator) createRemoteClusterRestClient(namespace, secretName string) (*http.Client, error) {
+	clientCert, clientKey, caCert, err := c.getClientCertificates(namespace, secretName)
+	if err != nil {
+		return nil, err
+	}
+	if clientCert == nil || clientKey == nil {
+		return nil, fmt.Errorf("missing client certificate key pair in secret %s", secretName)
+	}
+
+	// Load client cert
+	cert, err := tls.X509KeyPair(clientCert, clientKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	if len(caCert) != 0 {
+		// Load CA cert, if provided and trust the server certificate.
+		// This is required for self-signed certs.
+		tlsConfig.RootCAs = x509.NewCertPool()
+		ca, err := x509.ParseCertificate(caCert)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs.AddCert(ca)
+	}
+
+	// Setup HTTPS client
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}
+
+// getClientCertificates returns the client certificates and CA cert for remote allocation cluster call
+func (c *Allocator) getClientCertificates(namespace, secretName string) (clientCert, clientKey, caCert []byte, err error) {
+	secret, err := c.secretLister.Secrets(namespace).Get(secretName)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if secret == nil || len(secret.Data) == 0 {
+		return nil, nil, nil, fmt.Errorf("secert %s does not have data", secretName)
+	}
+
+	// Create http client using cert
+	clientCert = secret.Data[secretClientCertName]
+	clientKey = secret.Data[secretClientKeyName]
+	caCert = secret.Data[secretCaCertName]
+	return clientCert, clientKey, caCert, nil
+}
+
+// allocate allocated a GameServer from a given GameServerAllocation
+// this sets up allocation through a batch process.
+func (c *Allocator) allocate(gsa *allocationv1.GameServerAllocation, stop <-chan struct{}) (*agonesv1.GameServer, error) {
+	// creates an allocation request. This contains the requested GameServerAllocation, as well as the
+	// channel we expect the return values to come back for this GameServerAllocation
+	req := request{gsa: gsa, response: make(chan response)}
+
+	// this pushes the request into the batching process
+	c.pendingRequests <- req
+
+	select {
+	case res := <-req.response: // wait for the batch to be completed
+		return res.gs, res.err
+	case <-stop:
+		return nil, errors.New("shutting down")
+	}
+}
+
+// ListenAndAllocate is a blocking function that runs in a loop
+// looking at c.requestBatches for batches of requests that are coming through.
+func (c *Allocator) ListenAndAllocate(updateWorkerCount int, stop <-chan struct{}) {
+	// setup workers for allocation updates. Push response values into
+	// this queue for concurrent updating of GameServers to Allocated
+	updateQueue := c.allocationUpdateWorkers(updateWorkerCount, stop)
+
+	// Batch processing strategy:
+	// We constantly loop around the below for loop. If nothing is found in c.pendingRequests, we move to
+	// default: which will wait for half a second, to allow for some requests to backup in c.pendingRequests,
+	// providing us with a batch of Allocation requests in that channel
+
+	// Once we have 1 or more requests in c.pendingRequests (which is buffered to 100), we can start the batch process.
+
+	// Assuming this is the first run (either entirely, or for a while), list will be nil, and therefore the first
+	// thing that will be done is retrieving the Ready GameSerers and sorting them for this batch via
+	// c.listSortedReadyGameServers(). This list is maintained as we flow through the batch.
+
+	// We then use findGameServerForAllocation to loop around the sorted list of Ready GameServers to look for matches
+	// against the preferred and required selectors of the GameServerAllocation. If there is an error, we immediately
+	// pass that straight back to the response channel for this GameServerAllocation.
+
+	// Assuming we find a matching GameServer to our GameServerAllocation, we remove it from the list and the backing
+	// Ready GameServer cache.
+
+	// We then pass the found GameServers into the updateQueue, where there are updateWorkerCount number of goroutines
+	// waiting to concurrently attempt to move the GameServer into an Allocated state, and return the result to
+	// GameServerAllocation request's response channel
+
+	// Then we get the next item off the batch (c.pendingRequests), and do this all over again, but this time, we have
+	// an already sorted list of GameServers, so we only need to find one that matches our GameServerAllocation
+	// selectors, and put it into updateQueue
+
+	// The tracking of requestCount >= maxBatchBeforeRefresh is necessary, because without it, at high enough load
+	// the list of GameServers that we are using to allocate would never get refreshed (list = nil) with an updated
+	// list of Ready GameServers, and you would eventually never be able to Allocate anything as long as the load
+	// continued.
+
+	var list []*agonesv1.GameServer
+	requestCount := 0
+
+	for {
+		select {
+		case req := <-c.pendingRequests:
+			// refresh the list after every 100 allocations made in a single batch
+			requestCount++
+			if requestCount >= maxBatchBeforeRefresh {
+				list = nil
+				requestCount = 0
+			}
+
+			if list == nil {
+				list = c.readyGameServerCache.ListSortedReadyGameServers()
+			}
+
+			gs, index, err := findGameServerForAllocation(req.gsa, list)
+			if err != nil {
+				req.response <- response{request: req, gs: nil, err: err}
+				continue
+			}
+			// remove the game server that has been allocated
+			list = append(list[:index], list[index+1:]...)
+
+			if err := c.readyGameServerCache.RemoveFromReadyGameServer(gs); err != nil {
+				// this seems unlikely, but lets handle it just in case
+				req.response <- response{request: req, gs: nil, err: err}
+				continue
+			}
+
+			updateQueue <- response{request: req, gs: gs.DeepCopy(), err: nil}
+
+		case <-stop:
+			return
+		default:
+			list = nil
+			requestCount = 0
+			// slow down cpu churn, and allow items to batch
+			time.Sleep(batchWaitTime)
+		}
+	}
+}
+
+// allocationUpdateWorkers runs workerCount number of goroutines as workers to
+// process each GameServer passed into the returned updateQueue
+// Each worker will concurrently attempt to move the GameServer to an Allocated
+// state and then respond to the initial request's response channel with the
+// details of that update
+func (c *Allocator) allocationUpdateWorkers(workerCount int, stop <-chan struct{}) chan<- response {
+	updateQueue := make(chan response)
+
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			for {
+				select {
+				case res := <-updateQueue:
+					gs, err := c.readyGameServerCache.PatchGameServerMetadata(res.request.gsa.Spec.MetaPatch, *res.gs)
+					if err != nil {
+						// since we could not allocate, we should put it back
+						c.readyGameServerCache.AddToReadyGameServer(gs)
+						res.err = errors.Wrap(err, "error updating allocated gameserver")
+					} else {
+						res.gs = gs
+						c.recorder.Event(res.gs, corev1.EventTypeNormal, string(res.gs.Status.State), "Allocated")
+					}
+
+					res.request.response <- res
+				case <-stop:
+					return
+				}
+			}
+		}()
+	}
+
+	return updateQueue
+}
+
+// Retry retries fn based on backoff provided.
+func Retry(backoff wait.Backoff, fn func() error) error {
+	var lastConflictErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case err == ErrNoGameServerReady:
+			return true, err
+		default:
+			lastConflictErr = err
+			return false, nil
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastConflictErr
+	}
+	return err
+}
+
+// getRandomlySelectedGS selects a GS from the set of Gameservers randomly. This will reduce the contentions
+func (c *Allocator) getRandomlySelectedGS(gsa *allocationv1.GameServerAllocation, bestGSList []agonesv1.GameServer) *agonesv1.GameServer {
+	seed, err := strconv.Atoi(gsa.ObjectMeta.ResourceVersion)
+	if err != nil {
+		seed = 1234567
+	}
+
+	ln := c.topNGameServerCount
+	if ln > len(bestGSList) {
+		ln = len(bestGSList)
+	}
+
+	startIndex := len(bestGSList) - ln
+	bestGSList = bestGSList[startIndex:]
+	index := rand.New(rand.NewSource(int64(seed))).Intn(ln)
+	return &bestGSList[index]
+}

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -15,205 +15,70 @@
 package gameserverallocations
 
 import (
-	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
-	"sort"
-	"strconv"
 	"time"
 
-	"agones.dev/agones/pkg/apis/agones"
-	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
-	multiclusterv1alpha1 "agones.dev/agones/pkg/apis/multicluster/v1alpha1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
-	getterv1 "agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1"
 	"agones.dev/agones/pkg/client/informers/externalversions"
-	listerv1 "agones.dev/agones/pkg/client/listers/agones/v1"
-	multiclusterlisterv1alpha1 "agones.dev/agones/pkg/client/listers/multicluster/v1alpha1"
 	"agones.dev/agones/pkg/gameservers"
-	"agones.dev/agones/pkg/metrics"
 	"agones.dev/agones/pkg/util/apiserver"
 	"agones.dev/agones/pkg/util/https"
-	"agones.dev/agones/pkg/util/logfields"
 	"agones.dev/agones/pkg/util/runtime"
-	"agones.dev/agones/pkg/util/workerqueue"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	corev1lister "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 )
 
-var (
-	// ErrNoGameServerReady is returned when there are no Ready GameServers
-	// available
-	ErrNoGameServerReady = errors.New("Could not find a Ready GameServer")
-	// ErrConflictInGameServerSelection is returned when the candidate gameserver already allocated
-	ErrConflictInGameServerSelection = errors.New("The Gameserver was already allocated")
-
-	keyFleetName          = metrics.MustTagKey("fleet_name")
-	keyNodeName           = metrics.MustTagKey("node_name")
-	keyClusterName        = metrics.MustTagKey("cluster_name")
-	keyMultiCluster       = metrics.MustTagKey("is_multicluster")
-	keyStatus             = metrics.MustTagKey("status")
-	keySchedulingStrategy = metrics.MustTagKey("scheduling_strategy")
-
-	gameServerAllocationsLatency = stats.Float64("gameserver_allocations/latency", "The duration of gameserver allocations", "s")
-)
-
-func init() {
-	runtime.Must(view.Register(&view.View{
-		Name:        "gameserver_allocations_duration_seconds",
-		Measure:     gameServerAllocationsLatency,
-		Description: "The distribution of gameserver allocation requests latencies.",
-		Aggregation: view.Distribution(0, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2, 3),
-		TagKeys:     []tag.Key{keyFleetName, keyNodeName, keyClusterName, keyMultiCluster, keyStatus, keySchedulingStrategy},
-	}))
-}
-
-const (
-	secretClientCertName  = "tls.crt"
-	secretClientKeyName   = "tls.key"
-	secretCaCertName      = "ca.crt"
-	maxBatchQueue         = 100
-	maxBatchBeforeRefresh = 100
-	batchWaitTime         = 500 * time.Millisecond
-)
-
-// request is an async request for allocation
-type request struct {
-	gsa      *allocationv1.GameServerAllocation
-	response chan response
-}
-
-// response is an async response for a matching request
-type response struct {
-	request request
-	gs      *agonesv1.GameServer
-	err     error
-}
-
 // Controller is a the GameServerAllocation controller
 type Controller struct {
-	baseLogger       *logrus.Entry
-	counter          *gameservers.PerNodeCounter
-	readyGameServers gameServerCacheEntry
-	// Instead of selecting the top one, controller selects a random one
-	// from the topNGameServerCount of Ready gameservers
-	topNGameServerCount    int
-	gameServerSynced       cache.InformerSynced
-	gameServerGetter       getterv1.GameServersGetter
-	gameServerLister       listerv1.GameServerLister
-	allocationPolicyLister multiclusterlisterv1alpha1.GameServerAllocationPolicyLister
-	allocationPolicySynced cache.InformerSynced
-	secretLister           corev1lister.SecretLister
-	secretSynced           cache.InformerSynced
-	stop                   <-chan struct{}
-	workerqueue            *workerqueue.WorkerQueue
-	recorder               record.EventRecorder
-	pendingRequests        chan request
-}
-
-var allocationRetry = wait.Backoff{
-	Steps:    5,
-	Duration: 10 * time.Millisecond,
-	Factor:   1.0,
-	Jitter:   0.1,
+	api        *apiserver.APIServer
+	baseLogger *logrus.Entry
+	recorder   record.EventRecorder
+	allocator  *Allocator
 }
 
 // NewController returns a controller for a GameServerAllocation
 func NewController(apiServer *apiserver.APIServer,
 	health healthcheck.Handler,
 	counter *gameservers.PerNodeCounter,
-	topNGameServerCnt int,
 	kubeClient kubernetes.Interface,
 	kubeInformerFactory informers.SharedInformerFactory,
 	agonesClient versioned.Interface,
 	agonesInformerFactory externalversions.SharedInformerFactory,
 ) *Controller {
-
-	agonesInformer := agonesInformerFactory.Agones().V1()
 	c := &Controller{
-		counter:                counter,
-		topNGameServerCount:    topNGameServerCnt,
-		gameServerSynced:       agonesInformer.GameServers().Informer().HasSynced,
-		gameServerGetter:       agonesClient.AgonesV1(),
-		gameServerLister:       agonesInformer.GameServers().Lister(),
-		allocationPolicyLister: agonesInformerFactory.Multicluster().V1alpha1().GameServerAllocationPolicies().Lister(),
-		allocationPolicySynced: agonesInformerFactory.Multicluster().V1alpha1().GameServerAllocationPolicies().Informer().HasSynced,
-		secretLister:           kubeInformerFactory.Core().V1().Secrets().Lister(),
-		secretSynced:           kubeInformerFactory.Core().V1().Secrets().Informer().HasSynced,
-		pendingRequests:        make(chan request, maxBatchQueue),
+		api: apiServer,
+		allocator: NewAllocator(
+			agonesInformerFactory.Multicluster().V1alpha1().GameServerAllocationPolicies(),
+			kubeInformerFactory.Core().V1().Secrets(),
+			kubeClient,
+			NewReadyGameServerCache(agonesInformerFactory.Agones().V1().GameServers(), agonesClient.AgonesV1(), counter, health)),
 	}
 	c.baseLogger = runtime.NewLoggerWithType(c)
-	c.workerqueue = workerqueue.NewWorkerQueue(c.syncGameServers, c.baseLogger, logfields.GameServerKey, agones.GroupName+".GameServerUpdateController")
-	health.AddLivenessCheck("gameserverallocation-gameserver-workerqueue", healthcheck.Check(c.workerqueue.Healthy))
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(c.baseLogger.Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	c.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "GameServerAllocation-controller"})
 
-	c.registerAPIResource(apiServer)
-
-	agonesInformer.GameServers().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			// only interested in if the old / new state was/is Ready
-			oldGs := oldObj.(*agonesv1.GameServer)
-			newGs := newObj.(*agonesv1.GameServer)
-			key, ok := c.getKey(newGs)
-			if !ok {
-				return
-			}
-			if newGs.IsBeingDeleted() {
-				c.readyGameServers.Delete(key)
-			} else if oldGs.Status.State == agonesv1.GameServerStateReady || newGs.Status.State == agonesv1.GameServerStateReady {
-				if newGs.Status.State == agonesv1.GameServerStateReady {
-					c.readyGameServers.Store(key, newGs)
-				} else {
-					c.readyGameServers.Delete(key)
-				}
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			gs, ok := obj.(*agonesv1.GameServer)
-			if !ok {
-				return
-			}
-			var key string
-			if key, ok = c.getKey(gs); ok {
-				c.readyGameServers.Delete(key)
-			}
-		},
-	})
-
 	return c
 }
 
 // registers the api resource for gameserverallocation
-func (c *Controller) registerAPIResource(api *apiserver.APIServer) {
+func (c *Controller) registerAPIResource(stop <-chan struct{}) {
 	resource := metav1.APIResource{
 		Name:         "gameserverallocations",
 		SingularName: "gameserverallocation",
@@ -224,54 +89,25 @@ func (c *Controller) registerAPIResource(api *apiserver.APIServer) {
 		},
 		ShortNames: []string{"gsa"},
 	}
-	api.AddAPIResource(allocationv1.SchemeGroupVersion.String(), resource, c.allocationHandler)
+	c.api.AddAPIResource(allocationv1.SchemeGroupVersion.String(), resource, func(w http.ResponseWriter, r *http.Request, n string) error {
+		return c.processAllocationRequest(w, r, n, stop)
+	})
 }
 
 // Run runs this controller. Will block until stop is closed.
 // Ignores threadiness, as we only needs 1 worker for cache sync
 func (c *Controller) Run(_ int, stop <-chan struct{}) error {
-	c.stop = stop
-	c.baseLogger.Info("Wait for cache sync")
-	if !cache.WaitForCacheSync(stop, c.gameServerSynced, c.secretSynced, c.allocationPolicySynced) {
-		return errors.New("failed to wait for caches to sync")
-	}
-
-	// build the cache
-	err := c.syncReadyGSServerCache()
-	if err != nil {
+	if err := c.allocator.Start(stop); err != nil {
 		return err
 	}
 
-	// workers and logic for batching allocations
-	go c.runLocalAllocations(maxBatchQueue)
-
-	// we don't want mutiple workers refresh cache at the same time so one worker will be better.
-	// Also we don't expect to have too many failures when allocating
-	c.workerqueue.Run(1, stop)
+	c.registerAPIResource(stop)
 
 	return nil
 }
 
-func (c *Controller) loggerForGameServerKey(key string) *logrus.Entry {
-	return logfields.AugmentLogEntry(c.baseLogger, logfields.GameServerKey, key)
-}
-
-func (c *Controller) loggerForGameServerAllocationKey(key string) *logrus.Entry {
-	return logfields.AugmentLogEntry(c.baseLogger, logfields.GameServerAllocationKey, key)
-}
-
-func (c *Controller) loggerForGameServerAllocation(gsa *allocationv1.GameServerAllocation) *logrus.Entry {
-	gsaName := "NilGameServerAllocation"
-	if gsa != nil {
-		gsaName = gsa.Namespace + "/" + gsa.Name
-	}
-	return c.loggerForGameServerAllocationKey(gsaName).WithField("gsa", gsa)
-}
-
-// allocationHandler CRDHandler for allocating a gameserver. Only accepts POST
-// commands
-func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, namespace string) (err error) {
-	latency := c.newLatencyRecorder(r.Context())
+func (c *Controller) processAllocationRequest(w http.ResponseWriter, r *http.Request, namespace string, stop <-chan struct{}) (err error) {
+	latency := c.newMetrics(r.Context())
 	defer func() {
 		if err != nil {
 			latency.setError()
@@ -291,322 +127,39 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 		latency.setError()
 		return
 	}
-	var gsa *allocationv1.GameServerAllocation
-	gsa, err = c.allocationDeserialization(r, namespace)
+
+	gsa, err := c.allocationDeserialization(r, namespace)
 	if err != nil {
 		return err
 	}
 
-	// server side validation
-	if causes, ok := gsa.Validate(); !ok {
-		status := &metav1.Status{
-			Status:  metav1.StatusFailure,
-			Message: fmt.Sprintf("GameServerAllocation is invalid: Invalid value: %#v", gsa),
-			Reason:  metav1.StatusReasonInvalid,
-			Details: &metav1.StatusDetails{
-				Kind:   "GameServerAllocation",
-				Group:  allocationv1.SchemeGroupVersion.Group,
-				Causes: causes,
-			},
-			Code: http.StatusUnprocessableEntity,
-		}
-
-		var gvks []schema.GroupVersionKind
-		gvks, _, err = apiserver.Scheme.ObjectKinds(status)
-		if err != nil {
-			err = errors.Wrap(err, "could not find objectkinds for status")
-		}
-
-		status.TypeMeta = metav1.TypeMeta{Kind: gvks[0].Kind, APIVersion: gvks[0].Version}
-
-		w.WriteHeader(http.StatusUnprocessableEntity)
-		err = c.serialisation(r, w, status, apiserver.Codecs)
-		return
-	}
 	latency.setRequest(gsa)
-	// If multi-cluster setting is enabled, allocate base on the multicluster allocation policy.
-	var out *allocationv1.GameServerAllocation
-	if gsa.Spec.MultiClusterSetting.Enabled {
-		out, err = c.applyMultiClusterAllocation(gsa)
-	} else {
-		out, err = c.allocateFromLocalCluster(gsa)
-	}
 
+	result, err := c.allocator.Allocate(gsa, stop)
 	if err != nil {
 		return err
 	}
-	latency.setResponse(out)
-	err = c.serialisation(r, w, out, scheme.Codecs)
+	if status, ok := result.(*metav1.Status); ok {
+		w.WriteHeader(int(status.Code))
+	}
+
+	latency.setResponse(result)
+	err = c.serialisation(r, w, result, scheme.Codecs)
 	return err
 }
 
-// default set of tags for latency metric
-var latencyTags = []tag.Mutator{
-	tag.Insert(keyMultiCluster, "none"),
-	tag.Insert(keyClusterName, "none"),
-	tag.Insert(keySchedulingStrategy, "none"),
-	tag.Insert(keyFleetName, "none"),
-	tag.Insert(keyNodeName, "none"),
-	tag.Insert(keyStatus, "none"),
-}
-
-type latencyRecorder struct {
-	ctx              context.Context
-	gameServerLister listerv1.GameServerLister
-	logger           *logrus.Entry
-	start            time.Time
-}
-
-// newLatencyRecorder creates a new gsa latency recorder.
-func (c *Controller) newLatencyRecorder(ctx context.Context) *latencyRecorder {
+// newMetrics creates a new gsa latency recorder.
+func (c *Controller) newMetrics(ctx context.Context) *metrics {
 	ctx, err := tag.New(ctx, latencyTags...)
 	if err != nil {
 		c.baseLogger.WithError(err).Warn("failed to tag latency recorder.")
 	}
-	return &latencyRecorder{
+	return &metrics{
 		ctx:              ctx,
-		gameServerLister: c.gameServerLister,
+		gameServerLister: c.allocator.readyGameServerCache.gameServerLister,
 		logger:           c.baseLogger,
 		start:            time.Now(),
 	}
-}
-
-// mutate the current set of metric tags
-func (r *latencyRecorder) mutate(m ...tag.Mutator) {
-	var err error
-	r.ctx, err = tag.New(r.ctx, m...)
-	if err != nil {
-		r.logger.WithError(err).Warn("failed to mutate request context.")
-	}
-}
-
-// setStatus set the latency status tag.
-func (r *latencyRecorder) setStatus(status string) {
-	r.mutate(tag.Update(keyStatus, status))
-}
-
-// setError set the latency status tag as error.
-func (r *latencyRecorder) setError() {
-	r.mutate(tag.Update(keyStatus, "error"))
-}
-
-// setRequest set request metric tags.
-func (r *latencyRecorder) setRequest(in *allocationv1.GameServerAllocation) {
-	tags := []tag.Mutator{
-		tag.Update(keySchedulingStrategy, string(in.Spec.Scheduling)),
-	}
-	if in.ClusterName != "" {
-		tags = append(tags, tag.Update(keyClusterName, in.ClusterName))
-	}
-	tags = append(tags, tag.Update(keyMultiCluster, strconv.FormatBool(in.Spec.MultiClusterSetting.Enabled)))
-	r.mutate(tags...)
-}
-
-// setResponse set response metric tags.
-func (r *latencyRecorder) setResponse(out *allocationv1.GameServerAllocation) {
-	if out == nil {
-		return
-	}
-	r.setStatus(string(out.Status.State))
-	var tags []tag.Mutator
-	if out.Status.NodeName != "" {
-		tags = append(tags, tag.Update(keyNodeName, out.Status.NodeName))
-	}
-	// sets the fleet name tag if possible
-	if out.Status.State == allocationv1.GameServerAllocationAllocated {
-		gs, err := r.gameServerLister.GameServers(out.Namespace).Get(out.Status.GameServerName)
-		if err != nil {
-			r.logger.WithError(err).Warnf("failed to get gameserver:%s namespace:%s", out.Status.GameServerName, out.Namespace)
-		}
-		fleetName := gs.Labels[agonesv1.FleetNameLabel]
-		if fleetName != "" {
-			tags = append(tags, tag.Update(keyFleetName, fleetName))
-		}
-	}
-	r.mutate(tags...)
-}
-
-// record the current allocation latency.
-func (r *latencyRecorder) record() {
-	stats.Record(r.ctx, gameServerAllocationsLatency.M(time.Since(r.start).Seconds()))
-}
-
-// allocateFromLocalCluster allocates gameservers from the local cluster.
-func (c *Controller) allocateFromLocalCluster(gsa *allocationv1.GameServerAllocation) (*allocationv1.GameServerAllocation, error) {
-	var gs *agonesv1.GameServer
-	err := Retry(allocationRetry, func() error {
-		var err error
-		gs, err = c.allocate(gsa)
-		return err
-	})
-
-	if err != nil && err != ErrNoGameServerReady && err != ErrConflictInGameServerSelection {
-		// this will trigger syncing of the cache (assuming cache might not be up to date)
-		c.workerqueue.EnqueueImmediately(gs)
-		return nil, err
-	}
-
-	if err == ErrNoGameServerReady {
-		gsa.Status.State = allocationv1.GameServerAllocationUnAllocated
-	} else if err == ErrConflictInGameServerSelection {
-		gsa.Status.State = allocationv1.GameServerAllocationContention
-	} else {
-		gsa.ObjectMeta.Name = gs.ObjectMeta.Name
-		gsa.Status.State = allocationv1.GameServerAllocationAllocated
-		gsa.Status.GameServerName = gs.ObjectMeta.Name
-		gsa.Status.Ports = gs.Status.Ports
-		gsa.Status.Address = gs.Status.Address
-		gsa.Status.NodeName = gs.Status.NodeName
-	}
-
-	c.loggerForGameServerAllocation(gsa).Info("game server allocation")
-	return gsa, nil
-}
-
-// applyMultiClusterAllocation retrieves allocation policies and iterate on policies.
-// Then allocate gameservers from local or remote cluster accordingly.
-func (c *Controller) applyMultiClusterAllocation(gsa *allocationv1.GameServerAllocation) (result *allocationv1.GameServerAllocation, err error) {
-
-	selector := labels.Everything()
-	if len(gsa.Spec.MultiClusterSetting.PolicySelector.MatchLabels)+len(gsa.Spec.MultiClusterSetting.PolicySelector.MatchExpressions) != 0 {
-		selector, err = metav1.LabelSelectorAsSelector(&gsa.Spec.MultiClusterSetting.PolicySelector)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	policies, err := c.allocationPolicyLister.GameServerAllocationPolicies(gsa.ObjectMeta.Namespace).List(selector)
-	if err != nil {
-		return nil, err
-	} else if len(policies) == 0 {
-		return nil, errors.New("no multi-cluster allocation policy is specified")
-	}
-
-	it := multiclusterv1alpha1.NewConnectionInfoIterator(policies)
-	for {
-		connectionInfo := it.Next()
-		if connectionInfo == nil {
-			break
-		}
-		if connectionInfo.ClusterName == gsa.ObjectMeta.ClusterName {
-			result, err = c.allocateFromLocalCluster(gsa)
-			c.baseLogger.Error(err)
-		} else {
-			result, err = c.allocateFromRemoteCluster(*gsa, connectionInfo, gsa.ObjectMeta.Namespace)
-			c.baseLogger.Error(err)
-		}
-		if result != nil {
-			return result, nil
-		}
-	}
-	return nil, err
-}
-
-// allocateFromRemoteCluster allocates gameservers from a remote cluster by making
-// an http call to allocation service in that cluster.
-func (c *Controller) allocateFromRemoteCluster(gsa allocationv1.GameServerAllocation, connectionInfo *multiclusterv1alpha1.ClusterConnectionInfo, namespace string) (*allocationv1.GameServerAllocation, error) {
-	var gsaResult allocationv1.GameServerAllocation
-
-	// TODO: handle converting error to apiserver error
-	// TODO: cache the client
-	// TODO: instrument client with trace and stats from OpenCensus.
-	// https://github.com/census-instrumentation/opencensus-go/blob/master/plugin/ochttp/client.go
-	client, err := c.createRemoteClusterRestClient(namespace, connectionInfo.SecretName)
-	if err != nil {
-		return nil, err
-	}
-
-	// Forward the game server allocation request to another cluster,
-	// and disable multicluster settings to avoid the target cluster
-	// forward the allocation request again.
-	gsa.Spec.MultiClusterSetting.Enabled = false
-	body, err := json.Marshal(gsa)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Retry on transient error --> response.StatusCode >= 500
-	for i, endpoint := range connectionInfo.AllocationEndpoints {
-		response, err := client.Post(endpoint, "application/json", bytes.NewBuffer(body))
-		if err != nil {
-			return nil, err
-		}
-		defer response.Body.Close() // nolint: errcheck
-
-		data, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			return nil, err
-		}
-		if response.StatusCode >= 500 && (i+1) < len(connectionInfo.AllocationEndpoints) {
-			// If there is a server error try a different endpoint
-			c.baseLogger.WithError(err).WithField("endpoint", endpoint).Warn("The request sent failed, trying next endpoint")
-			continue
-		}
-		if response.StatusCode >= 400 {
-			// For error responses return the body without deserializing to an object.
-			return nil, errors.New(string(data))
-		}
-
-		err = json.Unmarshal(data, &gsaResult)
-		if err != nil {
-			return nil, err
-		}
-		break
-	}
-	return &gsaResult, nil
-}
-
-// createRemoteClusterRestClient creates a rest client with proper certs to make a remote call.
-func (c *Controller) createRemoteClusterRestClient(namespace, secretName string) (*http.Client, error) {
-	clientCert, clientKey, caCert, err := c.getClientCertificates(namespace, secretName)
-	if err != nil {
-		return nil, err
-	}
-	if clientCert == nil || clientKey == nil {
-		return nil, fmt.Errorf("missing client certificate key pair in secret %s", secretName)
-	}
-
-	// Load client cert
-	cert, err := tls.X509KeyPair(clientCert, clientKey)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
-	if len(caCert) != 0 {
-		// Load CA cert, if provided and trust the server certificate.
-		// This is required for self-signed certs.
-		tlsConfig.RootCAs = x509.NewCertPool()
-		ca, err := x509.ParseCertificate(caCert)
-		if err != nil {
-			return nil, err
-		}
-		tlsConfig.RootCAs.AddCert(ca)
-	}
-
-	// Setup HTTPS client
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}, nil
-}
-
-// getClientCertificates returns the client certificates and CA cert for remote allocation cluster call
-func (c *Controller) getClientCertificates(namespace, secretName string) (clientCert, clientKey, caCert []byte, err error) {
-	secret, err := c.secretLister.Secrets(namespace).Get(secretName)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if secret == nil || len(secret.Data) == 0 {
-		return nil, nil, nil, fmt.Errorf("secert %s does not have data", secretName)
-	}
-
-	// Create http client using cert
-	clientCert = secret.Data[secretClientCertName]
-	clientKey = secret.Data[secretClientKeyName]
-	caCert = secret.Data[secretCaCertName]
-	return clientCert, clientKey, caCert, nil
 }
 
 // allocationDeserialization processes the request and namespace, and attempts to deserialise its values
@@ -656,328 +209,4 @@ func (c *Controller) serialisation(r *http.Request, w http.ResponseWriter, obj k
 	w.Header().Set("Content-Type", info.MediaType)
 	err = info.Serializer.Encode(obj, w)
 	return errors.Wrapf(err, "error encoding %T", obj)
-}
-
-// allocate allocated a GameServer from a given GameServerAllocation
-// this sets up allocation through a batch process.
-func (c *Controller) allocate(gsa *allocationv1.GameServerAllocation) (*agonesv1.GameServer, error) {
-	// creates an allocation request. This contains the requested GameServerAllocation, as well as the
-	// channel we expect the return values to come back for this GameServerAllocation
-	req := request{gsa: gsa, response: make(chan response)}
-
-	// this pushes the request into the batching process
-	c.pendingRequests <- req
-
-	select {
-	case res := <-req.response: // wait for the batch to be completed
-		return res.gs, res.err
-	case <-c.stop:
-		return nil, errors.New("shutting down")
-	}
-}
-
-// runLocalAllocations is a blocking function that runs in a loop
-// looking at c.requestBatches for batches of requests that are coming through.
-func (c *Controller) runLocalAllocations(updateWorkerCount int) {
-	// setup workers for allocation updates. Push response values into
-	// this queue for concurrent updating of GameServers to Allocated
-	updateQueue := c.allocationUpdateWorkers(updateWorkerCount)
-
-	// Batch processing strategy:
-	// We constantly loop around the below for loop. If nothing is found in c.pendingRequests, we move to
-	// default: which will wait for half a second, to allow for some requests to backup in c.pendingRequests,
-	// providing us with a batch of Allocation requests in that channel
-
-	// Once we have 1 or more requests in c.pendingRequests (which is buffered to 100), we can start the batch process.
-
-	// Assuming this is the first run (either entirely, or for a while), list will be nil, and therefore the first
-	// thing that will be done is retrieving the Ready GameSerers and sorting them for this batch via
-	// c.listSortedReadyGameServers(). This list is maintained as we flow through the batch.
-
-	// We then use findGameServerForAllocation to loop around the sorted list of Ready GameServers to look for matches
-	// against the preferred and required selectors of the GameServerAllocation. If there is an error, we immediately
-	// pass that straight back to the response channel for this GameServerAllocation.
-
-	// Assuming we find a matching GameServer to our GameServerAllocation, we remove it from the list and the backing
-	// Ready GameServer cache.
-
-	// We then pass the found GameServers into the updateQueue, where there are updateWorkerCount number of goroutines
-	// waiting to concurrently attempt to move the GameServer into an Allocated state, and return the result to
-	// GameServerAllocation request's response channel
-
-	// Then we get the next item off the batch (c.pendingRequests), and do this all over again, but this time, we have
-	// an already sorted list of GameServers, so we only need to find one that matches our GameServerAllocation
-	// selectors, and put it into updateQueue
-
-	// The tracking of requestCount >= maxBatchBeforeRefresh is necessary, because without it, at high enough load
-	// the list of GameServers that we are using to allocate would never get refreshed (list = nil) with an updated
-	// list of Ready GameServers, and you would eventually never be able to Allocate anything as long as the load
-	// continued.
-
-	var list []*agonesv1.GameServer
-	requestCount := 0
-
-	for {
-		select {
-		case req := <-c.pendingRequests:
-			// refresh the list after every 100 allocations made in a single batch
-			requestCount++
-			if requestCount >= maxBatchBeforeRefresh {
-				list = nil
-				requestCount = 0
-			}
-
-			if list == nil {
-				list = c.listSortedReadyGameServers()
-			}
-
-			gs, index, err := findGameServerForAllocation(req.gsa, list)
-			if err != nil {
-				req.response <- response{request: req, gs: nil, err: err}
-				continue
-			}
-			// remove the game server that has been allocated
-			list = append(list[:index], list[index+1:]...)
-
-			key, _ := cache.MetaNamespaceKeyFunc(gs)
-			if ok := c.readyGameServers.Delete(key); !ok {
-				// this seems unlikely, but lets handle it just in case
-				req.response <- response{request: req, gs: nil, err: ErrConflictInGameServerSelection}
-				continue
-			}
-
-			updateQueue <- response{request: req, gs: gs.DeepCopy(), err: nil}
-
-		case <-c.stop:
-			return
-		default:
-			list = nil
-			requestCount = 0
-			// slow down cpu churn, and allow items to batch
-			time.Sleep(batchWaitTime)
-		}
-	}
-}
-
-// allocationUpdateWorkers runs workerCount number of goroutines as workers to
-// process each GameServer passed into the returned updateQueue
-// Each worker will concurrently attempt to move the GameServer to an Allocated
-// state and then respond to the initial request's response channel with the
-// details of that update
-func (c *Controller) allocationUpdateWorkers(workerCount int) chan<- response {
-	updateQueue := make(chan response)
-
-	for i := 0; i < workerCount; i++ {
-		go func() {
-			for {
-				select {
-				case res := <-updateQueue:
-					gsCopy := res.gs.DeepCopy()
-					c.patchMetadata(gsCopy, res.request.gsa.Spec.MetaPatch)
-					gsCopy.Status.State = agonesv1.GameServerStateAllocated
-
-					gs, err := c.gameServerGetter.GameServers(res.gs.ObjectMeta.Namespace).Update(gsCopy)
-					if err != nil {
-						key, _ := cache.MetaNamespaceKeyFunc(gs)
-						// since we could not allocate, we should put it back
-						c.readyGameServers.Store(key, gs)
-						res.err = errors.Wrap(err, "error updating allocated gameserver")
-					} else {
-						res.gs = gs
-						c.recorder.Event(res.gs, corev1.EventTypeNormal, string(res.gs.Status.State), "Allocated")
-					}
-
-					res.request.response <- res
-				case <-c.stop:
-					return
-				}
-			}
-		}()
-	}
-
-	return updateQueue
-}
-
-// listSortedReadyGameServers returns a list of the cache ready gameservers
-// sorted by most allocated to least
-func (c *Controller) listSortedReadyGameServers() []*agonesv1.GameServer {
-	length := c.readyGameServers.Len()
-	if length == 0 {
-		return []*agonesv1.GameServer{}
-	}
-
-	list := make([]*agonesv1.GameServer, 0, length)
-	c.readyGameServers.Range(func(_ string, gs *agonesv1.GameServer) bool {
-		list = append(list, gs)
-		return true
-	})
-	counts := c.counter.Counts()
-
-	sort.Slice(list, func(i, j int) bool {
-		gs1 := list[i]
-		gs2 := list[j]
-
-		c1, ok := counts[gs1.Status.NodeName]
-		if !ok {
-			return false
-		}
-
-		c2, ok := counts[gs2.Status.NodeName]
-		if !ok {
-			return true
-		}
-
-		if c1.Allocated > c2.Allocated {
-			return true
-		}
-		if c1.Allocated < c2.Allocated {
-			return false
-		}
-
-		// prefer nodes that have the most Ready gameservers on them - they are most likely to be
-		// completely filled and least likely target for scale down.
-		if c1.Ready < c2.Ready {
-			return false
-		}
-		if c1.Ready > c2.Ready {
-			return true
-		}
-
-		// finally sort lexicographically, so we have a stable order
-		return gs1.Status.NodeName < gs2.Status.NodeName
-	})
-
-	return list
-}
-
-// patch the labels and annotations of an allocated GameServer with metadata from a GameServerAllocation
-func (c *Controller) patchMetadata(gs *agonesv1.GameServer, fam allocationv1.MetaPatch) {
-	// patch ObjectMeta labels
-	if fam.Labels != nil {
-		if gs.ObjectMeta.Labels == nil {
-			gs.ObjectMeta.Labels = make(map[string]string, len(fam.Labels))
-		}
-		for key, value := range fam.Labels {
-			gs.ObjectMeta.Labels[key] = value
-		}
-	}
-	// apply annotations patch
-	if fam.Annotations != nil {
-		if gs.ObjectMeta.Annotations == nil {
-			gs.ObjectMeta.Annotations = make(map[string]string, len(fam.Annotations))
-		}
-		for key, value := range fam.Annotations {
-			gs.ObjectMeta.Annotations[key] = value
-		}
-	}
-}
-
-// syncGameServers synchronises the GameServers to Gameserver cache. This is called when a failure
-// happened during the allocation. This method will sync and make sure the cache is up to date.
-func (c *Controller) syncGameServers(key string) error {
-	c.loggerForGameServerKey(key).Info("Refreshing Ready Gameserver cache")
-
-	return c.syncReadyGSServerCache()
-}
-
-// syncReadyGSServerCache syncs the gameserver cache and updates the local cache for any changes.
-func (c *Controller) syncReadyGSServerCache() error {
-	c.baseLogger.Info("Wait for cache sync")
-	if !cache.WaitForCacheSync(c.stop, c.gameServerSynced) {
-		return errors.New("failed to wait for cache to sync")
-	}
-
-	// build the cache
-	gsList, err := c.gameServerLister.List(labels.Everything())
-	if err != nil {
-		return errors.Wrap(err, "could not list GameServers")
-	}
-
-	// convert list of current gameservers to map for faster access
-	currGameservers := make(map[string]*agonesv1.GameServer)
-	for _, gs := range gsList {
-		if key, ok := c.getKey(gs); ok {
-			currGameservers[key] = gs
-		}
-	}
-
-	// first remove the gameservers are not in the list anymore
-	tobeDeletedGSInCache := make([]string, 0)
-	c.readyGameServers.Range(func(key string, gs *agonesv1.GameServer) bool {
-		if _, ok := currGameservers[key]; !ok {
-			tobeDeletedGSInCache = append(tobeDeletedGSInCache, key)
-		}
-		return true
-	})
-
-	for _, staleGSKey := range tobeDeletedGSInCache {
-		c.readyGameServers.Delete(staleGSKey)
-	}
-
-	// refresh the cache of possible allocatable GameServers
-	for key, gs := range currGameservers {
-		if gsCache, ok := c.readyGameServers.Load(key); ok {
-			if !(gs.DeletionTimestamp.IsZero() && gs.Status.State == agonesv1.GameServerStateReady) {
-				c.readyGameServers.Delete(key)
-			} else if gs.ObjectMeta.ResourceVersion != gsCache.ObjectMeta.ResourceVersion {
-				c.readyGameServers.Store(key, gs)
-			}
-		} else if gs.DeletionTimestamp.IsZero() && gs.Status.State == agonesv1.GameServerStateReady {
-			c.readyGameServers.Store(key, gs)
-		}
-	}
-
-	return nil
-}
-
-// getKey extract the key of gameserver object
-func (c *Controller) getKey(gs *agonesv1.GameServer) (string, bool) {
-	var key string
-	ok := true
-	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(gs); err != nil {
-		ok = false
-		err = errors.Wrap(err, "Error creating key for object")
-		runtime.HandleError(c.baseLogger.WithField("obj", gs), err)
-	}
-	return key, ok
-}
-
-// Retry retries fn based on backoff provided.
-func Retry(backoff wait.Backoff, fn func() error) error {
-	var lastConflictErr error
-	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		err := fn()
-		switch {
-		case err == nil:
-			return true, nil
-		case err == ErrNoGameServerReady:
-			return true, err
-		default:
-			lastConflictErr = err
-			return false, nil
-		}
-	})
-	if err == wait.ErrWaitTimeout {
-		err = lastConflictErr
-	}
-	return err
-}
-
-// getRandomlySelectedGS selects a GS from the set of Gameservers randomly. This will reduce the contentions
-func (c *Controller) getRandomlySelectedGS(gsa *allocationv1.GameServerAllocation, bestGSList []agonesv1.GameServer) *agonesv1.GameServer {
-	seed, err := strconv.Atoi(gsa.ObjectMeta.ResourceVersion)
-	if err != nil {
-		seed = 1234567
-	}
-
-	ln := c.topNGameServerCount
-	if ln > len(bestGSList) {
-		ln = len(bestGSList)
-	}
-
-	startIndex := len(bestGSList) - ln
-	bestGSList = bestGSList[startIndex:]
-	index := rand.New(rand.NewSource(int64(seed))).Intn(ln)
-	return &bestGSList[index]
 }

--- a/pkg/gameserverallocations/find_test.go
+++ b/pkg/gameserverallocations/find_test.go
@@ -160,7 +160,8 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 
 	for k, v := range fixtures {
 		t.Run(k, func(t *testing.T) {
-			c, m := newFakeController()
+			controller, m := newFakeController()
+			c := controller.allocator.readyGameServerCache
 
 			m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 				return true, &agonesv1.GameServerList{Items: v.list}, nil
@@ -176,7 +177,7 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 			err = c.counter.Run(0, stop)
 			assert.Nil(t, err)
 
-			list := c.listSortedReadyGameServers()
+			list := c.ListSortedReadyGameServers()
 			v.test(t, list)
 		})
 	}
@@ -185,7 +186,8 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 func TestFindGameServerForAllocationDistributed(t *testing.T) {
 	t.Parallel()
 
-	c, m := newFakeController()
+	controller, m := newFakeController()
+	c := controller.allocator.readyGameServerCache
 	labels := map[string]string{"role": "gameserver"}
 
 	gsa := &allocationv1.GameServerAllocation{
@@ -229,7 +231,7 @@ func TestFindGameServerForAllocationDistributed(t *testing.T) {
 	err = c.counter.Run(0, stop)
 	assert.Nil(t, err)
 
-	list := c.listSortedReadyGameServers()
+	list := c.ListSortedReadyGameServers()
 	assert.Len(t, list, 6)
 
 	gs, index, err := findGameServerForAllocation(gsa, list)

--- a/pkg/gameserverallocations/metrics.go
+++ b/pkg/gameserverallocations/metrics.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameserverallocations
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
+	listerv1 "agones.dev/agones/pkg/client/listers/agones/v1"
+	mt "agones.dev/agones/pkg/metrics"
+	"agones.dev/agones/pkg/util/runtime"
+	"github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	keyFleetName          = mt.MustTagKey("fleet_name")
+	keyNodeName           = mt.MustTagKey("node_name")
+	keyClusterName        = mt.MustTagKey("cluster_name")
+	keyMultiCluster       = mt.MustTagKey("is_multicluster")
+	keyStatus             = mt.MustTagKey("status")
+	keySchedulingStrategy = mt.MustTagKey("scheduling_strategy")
+
+	gameServerAllocationsLatency = stats.Float64("gameserver_allocations/latency", "The duration of gameserver allocations", "s")
+)
+
+func init() {
+	runtime.Must(view.Register(&view.View{
+		Name:        "gameserver_allocations_duration_seconds",
+		Measure:     gameServerAllocationsLatency,
+		Description: "The distribution of gameserver allocation requests latencies.",
+		Aggregation: view.Distribution(0, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2, 3),
+		TagKeys:     []tag.Key{keyFleetName, keyNodeName, keyClusterName, keyMultiCluster, keyStatus, keySchedulingStrategy},
+	}))
+}
+
+// default set of tags for latency metric
+var latencyTags = []tag.Mutator{
+	tag.Insert(keyMultiCluster, "none"),
+	tag.Insert(keyClusterName, "none"),
+	tag.Insert(keySchedulingStrategy, "none"),
+	tag.Insert(keyFleetName, "none"),
+	tag.Insert(keyNodeName, "none"),
+	tag.Insert(keyStatus, "none"),
+}
+
+type metrics struct {
+	ctx              context.Context
+	gameServerLister listerv1.GameServerLister
+	logger           *logrus.Entry
+	start            time.Time
+}
+
+// mutate the current set of metric tags
+func (r *metrics) mutate(m ...tag.Mutator) {
+	var err error
+	r.ctx, err = tag.New(r.ctx, m...)
+	if err != nil {
+		r.logger.WithError(err).Warn("failed to mutate request context.")
+	}
+}
+
+// setStatus set the latency status tag.
+func (r *metrics) setStatus(status string) {
+	r.mutate(tag.Update(keyStatus, status))
+}
+
+// setError set the latency status tag as error.
+func (r *metrics) setError() {
+	r.mutate(tag.Update(keyStatus, "error"))
+}
+
+// setRequest set request metric tags.
+func (r *metrics) setRequest(in *allocationv1.GameServerAllocation) {
+	tags := []tag.Mutator{
+		tag.Update(keySchedulingStrategy, string(in.Spec.Scheduling)),
+	}
+	if in.ClusterName != "" {
+		tags = append(tags, tag.Update(keyClusterName, in.ClusterName))
+	}
+	tags = append(tags, tag.Update(keyMultiCluster, strconv.FormatBool(in.Spec.MultiClusterSetting.Enabled)))
+	r.mutate(tags...)
+}
+
+// setResponse set response metric tags.
+func (r *metrics) setResponse(o k8sruntime.Object) {
+	out, ok := o.(*allocationv1.GameServerAllocation)
+	if out == nil || !ok {
+		return
+	}
+	r.setStatus(string(out.Status.State))
+	var tags []tag.Mutator
+	if out.Status.NodeName != "" {
+		tags = append(tags, tag.Update(keyNodeName, out.Status.NodeName))
+	}
+	// sets the fleet name tag if possible
+	if out.Status.State == allocationv1.GameServerAllocationAllocated {
+		gs, err := r.gameServerLister.GameServers(out.Namespace).Get(out.Status.GameServerName)
+		if err != nil {
+			r.logger.WithError(err).Warnf("failed to get gameserver:%s namespace:%s", out.Status.GameServerName, out.Namespace)
+		}
+		fleetName := gs.Labels[agonesv1.FleetNameLabel]
+		if fleetName != "" {
+			tags = append(tags, tag.Update(keyFleetName, fleetName))
+		}
+	}
+	r.mutate(tags...)
+}
+
+// record the current allocation latency.
+func (r *metrics) record() {
+	stats.Record(r.ctx, gameServerAllocationsLatency.M(time.Since(r.start).Seconds()))
+}

--- a/pkg/gameserverallocations/ready_cache.go
+++ b/pkg/gameserverallocations/ready_cache.go
@@ -1,0 +1,298 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameserverallocations
+
+import (
+	"sort"
+
+	"agones.dev/agones/pkg/apis/agones"
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
+	getterv1 "agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1"
+	informerv1 "agones.dev/agones/pkg/client/informers/externalversions/agones/v1"
+	listerv1 "agones.dev/agones/pkg/client/listers/agones/v1"
+	"agones.dev/agones/pkg/gameservers"
+	"agones.dev/agones/pkg/util/logfields"
+	"agones.dev/agones/pkg/util/runtime"
+	"agones.dev/agones/pkg/util/workerqueue"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ReadyGameServerCache handles the gameserver sync operations for cache
+type ReadyGameServerCache struct {
+	baseLogger       *logrus.Entry
+	readyGameServers gameServerCacheEntry
+	gameServerGetter getterv1.GameServersGetter
+	gameServerLister listerv1.GameServerLister
+	gameServerSynced cache.InformerSynced
+	workerqueue      *workerqueue.WorkerQueue
+	counter          *gameservers.PerNodeCounter
+}
+
+// NewReadyGameServerCache creates a new instance of ReadyGameServerCache
+func NewReadyGameServerCache(informer informerv1.GameServerInformer, gameServerGetter getterv1.GameServersGetter, counter *gameservers.PerNodeCounter, health healthcheck.Handler) *ReadyGameServerCache {
+	c := &ReadyGameServerCache{
+		gameServerSynced: informer.Informer().HasSynced,
+		gameServerGetter: gameServerGetter,
+		gameServerLister: informer.Lister(),
+		counter:          counter,
+	}
+
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			// only interested in if the old / new state was/is Ready
+			oldGs := oldObj.(*agonesv1.GameServer)
+			newGs := newObj.(*agonesv1.GameServer)
+			key, ok := c.getKey(newGs)
+			if !ok {
+				return
+			}
+			if newGs.IsBeingDeleted() {
+				c.readyGameServers.Delete(key)
+			} else if oldGs.Status.State == agonesv1.GameServerStateReady || newGs.Status.State == agonesv1.GameServerStateReady {
+				if newGs.Status.State == agonesv1.GameServerStateReady {
+					c.readyGameServers.Store(key, newGs)
+				} else {
+					c.readyGameServers.Delete(key)
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			gs, ok := obj.(*agonesv1.GameServer)
+			if !ok {
+				return
+			}
+			var key string
+			if key, ok = c.getKey(gs); ok {
+				c.readyGameServers.Delete(key)
+			}
+		},
+	})
+
+	c.baseLogger = runtime.NewLoggerWithType(c)
+	c.workerqueue = workerqueue.NewWorkerQueue(c.SyncGameServers, c.baseLogger, logfields.GameServerKey, agones.GroupName+".GameServerUpdateController")
+	health.AddLivenessCheck("gameserverallocation-gameserver-workerqueue", healthcheck.Check(c.workerqueue.Healthy))
+
+	return c
+}
+
+func (c *ReadyGameServerCache) loggerForGameServerKey(key string) *logrus.Entry {
+	return logfields.AugmentLogEntry(c.baseLogger, logfields.GameServerKey, key)
+}
+
+// RemoveFromReadyGameServer removes a gameserver from the list of ready game server list
+func (c *ReadyGameServerCache) RemoveFromReadyGameServer(gs *agonesv1.GameServer) error {
+	key, _ := cache.MetaNamespaceKeyFunc(gs)
+	if ok := c.readyGameServers.Delete(key); !ok {
+		return ErrConflictInGameServerSelection
+	}
+	return nil
+}
+
+// Sync waits for cache to sync
+func (c *ReadyGameServerCache) Sync(stop <-chan struct{}) error {
+	c.baseLogger.Info("Wait for ReadyGameServerCache cache sync")
+	if !cache.WaitForCacheSync(stop, c.gameServerSynced) {
+		return errors.New("failed to wait for caches to sync")
+	}
+
+	// build the cache
+	return c.syncReadyGSServerCache()
+}
+
+// Resync enqueues an empty game server to be synced. Using queue helps avoiding multiple threads syncing at the same time.
+func (c *ReadyGameServerCache) Resync() {
+	// this will trigger syncing of the cache (assuming cache might not be up to date)
+	c.workerqueue.EnqueueImmediately(&agonesv1.GameServer{})
+}
+
+// Start prepares cache to start
+func (c *ReadyGameServerCache) Start(stop <-chan struct{}) error {
+	if err := c.Sync(stop); err != nil {
+		return err
+	}
+	// we don't want mutiple workers refresh cache at the same time so one worker will be better.
+	// Also we don't expect to have too many failures when allocating
+	go c.workerqueue.Run(1, stop)
+	return nil
+}
+
+// AddToReadyGameServer adds a gameserver to the list of ready game server list
+func (c *ReadyGameServerCache) AddToReadyGameServer(gs *agonesv1.GameServer) {
+	key, _ := cache.MetaNamespaceKeyFunc(gs)
+
+	c.readyGameServers.Store(key, gs)
+}
+
+// getReadyGameServers returns a list of ready game servers
+func (c *ReadyGameServerCache) getReadyGameServers() []*agonesv1.GameServer {
+	length := c.readyGameServers.Len()
+	if length == 0 {
+		return nil
+	}
+
+	list := make([]*agonesv1.GameServer, 0, length)
+	c.readyGameServers.Range(func(_ string, gs *agonesv1.GameServer) bool {
+		list = append(list, gs)
+		return true
+	})
+	return list
+}
+
+// ListSortedReadyGameServers returns a list of the cache ready gameservers
+// sorted by most allocated to least
+func (c *ReadyGameServerCache) ListSortedReadyGameServers() []*agonesv1.GameServer {
+	list := c.getReadyGameServers()
+	if list == nil {
+		return []*agonesv1.GameServer{}
+	}
+	counts := c.counter.Counts()
+
+	sort.Slice(list, func(i, j int) bool {
+		gs1 := list[i]
+		gs2 := list[j]
+
+		c1, ok := counts[gs1.Status.NodeName]
+		if !ok {
+			return false
+		}
+
+		c2, ok := counts[gs2.Status.NodeName]
+		if !ok {
+			return true
+		}
+
+		if c1.Allocated > c2.Allocated {
+			return true
+		}
+		if c1.Allocated < c2.Allocated {
+			return false
+		}
+
+		// prefer nodes that have the most Ready gameservers on them - they are most likely to be
+		// completely filled and least likely target for scale down.
+		if c1.Ready < c2.Ready {
+			return false
+		}
+		if c1.Ready > c2.Ready {
+			return true
+		}
+
+		// finally sort lexicographically, so we have a stable order
+		return gs1.Status.NodeName < gs2.Status.NodeName
+	})
+
+	return list
+}
+
+// PatchGameServerMetadata patches the input gameserver with allocation meta patch and returns the updated gameserver
+func (c *ReadyGameServerCache) PatchGameServerMetadata(fam allocationv1.MetaPatch, gs agonesv1.GameServer) (*agonesv1.GameServer, error) {
+	c.patchMetadata(&gs, fam)
+	gs.Status.State = agonesv1.GameServerStateAllocated
+
+	return c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(&gs)
+}
+
+// patch the labels and annotations of an allocated GameServer with metadata from a GameServerAllocation
+func (c *ReadyGameServerCache) patchMetadata(gs *agonesv1.GameServer, fam allocationv1.MetaPatch) {
+	// patch ObjectMeta labels
+	if fam.Labels != nil {
+		if gs.ObjectMeta.Labels == nil {
+			gs.ObjectMeta.Labels = make(map[string]string, len(fam.Labels))
+		}
+		for key, value := range fam.Labels {
+			gs.ObjectMeta.Labels[key] = value
+		}
+	}
+	// apply annotations patch
+	if fam.Annotations != nil {
+		if gs.ObjectMeta.Annotations == nil {
+			gs.ObjectMeta.Annotations = make(map[string]string, len(fam.Annotations))
+		}
+		for key, value := range fam.Annotations {
+			gs.ObjectMeta.Annotations[key] = value
+		}
+	}
+}
+
+// SyncGameServers synchronises the GameServers to Gameserver cache. This is called when a failure
+// happened during the allocation. This method will sync and make sure the cache is up to date.
+func (c *ReadyGameServerCache) SyncGameServers(key string) error {
+	c.loggerForGameServerKey(key).Info("Refreshing Ready Gameserver cache")
+
+	return c.syncReadyGSServerCache()
+}
+
+// syncReadyGSServerCache syncs the gameserver cache and updates the local cache for any changes.
+func (c *ReadyGameServerCache) syncReadyGSServerCache() error {
+	// build the cache
+	gsList, err := c.gameServerLister.List(labels.Everything())
+	if err != nil {
+		return errors.Wrap(err, "could not list GameServers")
+	}
+
+	// convert list of current gameservers to map for faster access
+	currGameservers := make(map[string]*agonesv1.GameServer)
+	for _, gs := range gsList {
+		if key, ok := c.getKey(gs); ok {
+			currGameservers[key] = gs
+		}
+	}
+
+	// first remove the gameservers are not in the list anymore
+	tobeDeletedGSInCache := make([]string, 0)
+	c.readyGameServers.Range(func(key string, gs *agonesv1.GameServer) bool {
+		if _, ok := currGameservers[key]; !ok {
+			tobeDeletedGSInCache = append(tobeDeletedGSInCache, key)
+		}
+		return true
+	})
+
+	for _, staleGSKey := range tobeDeletedGSInCache {
+		c.readyGameServers.Delete(staleGSKey)
+	}
+
+	// refresh the cache of possible allocatable GameServers
+	for key, gs := range currGameservers {
+		if gsCache, ok := c.readyGameServers.Load(key); ok {
+			if !(gs.DeletionTimestamp.IsZero() && gs.Status.State == agonesv1.GameServerStateReady) {
+				c.readyGameServers.Delete(key)
+			} else if gs.ObjectMeta.ResourceVersion != gsCache.ObjectMeta.ResourceVersion {
+				c.readyGameServers.Store(key, gs)
+			}
+		} else if gs.DeletionTimestamp.IsZero() && gs.Status.State == agonesv1.GameServerStateReady {
+			c.readyGameServers.Store(key, gs)
+		}
+	}
+
+	return nil
+}
+
+// getKey extract the key of gameserver object
+func (c *ReadyGameServerCache) getKey(gs *agonesv1.GameServer) (string, bool) {
+	var key string
+	ok := true
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(gs); err != nil {
+		ok = false
+		err = errors.Wrap(err, "Error creating key for object")
+		runtime.HandleError(c.baseLogger.WithField("obj", gs), err)
+	}
+	return key, ok
+}


### PR DESCRIPTION
gameserverallocations is a module with multiple independent responsibilities.
1) Controller which implements the APIServer extension 
2) Allocation handler which allocate from the pool of ready game servers and does batch allocation
3) Cache handler which handles the pool of game servers that is cached
4) Latency recorder

This refactoring does not change any logic and only moves the code around to its rightful modules to simplify and also to make the allocation library reusable by agones-allocator service to address https://github.com/googleforgames/agones/issues/1018 with parent issue https://github.com/googleforgames/agones/issues/597.