### PR TITLE
Update golangci-lint to 1.18, add bodyclose check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
     - misspell
     - unparam
     - nakedret
+    - bodyclose
 
 issues:
   # This turns off the default excludes - which was causing the linter

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -68,7 +68,7 @@ RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
 RUN echo "source <(helm completion bash)" >> /root/.bashrc
 
 # install golang-ci linter
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.16.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.18.0
 
 #
 #  \ \      / /__| |__  ___(_) |_ ___

--- a/pkg/util/https/https_test.go
+++ b/pkg/util/https/https_test.go
@@ -35,5 +35,6 @@ func TestFourZeroFour(t *testing.T) {
 	FourZeroFour(l, w, r)
 
 	resp := w.Result()
+	defer resp.Body.Close() // nolint: errcheck
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/pkg/util/https/server_test.go
+++ b/pkg/util/https/server_test.go
@@ -53,9 +53,11 @@ func TestServerRun(t *testing.T) {
 	client := ts.server.Client()
 	resp, err := client.Get(ts.server.URL + "/test")
 	assert.Nil(t, err)
+	defer resp.Body.Close() // nolint: errcheck
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	resp, err = client.Get(ts.server.URL + "/")
 	assert.Nil(t, err)
+	defer resp.Body.Close() // nolint: errcheck
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -120,6 +120,7 @@ func TestWebHookAddHandler(t *testing.T) {
 
 			resp, err := client.Do(r)
 			assert.Nil(t, err)
+			defer resp.Body.Close() // nolint: errcheck
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 			assert.Equal(t, handles.expected.count, callCount, "[%v] /test should have been called for %#v", k, handles)
@@ -215,6 +216,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 
 			resp, err := client.Do(r)
 			assert.Nil(t, err)
+			defer resp.Body.Close() // nolint: errcheck
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			body, err := ioutil.ReadAll(resp.Body)
 			assert.Nil(t, err)


### PR DESCRIPTION
Fix some tests which leak connections (`bodyclose` linter).

This version of `golangci-lint` would be needed for upgrading to Golang 1.13.

Fixed also:
```
pkg/util/apiserver/apiserver.go:128:22: appendAssign: append result not assigned to the same slice (gocritic)                                                                                
        list.APIResources = append(as.resourceList[groupVersion].APIResources, resource)
```