### PR TITLE
Cpp SDK. Fixed regex for version detection. Fixed mingw build.

### DIFF
--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -50,7 +50,7 @@ if (Git_FOUND)
         OUTPUT_VARIABLE output
     )
     if (${result} EQUAL 0)
-        string(REGEX MATCH "\\d+.\\d+.\\d+" AGONES_VERSION ${output})
+        string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" AGONES_VERSION ${output})
     endif()
 else()
     message(WARNING "Git was not found. Current Agones version is set to ${AGONES_VERSION}")

--- a/sdks/cpp/cmake/agonesConfig.cmake.in
+++ b/sdks/cpp/cmake/agonesConfig.cmake.in
@@ -26,9 +26,9 @@ if (${AGONES_OWN_GRPC})
 endif()
 
 include(CMakeFindDependencyMacro)
-find_dependency(ZLIB REQUIRED)
-find_dependency(Protobuf REQUIRED CONFIG)
-find_dependency(gRPC REQUIRED CONFIG)
+find_dependency(ZLIB)
+find_dependency(Protobuf CONFIG)
+find_dependency(gRPC CONFIG)
 include("${CMAKE_CURRENT_LIST_DIR}/agonesTargets.cmake")
 
 check_required_components(agones)


### PR DESCRIPTION
Fixed Agones version detection for CMake scripts (based on git tag).
Fixed mingw (windows) build of zlib and gRPC dependency.
Added more informative error for mingw build, if OpenSSL was not found (rare case); because building of OpenSSL with mingw in a cross-platform way is tricky (require CMake->MSYS->OpenSSL chain). I'm not sure that we should add an instruction how to build OpenSSL to our documentation. Prebuilt OpenSSL for windows may be found [there](https://slproweb.com/products/Win32OpenSSL.html). OpenSSL is required only for successful gRPC build.