### PR TITLE
Fix the log output when starting the grpc gateway in the sdkserver

### DIFF
--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -222,7 +222,7 @@ func runGateway(ctx context.Context, grpcEndpoint string, mux *gwruntime.ServeMu
 		logger.WithError(err).Fatal("Could not register grpc-gateway")
 	}
 
-	logger.WithField("grpcEndpoint", grpcEndpoint).Info("Starting SDKServer grpc-gateway...")
+	logger.WithField("httpEndpoint", httpServer.Addr).Info("Starting SDKServer grpc-gateway...")
 	if err := httpServer.ListenAndServe(); err != nil {
 		if err == http.ErrServerClosed {
 			logger.WithError(err).Info("http server closed")


### PR DESCRIPTION
So that it is clear what port is being bound for http requests.

Very minor fix, but this has been confusing for me for the last couple of days. 