### PR TITLE
Add owners files for the C++ code

### DIFF
--- a/examples/cpp-simple/OWNERS
+++ b/examples/cpp-simple/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - devjgm

--- a/sdks/cpp/OWNERS
+++ b/sdks/cpp/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - devjgm


### PR DESCRIPTION
Two reasons:

1. To document that @devjgm is handling the bulk of the code reviews (especially for style).
1. This will cause the blunderbuss plugin for prow to auto assign code reviews. 

/assign @devjgm 