### PR TITLE
Use environment variables to dynamically set the grpc port in the golang sdk.

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -32,6 +32,25 @@ This means that more languages can be supported in the future with minimal effor
 There is also [local development tooling]({{< relref "local.md" >}}) for working against the SDK locally,
 without having to spin up an entire Kubernetes infrastructure.
 
+{{% feature publishVersion="1.1.0" %}}
+## Connecting to the SDK Server
+
+Starting with Agones 1.1.0, the port that the SDK Server listens on for incoming gRPC or HTTP requests is
+configurable. This provides flexibility in cases where the default port conflicts with a port that is needed
+by the game server.
+
+Agones will automatically set the following environment variables on all game server containers:
+
+* `AGONES_SDK_GRPC_PORT`: The port where the gRPC server is listening
+* `AGONES_SDK_HTTP_PORT`: The port where the grpc-gateway is listening
+
+The SDKs will automatically discover and connect to the gRPC port specified in the environment variable.
+
+If your game server requires using a REST client, it is advised to use the port from the environment variable,
+otherwise your game server will not be able to contact the SDK server if it is configured to use a non-default port.
+
+{{% /feature %}}
+
 ## Function Reference
 
 While each of the SDKs are canonical to their languages, they all have the following

--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -8,7 +8,17 @@ description: "This is the REST version of the Agones Game Server Client SDK. "
 
 Check the [Client SDK Documentation]({{< relref "_index.md" >}}) for more details on each of the SDK functions and how to run the SDK locally.
 
+{{% feature expiryVersion="1.1.0" %}}
 The REST API can be accessed from `http://localhost:59358/` from the game server process.
+{{% /feature %}}
+
+{{% feature publishVersion="1.1.0" %}}
+The REST API can be accessed from `http://localhost:${AGONES_SDK_HTTP_PORT}/` from the game server process.
+`AGONES_SDK_HTTP_PORT` is an environment variable automatically set for the game server process by Agones to
+support binding the REST API to a dynamic port. It is advised to use the environment variable rather than a
+hard coded port; otherwise your game server will not be able to contact the SDK server if it is configured to
+use a non-default port.
+{{% /feature %}}
 
 Generally the REST interface gets used if gRPC isn't well supported for a given language or platform.
 
@@ -39,9 +49,16 @@ Call when the GameServer is ready to accept connections
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/ready
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:${AGONES_SDK_HTTP_PORT}/ready
+```
+{{% /feature %}}
 
 ### Health
 Send a Empty every d Duration to declare that this GameSever is healthy
@@ -52,9 +69,16 @@ Send a Empty every d Duration to declare that this GameSever is healthy
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/health
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:${AGONES_SDK_HTTP_PORT}/health
+```
+{{% /feature %}}
 
 ### Shutdown
 
@@ -66,9 +90,16 @@ Call when the GameServer session is over and it's time to shut down
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/shutdown
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:${AGONES_SDK_HTTP_PORT}/shutdown
+```
+{{% /feature %}}
 
 ### Set Label
 
@@ -78,9 +109,16 @@ See the SDK [SetLabel]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabel-key-
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:59358/metadata/label
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:${AGONES_SDK_HTTP_PORT}/metadata/label
+```
+{{% /feature %}}
 
 ### Set Annotation
 
@@ -88,9 +126,16 @@ Apply a Annotation with the prefix "agones.dev/sdk-" to the backing `GameServer`
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:59358/metadata/annotation
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d '{"key": "foo", "value": "bar"}' -H "Content-Type: application/json" -X PUT http://localhost:${AGONES_SDK_HTTP_PORT}/metadata/annotation
+```
+{{% /feature %}}
 
 ### GameServer
 
@@ -99,9 +144,16 @@ Call when you want to retrieve the backing `GameServer` configuration details
 - Path: `/gameserver`
 - Method: `GET`
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -H "Content-Type: application/json" -X GET http://localhost:59358/gameserver
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -H "Content-Type: application/json" -X GET http://localhost:${AGONES_SDK_HTTP_PORT}/gameserver
+```
+{{% /feature %}}
 
 Response:
 ```json
@@ -141,9 +193,16 @@ These updates will come as newline delimited JSON, send on each update. To that 
 want to keep the http connection open, and read lines from the result stream and and process as they
 come in.
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -H "Content-Type: application/json" -X GET http://localhost:59358/watch/gameserver
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -H "Content-Type: application/json" -X GET http://localhost:${AGONES_SDK_HTTP_PORT}/watch/gameserver
+```
+{{% /feature %}}
 
 Response:
 ```json
@@ -162,9 +221,16 @@ Move Gameserver into a Reserved state for a certain amount of seconds for the fu
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d '{"seconds": "5"}' -H "Content-Type: application/json" -X POST http://localhost:59358/reserve
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d '{"seconds": "5"}' -H "Content-Type: application/json" -X POST http://localhost:${AGONES_SDK_HTTP_PORT}/reserve
+```
+{{% /feature %}}
 
 ### Allocate
 
@@ -177,6 +243,13 @@ relinquish control to an external service which likely doesn't have as much info
 
 #### Example
 
+{{% feature expiryVersion="1.1.0" %}}
 ```bash
 $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/allocate
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+```bash
+$ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:${AGONES_SDK_HTTP_PORT}/allocate
+```
+{{% /feature %}}

--- a/site/content/en/docs/Guides/Client SDKs/unreal.md
+++ b/site/content/en/docs/Guides/Client SDKs/unreal.md
@@ -31,7 +31,12 @@ At this moment we do not provide binaries for the plugin. This requires you to c
 The settings for the Agones Plugin can be found in the Unreal Engine editor `Edit > Project Settings > Plugins >  Agones`
 
 Available settings:
+{{% feature expiryVersion="1.1.0" %}}
 - Agones Sidecar IP. (default: `http://localhost:59358`)
+{{% /feature %}}
+{{% feature publishVersion="1.1.0" %}}
+- Agones Sidecar IP. (default: `http://localhost:${AGONES_SDK_HTTP_PORT}`)
+{{% /feature %}}
 - Health Ping Enabled. Whether the server sends a health ping to the Agones sidecar. (default: `true`)
 - Health Ping Seconds. Interval of the server sending a health ping to the Agones sidecar. (default: `5`)
 - Debug Logging Enabled. Debug logging for development of this Plugin. (default: `false`)


### PR DESCRIPTION
I wrote some code to show what option 1 from https://github.com/googleforgames/agones/issues/851#issuecomment-536127066 would look like, since it seemed like the best option to me. 

I'll add tests and do some more checking if we decide to go this route, but I've already verified:

1. The sdk / sdkserver can be set to different ports and the gameserver becomes ready
1. If you specify the env vars they get overridden
1. If you specify the env vars in a configmap using EnvFromSource they get overridden

so it seems pretty robust. 