### PR TITLE
Use non-ephemeral ports for side car HTTP and gRPC.

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -118,7 +118,7 @@ ensure-build-sdk-image:
 run-sdk-conformance-local: TIMEOUT ?= 30
 run-sdk-conformance-local: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch
 run-sdk-conformance-local: ensure-agones-sdk-image
-	docker run -e "ADDRESS=" -p 59357:59357 \
+	docker run -e "ADDRESS=" -p 9357:9357 \
 	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" $(sidecar_tag)
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
@@ -130,7 +130,7 @@ run-sdk-conformance-no-build: TESTS ?= ready,allocate,setlabel,setannotation,gam
 run-sdk-conformance-no-build: ensure-agones-sdk-image
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	DOCKER_RUN_ARGS="--network=host $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \
-	sleep $(DELAY) && docker run -p 59357:59357 -e "ADDRESS=" \
+	sleep $(DELAY) && docker run -p 9357:9357 -e "ADDRESS=" \
 	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" --net=host  $(sidecar_tag)
 
 # Run SDK conformance test for a specific SDK_FOLDER

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -41,8 +41,8 @@ import (
 )
 
 const (
-	grpcPort = 59357
-	httpPort = 59358
+	grpcPort = 9357
+	httpPort = 9358
 
 	// specifically env vars
 	gameServerNameEnv = "GAMESERVER_NAME"

--- a/sdks/cpp/src/agones/sdk.cc
+++ b/sdks/cpp/src/agones/sdk.cc
@@ -27,7 +27,7 @@ struct SDK::SDKImpl {
 };
 
 SDK::SDK() : pimpl_{std::make_unique<SDKImpl>()} {
-  pimpl_->channel_ = grpc::CreateChannel("localhost:59357",
+  pimpl_->channel_ = grpc::CreateChannel("localhost:9357",
                                          grpc::InsecureChannelCredentials());
 }
 

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const port = 59357
+const port = 9357
 
 // GameServerCallback is a function definition to be called
 // when a GameServer CRD has been changed
@@ -40,7 +40,7 @@ type SDK struct {
 }
 
 // NewSDK starts a new SDK instance, and connects to
-// localhost on port 59357. Blocks until connection and handshake are made.
+// localhost on port 9357. Blocks until connection and handshake are made.
 // Times out after 30 seconds.
 func NewSDK() (*SDK, error) {
 	addr := fmt.Sprintf("localhost:%d", port)

--- a/sdks/nodejs/src/agonesSDK.js
+++ b/sdks/nodejs/src/agonesSDK.js
@@ -19,7 +19,7 @@ const services = require('../lib/sdk_grpc_pb');
 
 class AgonesSDK {
 	constructor() {
-		this.client = new services.SDKClient('localhost:59357', grpc.credentials.createInsecure());
+		this.client = new services.SDKClient('localhost:9357', grpc.credentials.createInsecure());
 		this.healthStream = undefined;
 		this.emitters = [];
 	}

--- a/sdks/rust/src/sdk.rs
+++ b/sdks/rust/src/sdk.rs
@@ -25,7 +25,7 @@ use grpc::sdk;
 use grpc::sdk_grpc;
 use types::*;
 
-const PORT: i32 = 59357;
+const PORT: i32 = 9357;
 
 /// SDK is an instance of the Agones SDK
 pub struct Sdk {
@@ -34,7 +34,7 @@ pub struct Sdk {
 }
 
 impl Sdk {
-    /// Starts a new SDK instance, and connects to localhost on port 59357.
+    /// Starts a new SDK instance, and connects to localhost on port 9357.
     /// Blocks until connection and handshake are made.
     /// Times out after ~30 seconds.
     pub fn new() -> Result<Sdk> {

--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -44,7 +44,7 @@ namespace Agones
         /// </summary>
         public bool logEnabled = false;
 
-        private const string sidecarAddress = "http://localhost:59358";
+        private const string sidecarAddress = "http://localhost:9358";
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
         private struct KeyValueMessage

--- a/sdks/unreal/Agones/Source/Agones/AgonesSettings.cpp
+++ b/sdks/unreal/Agones/Source/Agones/AgonesSettings.cpp
@@ -16,7 +16,7 @@
 
 UAgonesSettings::UAgonesSettings()
 	: Super()
-	, AgonesSidecarAddress("http://localhost:59358")
+	, AgonesSidecarAddress("http://localhost:9358")
 	, bHealthPingEnabled(true)
 	, HealthPingSeconds(5.0f)
 	, bDebugLogEnabled(false)

--- a/site/content/en/docs/Guides/Client SDKs/local.md
+++ b/site/content/en/docs/Guides/Client SDKs/local.md
@@ -35,7 +35,7 @@ For example:
 
 ```console
 $ ./sidecar.linux.amd64 --local
-{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":""},"grpcPort":59357,"httpPort":59358,"level":"info","msg":"Starting sdk sidecar","source":"main","time":"2018-08-25T18:01:58-07:00","version":"0.4.0-b44960a8"}
+{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":""},"grpcPort":9357,"httpPort":9358,"level":"info","msg":"Starting sdk sidecar","source":"main","time":"2018-08-25T18:01:58-07:00","version":"0.4.0-b44960a8"}
 {"level":"info","msg":"Starting SDKServer grpc service...","source":"main","time":"2018-08-25T18:01:58-07:00"}
 {"level":"info","msg":"Starting SDKServer grpc-gateway...","source":"main","time":"2018-08-25T18:01:58-07:00"}
 {"level":"info","msg":"Ready request has been received!","time":"2017-12-22T16:09:19-08:00"}
@@ -61,7 +61,7 @@ For example:
 
 ```console
 $ ./sdk-server.linux.amd64 --local -f ../../../examples/simple-udp/gameserver.yaml
-{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"../../../examples/simple-udp/gameserver.yaml"},"grpcPort":59357,"httpPort":59358,"level":"info","msg":"Starting sdk sidecar","source":"main","time":"2018-08-25T17:56:39-07:00","version":"0.4.0-b44960a8"}
+{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"../../../examples/simple-udp/gameserver.yaml"},"grpcPort":9357,"httpPort":9358,"level":"info","msg":"Starting sdk sidecar","source":"main","time":"2018-08-25T17:56:39-07:00","version":"0.4.0-b44960a8"}
 {"level":"info","msg":"Reading GameServer configuration","path":"/home/user/workspace/agones/src/agones.dev/agones/examples/simple-udp/gameserver.yaml","source":"main","time":"2018-08-25T17:56:39-07:00"}
 {"level":"info","msg":"Starting SDKServer grpc service...","source":"main","time":"2018-08-25T17:56:39-07:00"}
 {"level":"info","msg":"Starting SDKServer grpc-gateway...","source":"main","time":"2018-08-25T17:56:39-07:00"}

--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -8,7 +8,7 @@ description: "This is the REST version of the Agones Game Server Client SDK. "
 
 Check the [Client SDK Documentation]({{< relref "_index.md" >}}) for more details on each of the SDK functions and how to run the SDK locally.
 
-The REST API can be accessed from `http://localhost:59358/` from the game server process.
+The REST API can be accessed from `http://localhost:9358/` from the game server process.
 
 Generally the REST interface gets used if gRPC isn't well supported for a given language or platform.
 
@@ -40,7 +40,7 @@ Call when the GameServer is ready to accept connections
 #### Example
 
 ```bash
-$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/ready
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:9358/ready
 ```
 
 ### Health
@@ -53,7 +53,7 @@ Send a Empty every d Duration to declare that this GameSever is healthy
 #### Example
 
 ```bash
-$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/health
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:9358/health
 ```
 
 ### Shutdown
@@ -67,7 +67,7 @@ Call when the GameServer session is over and it's time to shut down
 #### Example
 
 ```bash
-$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/shutdown
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:9358/shutdown
 ```
 
 ### Set Label
@@ -79,7 +79,7 @@ See the SDK [SetLabel]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabel-key-
 #### Example
 
 ```bash
-$ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:59358/metadata/label
+$ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:9358/metadata/label
 ```
 
 ### Set Annotation
@@ -89,7 +89,7 @@ Apply a Annotation with the prefix "agones.dev/sdk-" to the backing `GameServer`
 #### Example
 
 ```bash
-$ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:59358/metadata/annotation
+$ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:9358/metadata/annotation
 ```
 
 ### GameServer
@@ -100,7 +100,7 @@ Call when you want to retrieve the backing `GameServer` configuration details
 - Method: `GET`
 
 ```bash
-$ curl -H "Content-Type: application/json" -X GET http://localhost:59358/gameserver
+$ curl -H "Content-Type: application/json" -X GET http://localhost:9358/gameserver
 ```
 
 Response:
@@ -142,7 +142,7 @@ want to keep the http connection open, and read lines from the result stream and
 come in.
 
 ```bash
-$ curl -H "Content-Type: application/json" -X GET http://localhost:59358/watch/gameserver
+$ curl -H "Content-Type: application/json" -X GET http://localhost:9358/watch/gameserver
 ```
 
 Response:
@@ -164,5 +164,5 @@ relinquish control to an external service which likely doesn't have as much info
 #### Example
 
 ```bash
-$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/allocate
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:9358/allocate
 ```

--- a/site/content/en/docs/Guides/Client SDKs/unreal.md
+++ b/site/content/en/docs/Guides/Client SDKs/unreal.md
@@ -31,7 +31,7 @@ At this moment we do not provide binaries for the plugin. This requires you to c
 The settings for the Agones Plugin can be found in the Unreal Engine editor `Edit > Project Settings > Plugins >  Agones`
 
 Available settings:
-- Agones Sidecar IP. (default: `http://localhost:59358`)
+- Agones Sidecar IP. (default: `http://localhost:9358`)
 - Health Ping Enabled. Whether the server sends a health ping to the Agones sidecar. (default: `true`)
 - Health Ping Seconds. Interval of the server sending a health ping to the Agones sidecar. (default: `5`)
 - Debug Logging Enabled. Debug logging for development of this Plugin. (default: `false`)


### PR DESCRIPTION
Replaced 59357 with 9357 and 59358 with 9358.

Fixes #851.