### PR TITLE
flaky/TestFleetScaleUpEditAndScaleDown

### DIFF
--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -99,7 +99,7 @@ func TestFleetScaleUpEditAndScaleDown(t *testing.T) {
 			assert.Nil(t, err)
 
 			// Wait for one more GSSet to be created and ReadyReplicas created in new GSS
-			err = wait.PollImmediate(1*time.Second, 15*time.Second, func() (bool, error) {
+			err = wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
 				selector := labels.SelectorFromSet(labels.Set{agonesv1.FleetNameLabel: flt.ObjectMeta.Name})
 				list, err := framework.AgonesClient.AgonesV1().GameServerSets(defaultNs).List(
 					metav1.ListOptions{LabelSelector: selector.String()})


### PR DESCRIPTION
Increase timeout on scaling -- 15 seconds wasn't that long a time.

Tested by running 100 times, and it passed:
`go test -v -p=32 -timeout=1h -count=100 -mod=vendor -run=^TestFleetScaleUpEditAndScaleDown$ agones.dev/agones/test/e2e`