### PR TITLE
Add SDK server HTTP API test

### DIFF
--- a/build/build-sdk-images/restapi/Dockerfile
+++ b/build/build-sdk-images/restapi/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASE_IMAGE=agones-build-sdk-base:latest
+FROM $BASE_IMAGE
+
+RUN apt-get update && \
+    apt-get install -y wget jq && \
+    apt-get clean
+
+# install go
+WORKDIR /usr/local
+ENV GO_VERSION=1.12
+ENV GO111MODULE=on
+ENV GOPATH /go
+RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir -p ${GOPATH}
+
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
+    apt-get install -y nodejs
+
+RUN  apt-get install -y openjdk-8-jre
+
+ENV PATH /usr/local/go/bin:/go/bin:$PATH
+
+
+# code generation scripts
+COPY *.sh /root/
+RUN chmod +x /root/*.sh

--- a/build/build-sdk-images/restapi/build-sdk-test.sh
+++ b/build/build-sdk-images/restapi/build-sdk-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+mkdir /go/src/agones.dev/agones/swagger
+wget -q http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.8/swagger-codegen-cli-2.4.8.jar -O /tmp/swagger-codegen-cli.jar
+java -jar /tmp/swagger-codegen-cli.jar generate -i /go/src/agones.dev/agones/sdk.swagger.json  -l go -o /go/src/agones.dev/agones/test/sdk/restapi/swagger

--- a/build/build-sdk-images/restapi/clean.sh
+++ b/build/build-sdk-images/restapi/clean.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+rm -rf /go/src/agones.dev/agones/test/sdk/restapi/swagger
+rm /go/src/agones.dev/agones/test/sdk/restapi/http-api-test.go

--- a/build/build-sdk-images/restapi/sdktest.sh
+++ b/build/build-sdk-images/restapi/sdktest.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+GO111MODULE=on
+cd /go/src/agones.dev/agones/test/sdk/restapi
+cp ./http-api-test.go.nolint ./http-api-test.go
+go run http-api-test.go

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -238,7 +238,7 @@ steps:
 - name: "make-docker"
   id: sdk-conformance
   dir: "build"
-  args: [ "-j", "3", "run-sdk-conformance-tests"]
+  args: [ "-j", "4", "run-sdk-conformance-tests"]
   waitFor:
     - build-images
 

--- a/test/sdk/restapi/http-api-test.go.nolint
+++ b/test/sdk/restapi/http-api-test.go.nolint
@@ -1,0 +1,113 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"agones.dev/agones/test/sdk/restapi/swagger"
+	"golang.org/x/net/context"
+)
+
+func main() {
+	log.Println("Client is starting")
+	conf := swagger.NewConfiguration()
+	portStr := os.Getenv("AGONES_SDK_HTTP_PORT")
+	conf.BasePath = "http://localhost:" + portStr
+	cli := swagger.NewAPIClient(conf)
+
+	ctx := context.Background()
+
+	// Wait for SDK server to start the test (30 seconds)
+	for c := 0; c < 5; c++ {
+		_, _, err := cli.SDKApi.Ready(ctx, swagger.SdkEmpty{})
+		if err == nil {
+			break
+		} else {
+			log.Printf("Could not send Ready: %v\n", err)
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	c := make(chan string)
+
+	once := true
+	go func() {
+		for {
+			gs, _, err := cli.SDKApi.WatchGameServer(ctx)
+			log.Printf("Watch response: %+v", gs)
+			if err != nil {
+				log.Printf("Error in WatchGameServer: %v\n", err)
+				return
+			} else {
+				if gs.ObjectMeta != nil {
+					uid := gs.ObjectMeta.Uid
+					if once {
+						c <- uid
+						once = false
+					}
+				} else {
+					log.Printf("Could not read GS Uid \n")
+				}
+			}
+		}
+	}()
+
+	_, _, err := cli.SDKApi.Health(ctx, swagger.SdkEmpty{})
+	if err != nil {
+		log.Fatalf("Could not send health check: %v\n", err)
+	}
+
+	_, _, err = cli.SDKApi.Reserve(ctx, swagger.SdkDuration{"5"})
+	if err != nil {
+		log.Fatalf("Could not send Reserve: %v\n", err)
+	}
+
+	_, _, err = cli.SDKApi.Allocate(ctx, swagger.SdkEmpty{})
+	if err != nil {
+		log.Fatalf("Could not send Allocate: %v\n", err)
+	}
+
+	gs, _, err := cli.SDKApi.GetGameServer(ctx)
+	if err != nil {
+		log.Fatalf("Could not GetGameserver: %v\n", err)
+	}
+
+	creationTS := gs.ObjectMeta.CreationTimestamp
+
+	_, _, err = cli.SDKApi.SetLabel(ctx, swagger.SdkKeyValue{"creationTimestamp", creationTS})
+	if err != nil {
+		log.Fatalf("Could not SetLabel: %v\n", err)
+	}
+
+	// TODO: fix WatchGameServer() HTTP API Swagger definition and remove the following lines
+	go func() {
+		c <- gs.ObjectMeta.Uid
+	}()
+
+	uid := <-c
+	_, _, err = cli.SDKApi.SetAnnotation(ctx, swagger.SdkKeyValue{"UID", uid})
+	if err != nil {
+		log.Fatalf("Could not SetAnnotation: %v\n", err)
+	}
+
+	_, _, err = cli.SDKApi.Shutdown(ctx, swagger.SdkEmpty{})
+	if err != nil {
+		log.Fatalf("Could not GetGameserver: %v\n", err)
+	}
+	log.Println("REST API test finished, all queries were performed")
+}


### PR DESCRIPTION
Add conformance test for Rest API SDK server port 59358.
Does not contain swagger pregenerated files. Switched Go file to other
file extension, because it is not possible to exclude one file from
GolangCI linter run.

For #927