### PR TITLE
GameServer container restart before Ready, move to Unhealthy state After

### DIFF
--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -42,7 +42,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["create", "delete", "list", "watch"]
+  verbs: ["create", "delete", "update", "list", "watch"]
 - apiGroups: [""]
   resources: ["nodes", "secrets"]
   verbs: ["list", "watch"]

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -40,7 +40,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["create", "delete", "list", "watch"]
+  verbs: ["create", "delete", "update", "list", "watch"]
 - apiGroups: [""]
   resources: ["nodes", "secrets"]
   verbs: ["list", "watch"]

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -91,6 +91,10 @@ const (
 	// DevAddressAnnotation is an annotation to indicate that a GameServer hosted outside of Agones.
 	// A locally hosted GameServer is not managed by Agones it is just simply registered.
 	DevAddressAnnotation = "agones.dev/dev-address"
+	// GameServerReadyContainerIDAnnotation is an annotation that is set on a backing pod when a GameServer
+	// becomes ready, so we can track when restarts should occur and when a GameServer
+	// should be moved to Unhealthy.
+	GameServerReadyContainerIDAnnotation = agones.GroupName + "/ready-container-id"
 )
 
 var (

--- a/pkg/sdk/sdk.pb.go
+++ b/pkg/sdk/sdk.pb.go
@@ -18,13 +18,13 @@
 
 package sdk
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "google.golang.org/genproto/googleapis/api/annotations"
-
 import (
+	fmt "fmt"
+	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 	context "golang.org/x/net/context"
+	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
 )
 

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -233,8 +233,13 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	newGs, err = framework.WaitForGameServerState(newGs, agonesv1.GameServerStateScheduled, time.Minute)
 	assert.NoError(t, err)
 
+	logger.WithField("gs", newGs.ObjectMeta.Name).Info("GameServer created")
+
 	// crash the pod
-	conn, err := net.Dial("udp", fmt.Sprintf("%s:%d", newGs.Status.Address, newGs.Status.Ports[0].Port))
+	address := fmt.Sprintf("%s:%d", newGs.Status.Address, newGs.Status.Ports[0].Port)
+	logger.WithField("address", address).Info("Dialing UDP message to address")
+
+	conn, err := net.Dial("udp", address)
 	assert.NoError(t, err)
 	defer conn.Close() // nolint: errcheck
 


### PR DESCRIPTION
This brings our implementation inline with what our health checking documentation states that we do.

To solve this, we store the currently running GameServer containerID (which is unique to that running instance), as an annotation on the GameServer Pod.

When the annotation is not there, we know the Pod is not yet Ready, so we can ignore it when our Unhealthy check occurs, and restarts of the GameServer container can happen as per usual.

When the annotation is there, we know to check for failure, but to avoid ContainerStatus.LastTerminationState polluting the result since that crash/failure may have happened before the GameServer is ready, we can compare the current ContainerID to the one stored in the
annotation -- which when equal means we can skip looking at the LastTerminationState, as it was before the GameServer was marked as Ready.

Lots of unit and e2e test updates to go with this to test it out.

Closes #956