### PR TITLE
Remove the ugly gaps in the Fleet & GameServer reference

### DIFF
--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -12,6 +12,7 @@ Like any other Kubernetes resource you describe a `Fleet`'s desired state via a 
 
 A full `Fleet` specification is available below and in the {{< ghlink href="examples/fleet.yaml" >}}example folder{{< /ghlink >}} for reference :
 
+{{% feature expiryVersion="1.1.0" %}}
 ```yaml
 apiVersion: "agones.dev/v1"
 kind: Fleet
@@ -57,11 +58,6 @@ spec:
       health:
         initialDelaySeconds: 30
         periodSeconds: 60
-{{% feature publishVersion="1.1.0" %}}
-      # logging parameters for game server sidecar
-      logging:
-        sdkServer: Info
-{{% /feature %}}
       # The GameServer's Pod template
       template:
         spec:
@@ -69,6 +65,64 @@ spec:
           - name: simple-udp
             image: gcr.io/agones-images/udp-server:0.15
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```yaml
+apiVersion: "agones.dev/v1"
+kind: Fleet
+# Fleet Metadata
+# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+metadata:
+  name: fleet-example
+spec:
+  # the number of GameServers to keep Ready or Allocated in this Fleet
+  replicas: 2
+  # defines how GameServers are organised across the cluster.
+  # Options include:
+  # "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack
+  # resources
+  # "Distributed" is aimed at static Kubernetes clusters, wherein we want to distribute resources across the entire
+  # cluster
+  scheduling: Packed
+  # a GameServer template - see:
+  # https://agones.dev/site/docs/reference/gameserver/ for all the options
+  strategy:
+    # The replacement strategy for when the GameServer template is changed. Default option is "RollingUpdate",
+    # "RollingUpdate" will increment by maxSurge value on each iteration, while decrementing by maxUnavailable on each
+    # iteration, until all GameServers have been switched from one version to another.
+    # "Recreate" terminates all non-allocated GameServers, and starts up a new set with the new details to replace them.
+    type: RollingUpdate
+    # Only relevant when `type: RollingUpdate`
+    rollingUpdate:
+      # the amount to increment the new GameServers by. Defaults to 25%
+      maxSurge: 25%
+      # the amount to decrements GameServers by. Defaults to 25%
+      maxUnavailable: 25%
+  template:
+    # GameServer metadata
+    metadata:
+      labels:
+        foo: bar
+    # GameServer specification
+    spec:
+      ports:
+      - name: default
+        portPolicy: Dynamic
+        containerPort: 26000
+      health:
+        initialDelaySeconds: 30
+        periodSeconds: 60
+      # logging parameters for game server sidecar
+      logging:
+        sdkServer: Info
+      # The GameServer's Pod template
+      template:
+        spec:
+          containers:
+          - name: simple-udp
+            image: gcr.io/agones-images/udp-server:0.15
+```
+{{% /feature %}}
 
 Since Agones defines a new 
 [Custom Resources Definition (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -9,6 +9,7 @@ description: >
 
 A full GameServer specification is available below and in the {{< ghlink href="examples/gameserver.yaml" >}}example folder{{< /ghlink >}} for reference :
 
+{{% feature expiryVersion="1.1.0" %}}
 ```yaml
 apiVersion: "agones.dev/v1"
 kind: GameServer
@@ -49,15 +50,6 @@ spec:
     # Minimum consecutive failures for the health probe to be considered failed after having succeeded.
     # Defaults to 3. Minimum value is 1
     failureThreshold: 3
-{{% feature publishVersion="1.1.0" %}}
-  # logging parameters for game server sidecar
-  logging:
-    # sdkServer logging parameter has three options:
-    #  - "Info" (default) The SDK server will output all messages except for debug messages
-    #  - "Debug" The SDK server will output all messages including debug messages
-    #  - "Error" The SDK server will only output error messages
-    sdkServer: Info
-{{% /feature %}}
   # Pod template configuration
   # https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podtemplate-v1-core
   template:
@@ -72,6 +64,70 @@ spec:
         image:  gcr.io/agones-images/udp-server:0.15
         imagePullPolicy: Always
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```yaml
+apiVersion: "agones.dev/v1"
+kind: GameServer
+# GameServer Metadata
+# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+metadata:
+  # generateName: "gds-example" # generate a unique name, with the given prefix
+  name: "gds-example" # set a fixed name
+spec:
+  # if there is more than one container, specify which one is the game server
+  container: example-server
+  # Array of ports that can be exposed as direct connections to the game server container
+  ports:
+    # name is a descriptive name for the port
+  - name: default
+    # portPolicy has three options:
+    # - "Dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
+    # - "Static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+    # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
+    #      This will mean that users will need to lookup what port has been opened through the server side SDK.
+    # port is available. When static is the policy specified, `hostPort` is required to be populated
+    portPolicy: Static
+    # the port that is being opened on the game server process
+    containerPort: 7654
+    # the port exposed on the host, only required when `portPolicy` is "Static". Overwritten when portPolicy is "Dynamic".
+    hostPort: 7777
+    # protocol being used. Defaults to UDP. TCP is the only other option
+    protocol: UDP
+  # Health checking for the running game server
+  health:
+    # Disable health checking. defaults to false, but can be set to true
+    disabled: false
+    # Number of seconds after the container has started before health check is initiated. Defaults to 5 seconds
+    initialDelaySeconds: 5
+    # If the `Health()` function doesn't get called at least once every period (seconds), then
+    # the game server is not healthy. Defaults to 5
+    periodSeconds: 5
+    # Minimum consecutive failures for the health probe to be considered failed after having succeeded.
+    # Defaults to 3. Minimum value is 1
+    failureThreshold: 3
+  # logging parameters for game server sidecar
+  logging:
+    # sdkServer logging parameter has three options:
+    #  - "Info" (default) The SDK server will output all messages except for debug messages
+    #  - "Debug" The SDK server will output all messages including debug messages
+    #  - "Error" The SDK server will only output error messages
+    sdkServer: Info
+  # Pod template configuration
+  # https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podtemplate-v1-core
+  template:
+    # pod metadata. Name & Namespace is overwritten
+    metadata:
+      labels:
+        myspeciallabel: myspecialvalue
+    # Pod Specification
+    spec:
+      containers:
+      - name: simple-udp
+        image:  gcr.io/agones-images/udp-server:0.15
+        imagePullPolicy: Always
+```
+{{% /feature %}}
 
 Since Agones defines a new [Custom Resources Definition (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) we can define a new resource using the kind `GameServer` with the custom group `agones.dev` and API version `v1`.
 


### PR DESCRIPTION
Unfortunately, can't put feature shortcodes in the middle of code blocks