### PR TITLE
Define the proto definition for the allocator service

### DIFF
--- a/cmd/allocator/v1alpha1/allocation.proto
+++ b/cmd/allocator/v1alpha1/allocation.proto
@@ -1,0 +1,96 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package v1alpha1;
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
+import "google/api/annotations.proto";
+
+service AllocationService {
+ rpc PostAllocate(AllocationRequest) returns (AllocationResponse) {
+   option (google.api.http) = {
+     post: "/v1alpha1/gameserverallocation"
+     body: "*"
+   };
+ }
+}
+
+message AllocationRequest {
+  // The k8s namespace that is hosting the targetted fleet of gameservers to be allocated
+  string namespace = 1;
+
+  // If specified, multi-cluster policies are applied. Otherwise, allocation will happen locally.
+  MultiClusterSetting multiClusterSetting = 2;
+
+  // The required allocation. Defaults to all GameServers.
+  k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector requiredGameServerSelector = 3;
+
+  // The ordered list of preferred allocations out of the `required` set.
+  // If the first selector is not matched, the selection attempts the second selector, and so on.
+  repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector preferredGameServerSelector = 4;
+
+  // Scheduling strategy. Defaults to "Packed".
+  SchedulingStrategy scheduling = 5;
+  enum SchedulingStrategy {
+    Packed = 0;
+    Distributed = 1;
+  }
+
+  // MetaPatch is optional custom metadata that is added to the game server at
+  // allocation You can use this to tell the server necessary session data
+  MetaPatch metaPatch = 6;
+}
+
+message AllocationResponse {
+  GameServerAllocationState state = 1;
+
+  // The allocation state
+  enum GameServerAllocationState {
+    Unknown = 0;
+    // Allocated is for successful allocation
+    Allocated = 1;
+    // UnAllocated is for unsuccessful allocation due to lack of gameserver resources
+    UnAllocated = 2;
+    // Contention is for unsuccessful allocation due to contention
+    Contention = 3;
+  }
+
+  string gameServerName = 2;
+  repeated GameServerStatusPort ports = 3;
+  string address = 4;
+  string nodeName = 5;
+
+  // The gameserver port info that is allocated.
+  message GameServerStatusPort {
+    string name = 1;
+    int32 port = 2;
+  }
+}
+
+// Specifies settings for multi-cluster allocation.
+message MultiClusterSetting {
+    // If set to true, multi-cluster allocation is enabled.
+    bool enabled = 1;
+
+    // Selects multi-cluster allocation policies to apply. If not specified, all multi-cluster allocation policies are to be applied.
+    k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector policySelector = 2;
+}
+   
+// MetaPatch is the metadata used to patch the GameServer metadata on allocation
+message MetaPatch {
+    map<string, string> labels = 1;
+    map<string, string> annotations = 2;
+}


### PR DESCRIPTION
Define the v1alpha1 gRPC API protobuf definition for the allocator service according to the [GameServerAllocation](https://github.com/googleforgames/agones/blob/master/pkg/apis/allocation/v1/gameserverallocation.go) Extension API server.