### PR TITLE
flaky/TestGameServerShutdown

### DIFF
--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -355,7 +355,7 @@ func TestGameServerShutdown(t *testing.T) {
 
 	assert.Equal(t, "ACK: EXIT\n", reply)
 
-	err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(time.Second, 3*time.Minute, func() (bool, error) {
 		gs, err = framework.AgonesClient.AgonesV1().GameServers(defaultNs).Get(readyGs.ObjectMeta.Name, metav1.GetOptions{})
 
 		if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
Increase timeout, which should solve this, as it can sometimes take up to a minute for a GameServer to shutdown and be removed.

Run 100 times and passed:
`go test -v -p=32 -timeout=1h -count=100 -mod=vendor -run=^TestGameServerShutdown$ agones.dev/agones/test/e2e`