### PR TITLE
Fix install.yaml

### DIFF
--- a/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
@@ -107,24 +107,24 @@ properties:
             - Error
             - Info
             - Debug
-        grpcPort:
-          title: The port on which the SDK server binds the gRPC server to accept incoming connections
-          description: |
-            The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-            encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-            of Agones.
-          type: integer
-          minimum: 1
-          maximum: 65535
-        httpPort:
-          title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
-          description: |
-            The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-            encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-            of Agones.
-          type: integer
-          minimum: 1
-          maximum: 65535
+          grpcPort:
+            title: The port on which the SDK server binds the gRPC server to accept incoming connections
+            description: |
+              The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
+              encounter conflicts in rare cases. The default will be changed to 9357 in a future release
+              of Agones.
+            type: integer
+            minimum: 1
+            maximum: 65535
+          httpPort:
+            title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
+            description: |
+              The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
+              encounter conflicts in rare cases. The default will be changed to 9358 in a future release
+              of Agones.
+            type: integer
+            minimum: 1
+            maximum: 65535
       scheduling:
         type: string
         enum:

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -354,24 +354,24 @@ spec:
                           - Error
                           - Info
                           - Debug
-                      grpcPort:
-                        title: The port on which the SDK server binds the gRPC server to accept incoming connections
-                        description: |
-                          The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-                          encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-                          of Agones.
-                        type: integer
-                        minimum: 1
-                        maximum: 65535
-                      httpPort:
-                        title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
-                        description: |
-                          The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-                          encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-                          of Agones.
-                        type: integer
-                        minimum: 1
-                        maximum: 65535
+                        grpcPort:
+                          title: The port on which the SDK server binds the gRPC server to accept incoming connections
+                          description: |
+                            The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
+                            encounter conflicts in rare cases. The default will be changed to 9357 in a future release
+                            of Agones.
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                        httpPort:
+                          title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
+                          description: |
+                            The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
+                            encounter conflicts in rare cases. The default will be changed to 9358 in a future release
+                            of Agones.
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
                     scheduling:
                       type: string
                       enum:
@@ -642,24 +642,24 @@ spec:
                   - Error
                   - Info
                   - Debug
-              grpcPort:
-                title: The port on which the SDK server binds the gRPC server to accept incoming connections
-                description: |
-                  The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-                  encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-                  of Agones.
-                type: integer
-                minimum: 1
-                maximum: 65535
-              httpPort:
-                title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
-                description: |
-                  The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-                  encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-                  of Agones.
-                type: integer
-                minimum: 1
-                maximum: 65535
+                grpcPort:
+                  title: The port on which the SDK server binds the gRPC server to accept incoming connections
+                  description: |
+                    The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
+                    encounter conflicts in rare cases. The default will be changed to 9357 in a future release
+                    of Agones.
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                httpPort:
+                  title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
+                  description: |
+                    The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
+                    encounter conflicts in rare cases. The default will be changed to 9358 in a future release
+                    of Agones.
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
             scheduling:
               type: string
               enum:
@@ -943,24 +943,24 @@ spec:
                           - Error
                           - Info
                           - Debug
-                      grpcPort:
-                        title: The port on which the SDK server binds the gRPC server to accept incoming connections
-                        description: |
-                          The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-                          encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-                          of Agones.
-                        type: integer
-                        minimum: 1
-                        maximum: 65535
-                      httpPort:
-                        title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
-                        description: |
-                          The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-                          encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-                          of Agones.
-                        type: integer
-                        minimum: 1
-                        maximum: 65535
+                        grpcPort:
+                          title: The port on which the SDK server binds the gRPC server to accept incoming connections
+                          description: |
+                            The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
+                            encounter conflicts in rare cases. The default will be changed to 9357 in a future release
+                            of Agones.
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                        httpPort:
+                          title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
+                          description: |
+                            The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
+                            encounter conflicts in rare cases. The default will be changed to 9358 in a future release
+                            of Agones.
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
                     scheduling:
                       type: string
                       enum:


### PR DESCRIPTION
Indentation fix of `grpcPort` and `httpPort` .

Closes #1090 .