### PR TITLE
Faster subsequent Rust SDK conformance builds

### DIFF
--- a/build/build-sdk-images/rust/build-sdk-test.sh
+++ b/build/build-sdk-images/rust/build-sdk-test.sh
@@ -15,5 +15,10 @@
 # limitations under the License.
 
 set -ex
+mkdir -p /go/src/agones.dev/agones/test/sdk/rust/.cargo
+mkdir -p /go/src/agones.dev/agones/test/sdk/rust/.cargo-targets
 cd /go/src/agones.dev/agones/test/sdk/rust
+export CARGO_HOME=/go/src/agones.dev/agones/test/sdk/rust/.cargo
+export CARGO_TARGET_DIR=/go/src/agones.dev/agones/test/sdk/rust/.cargo-targets
+cargo fetch
 cargo build

--- a/build/build-sdk-images/rust/clean.sh
+++ b/build/build-sdk-images/rust/clean.sh
@@ -18,4 +18,5 @@ set -ex
 cd /go/src/agones.dev/agones/test/sdk/rust
 cargo clean
 rm -f /go/src/agones.dev/agones/test/sdk/rust/Cargo.lock
-rm -rf /go/src/agones.dev/agones/test/sdk/rust/target
+rm -rf /go/src/agones.dev/agones/test/sdk/rust/.cargo-targets
+rm -rf /go/src/agones.dev/agones/test/sdk/rust/.cargo

--- a/build/build-sdk-images/rust/sdktest.sh
+++ b/build/build-sdk-images/rust/sdktest.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 set -ex
-/go/src/agones.dev/agones/test/sdk/rust/target/debug/rust-simple
+/go/src/agones.dev/agones/test/sdk/rust/.cargo-targets/debug/rust-simple

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,6 +36,13 @@ steps:
     - '--key=$_CPP_SDK_BUILD_CACHE_KEY'
   waitFor: ['-']
 
+- name: gcr.io/$PROJECT_ID/restore_cache
+  id: rust-sdk-build-restore-cache
+  args:
+    - '--bucket=gs://$_CACHE_BUCKET'
+    - '--key=$_RUST_SDK_BUILD_CACHE_KEY-$( checksum test/sdk/rust/Cargo.toml )'
+  waitFor: ['-']
+
 #
 # Creates the initial make + docker build platform
 #
@@ -236,6 +243,21 @@ steps:
     - build-images
 
 #
+# Cache the Rust SDK build directory, to speed up subsequent builds (considerably)
+#
+
+- name: 'gcr.io/$PROJECT_ID/save_cache'
+  args:
+    - '--bucket=gs://$_CACHE_BUCKET'
+    - '--key=$_RUST_SDK_BUILD_CACHE_KEY-$( checksum test/sdk/rust/Cargo.toml )'
+    - '--path=test/sdk/rust/.cargo'
+    - '--path=test/sdk/rust/.cargo-targets'
+    - '--no-clobber'
+  id: rust-build-save-cache
+  waitFor:
+    - sdk-conformance
+
+#
 # Zip up artifacts and push to storage
 #
 
@@ -256,6 +278,7 @@ substitutions:
   _CACHE_BUCKET: agones-build-cache
   _HTMLTEST_CACHE_KEY: htmltest-0.10.1
   _CPP_SDK_BUILD_CACHE_KEY: cpp-sdk-build
+  _RUST_SDK_BUILD_CACHE_KEY: rust-sdk-build
 
 tags: ['ci']
 timeout: "1h"

--- a/test/sdk/rust/.gitignore
+++ b/test/sdk/rust/.gitignore
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-/target/
 Cargo.lock

--- a/test/sdk/rust/Cargo.toml
+++ b/test/sdk/rust/Cargo.toml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# Update this version to trigger update of GCP cloud-build cache,
+# when Rust SDK or Rust test would be updated
 [package]
 name = "rust-simple"
 version = "0.1.0"


### PR DESCRIPTION
Add save-cache target for Rust. Fixed Rust SDK test subsequent call was downloading and rebuilding all dependencies.