### PR TITLE
Add a delay flag to the sdkserver

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -125,13 +125,13 @@ run-sdk-conformance-local: ensure-agones-sdk-image
 # Sleeps the start of the sidecar to test that the SDK blocks on connection correctly
 run-sdk-conformance-no-build: TIMEOUT ?= 30
 run-sdk-conformance-no-build: RANDOM := $(shell bash -c 'echo $$RANDOM')
-run-sdk-conformance-no-build: DELAY ?= $(shell bash -c "echo $$[ ($(RANDOM) % 5 ) + 1 ]s")
+run-sdk-conformance-no-build: DELAY ?= $(shell bash -c "echo $$[ ($(RANDOM) % 5 ) + 1 ]")
 run-sdk-conformance-no-build: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
 run-sdk-conformance-no-build: ensure-agones-sdk-image
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	DOCKER_RUN_ARGS="--network=host $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \
-	sleep $(DELAY) && docker run -p 59357:59357 -e "ADDRESS=" \
-	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" --net=host  $(sidecar_tag)
+	docker run -p 59357:59357 -e "ADDRESS=" -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" -e "DELAY=$(DELAY)" \
+	 --net=host  $(sidecar_tag)
 
 # Run SDK conformance test for a specific SDK_FOLDER
 run-sdk-conformance-test:


### PR DESCRIPTION
To enable test scenarios where it doesn't start up immediately.