### PR TITLE
Add owners files for the nodejs code

### DIFF
--- a/examples/nodejs-simple/OWNERS
+++ b/examples/nodejs-simple/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - steven-supersolid

--- a/sdks/nodejs/OWNERS
+++ b/sdks/nodejs/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - steven-supersolid


### PR DESCRIPTION
Two reasons:

1. To document that @steven-supersolid is handling the bulk of the code reviews (especially for style).
1. This will cause the blunderbuss plugin for prow to auto assign code reviews.

/assign @steven-supersolid