### PR TITLE
GameServer container restart before Ready, move to Unhealthy state After (v2)

### DIFF
--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -629,6 +629,33 @@ func TestGameServerIsDeletable(t *testing.T) {
 	assert.True(t, gs.IsDeletable())
 }
 
+func TestGameServerIsBeforeReady(t *testing.T) {
+	fixtures := []struct {
+		state    GameServerState
+		expected bool
+	}{
+		{GameServerStatePortAllocation, true},
+		{GameServerStateCreating, true},
+		{GameServerStateStarting, true},
+		{GameServerStateScheduled, true},
+		{GameServerStateRequestReady, true},
+		{GameServerStateReady, false},
+		{GameServerStateShutdown, false},
+		{GameServerStateError, false},
+		{GameServerStateUnhealthy, false},
+		{GameServerStateReserved, false},
+		{GameServerStateAllocated, false},
+	}
+
+	for _, test := range fixtures {
+		t.Run(string(test.state), func(t *testing.T) {
+			gs := &GameServer{Status: GameServerStatus{State: test.state}}
+			assert.Equal(t, test.expected, gs.IsBeforeReady())
+		})
+	}
+
+}
+
 func TestGameServerApplyToPodGameServerContainer(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/gameservers/health_test.go
+++ b/pkg/gameservers/health_test.go
@@ -79,6 +79,112 @@ func TestHealthUnschedulableWithNoFreePorts(t *testing.T) {
 	assert.False(t, hc.unschedulableWithNoFreePorts(pod))
 }
 
+func TestHealthControllerSkipUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	fixtures := map[string]struct {
+		setup    func(*agonesv1.GameServer, *corev1.Pod)
+		expected bool
+	}{
+		"scheduled and terminated container": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateScheduled
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  gs.Spec.Container,
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				}}
+			},
+			expected: true,
+		},
+		"after ready and terminated container": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateReady
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  gs.Spec.Container,
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				}}
+			},
+			expected: false,
+		},
+		"before ready, with no terminated container": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateScheduled
+			},
+			expected: false,
+		},
+		"after ready, with no terminated container": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateAllocated
+			},
+			expected: false,
+		},
+		"before ready, with a LastTerminated container": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateScheduled
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:                 gs.Spec.Container,
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				}}
+			},
+			expected: true,
+		},
+		"after ready, with a LastTerminated container, not matching": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateReady
+				gs.Annotations[agonesv1.GameServerReadyContainerIDAnnotation] = "4321"
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					ContainerID:          "1234",
+					Name:                 gs.Spec.Container,
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				}}
+			},
+			expected: false,
+		},
+		"after ready, with a LastTerminated container, matching": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateReserved
+				gs.Annotations[agonesv1.GameServerReadyContainerIDAnnotation] = "1234"
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					ContainerID:          "1234",
+					Name:                 gs.Spec.Container,
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				}}
+			},
+			expected: true,
+		},
+		"pod is missing!": {
+			setup: func(server *agonesv1.GameServer, pod *corev1.Pod) {
+				pod.ObjectMeta.Name = "missing"
+			},
+			expected: false,
+		},
+	}
+
+	for k, v := range fixtures {
+		t.Run(k, func(t *testing.T) {
+			m := agtesting.NewMocks()
+			hc := NewHealthController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
+			gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: defaultNs}, Spec: newSingleContainerSpec()}
+			gs.ApplyDefaults()
+			pod, err := gs.Pod()
+			assert.NoError(t, err)
+
+			v.setup(gs, pod)
+
+			m.KubeClient.AddReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &corev1.PodList{Items: []corev1.Pod{*pod}}, nil
+			})
+
+			_, cancel := agtesting.StartInformers(m, hc.podSynced)
+			defer cancel()
+
+			result, err := hc.skipUnhealthy(gs)
+			assert.NoError(t, err)
+			assert.Equal(t, v.expected, result)
+		})
+	}
+}
+
 func TestHealthControllerSyncGameServer(t *testing.T) {
 	t.Parallel()
 
@@ -86,8 +192,9 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 		updated bool
 	}
 	fixtures := map[string]struct {
-		state    agonesv1.GameServerState
-		expected expected
+		state     agonesv1.GameServerState
+		podStatus *corev1.PodStatus
+		expected  expected
 	}{
 		"started": {
 			state: agonesv1.GameServerStateStarting,
@@ -119,6 +226,18 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 				updated: true,
 			},
 		},
+		"container failed before ready": {
+			state: agonesv1.GameServerStateStarting,
+			podStatus: &corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "container", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}}}},
+			expected: expected{updated: false},
+		},
+		"container failed after ready": {
+			state: agonesv1.GameServerStateAllocated,
+			podStatus: &corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "container", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}}}},
+			expected: expected{updated: true},
+		},
 	}
 
 	for name, test := range fixtures {
@@ -133,6 +252,16 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 
 			got := false
 			updated := false
+			m.KubeClient.AddReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				list := &corev1.PodList{Items: []corev1.Pod{}}
+				if test.podStatus != nil {
+					pod, err := gs.Pod()
+					assert.NoError(t, err)
+					pod.Status = *test.podStatus
+					list.Items = append(list.Items, *pod)
+				}
+				return true, list, nil
+			})
 			m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 				got = true
 				return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{gs}}, nil
@@ -145,7 +274,7 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 				return true, gsObj, nil
 			})
 
-			_, cancel := agtesting.StartInformers(m)
+			_, cancel := agtesting.StartInformers(m, hc.gameServerSynced, hc.podSynced)
 			defer cancel()
 
 			err := hc.syncGameServer("default/test")

--- a/pkg/sdk/sdk.pb.go
+++ b/pkg/sdk/sdk.pb.go
@@ -18,13 +18,13 @@
 
 package sdk
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "google.golang.org/genproto/googleapis/api/annotations"
-
 import (
+	fmt "fmt"
+	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 	context "golang.org/x/net/context"
+	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
This brings our implementation inline with what our health checking documentation states that we do.

This is done by implementing extra checks in the HealthController to determine if it's appropriate to move to Unhealthy rather than allow a restart to occur.

Replaced PR #1069

Closes #956