### PR TITLE
Slack invite link is no longer active

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Documentation can be found on the [Agones website](https://agones.dev/site/docs/
 
 ## Get involved
 
-- [Slack](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU)
+- [Slack](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U)
 - [Twitter](https://twitter.com/agonesdev)
 - [Mailing List](https://groups.google.com/forum/#!forum/agones-discuss)
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -114,7 +114,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/googleforgames/agon
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
 	name = "Slack"
-	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU"
+	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U"
 	icon = "fab fa-slack"
         desc = "Chat with other project users in #users"
 [[params.links.user]]
@@ -135,7 +135,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/googleforgames/agon
         desc = "Development takes place here!"
 [[params.links.developer]]
 	name = "Slack"
-	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU"
+	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers in #developers"
 # [[params.links.developer]]

--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -58,7 +58,7 @@ for backend agnostic game server metrics and monitoring dashboards
 {{< /blocks/section >}}
 
 {{< blocks/section color="secondary"  >}}
-{{% blocks/feature icon="fab fa-slack" title="Join us on Slack" url="https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU" %}}
+{{% blocks/feature icon="fab fa-slack" title="Join us on Slack" url="https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U" %}}
 Join the community on Slack
 {{% /blocks/feature %}}
 

--- a/site/content/en/blog/news/announcing-agones-1-0-0.md
+++ b/site/content/en/blog/news/announcing-agones-1-0-0.md
@@ -50,7 +50,7 @@ But we also want to hear from our users and testers of Agones -- what would you 
 is a feature that would be useful for you, please 
 [file a feature request](https://github.com/googleforgames/agones/issues/new?assignees=&labels=kind%2Ffeature&template=feature_request.md&title=),
 or talk about it in our
-[Slack channel](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU)!
+[Slack channel](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U)!
 
 ## Getting Started
 

--- a/site/content/en/blog/news/new-agones-site.md
+++ b/site/content/en/blog/news/new-agones-site.md
@@ -23,4 +23,4 @@ Big thanks to [Hugo](https://gohugo.io) for being the static site generator, and
 
 Please let us know if you have feedback, either by [filing an issue](https://github.com/GoogleCloudPlatform/agones/issues)
 , or [submitting a pull request](https://github.com/GoogleCloudPlatform/agones/pulls) or come chat with us
-on [Slack](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU)! 
+on [Slack](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U)! 


### PR DESCRIPTION
Slack says the previous link is no longer active 🤷

Apparently this link won't expire - but supposedly the last one wouldn't either - but at least it took a few years.