### PR TITLE
Added dynamic configuration of http port in the unity sdk

### DIFF
--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -44,7 +44,7 @@ namespace Agones
         /// </summary>
         public bool logEnabled = false;
 
-        private const string sidecarAddress = "http://localhost:59358";
+        private string sidecarAddress;
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
         private struct KeyValueMessage
@@ -58,6 +58,8 @@ namespace Agones
         // Use this for initialization.
         private void Start()
         {
+            String port = Environment.GetEnvironmentVariable("AGONES_SDK_HTTP_PORT");
+            sidecarAddress = "http://localhost:" + (port ?? "59358");
             HealthCheckAsync();
         }
 


### PR DESCRIPTION
@dzlier-gcp -- I'm looking for feedback on the way that I'm getting the environment variable and converting it to an integer. This follows the pattern I implemented for [Go](https://github.com/googleforgames/agones/pull/1086) / [nodejs](https://github.com/googleforgames/agones/pull/1093), but [in the C++ sdk](https://github.com/googleforgames/agones/pull/1092) I went with a more concise solution (with less logging / error checking) since that was considered more stylistically correct. 

Part of #851.

