### PR TITLE
Fix metrics bug for when a gameserver is not retrievable

### DIFF
--- a/pkg/gameserverallocations/metrics.go
+++ b/pkg/gameserverallocations/metrics.go
@@ -116,6 +116,7 @@ func (r *metrics) setResponse(o k8sruntime.Object) {
 		gs, err := r.gameServerLister.GameServers(out.Namespace).Get(out.Status.GameServerName)
 		if err != nil {
 			r.logger.WithError(err).Warnf("failed to get gameserver:%s namespace:%s", out.Status.GameServerName, out.Namespace)
+			return
 		}
 		fleetName := gs.Labels[agonesv1.FleetNameLabel]
 		if fleetName != "" {


### PR DESCRIPTION
If the gameserver is not retrievable (e.g. for when a gs is allocated remotely) the operation is logged as warning and fails with nil exception as it continues to gs.Labels.