### PR TITLE
Logging Agones version and port on the startup.

### DIFF
--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"agones.dev/agones/pkg"
 	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
 	"agones.dev/agones/pkg/metrics"
@@ -62,6 +63,10 @@ type handler func(w http.ResponseWriter, r *http.Request)
 
 func main() {
 	conf := parseEnvFlags()
+
+	logger.WithField("version", pkg.Version).
+		WithField("sslPort", sslPort).
+		Info("Starting agones-allocator")
 
 	health, closer := setupMetricsRecorder(conf)
 	defer closer()


### PR DESCRIPTION
Addressing https://github.com/googleforgames/agones/issues/1042 for allocator service