### PR TITLE
CRASH for simple-udp example

### DIFF
--- a/examples/simple-udp/Makefile
+++ b/examples/simple-udp/Makefile
@@ -27,7 +27,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/udp-server:0.14
+server_tag = $(REPOSITORY)/udp-server:0.15
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _


### PR DESCRIPTION
This provides the CRASH command, to make GameServer crash testing easier.

This also includes a new param to disable automatically moving to `Ready` on startup, to enable testing crash events before and after a `Ready` state has been achieved.

I'll push up the image on PR merge.

Work on #956