### PR TITLE
Drop the Extension API Server reference from agones-allocator

### DIFF
--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -136,9 +136,24 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 - apiGroups: ["allocation.agones.dev"]
   resources: ["gameserverallocations"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["nodes", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["agones.dev"]
+  resources: ["gameservers", "gameserversets"]
+  verbs: ["get", "list", "update", "watch"]
+- apiGroups: ["agones.dev"]
+  resources: ["gameservers"]
+  verbs: ["patch"]
+- apiGroups: ["multicluster.agones.dev"]
+  resources: ["gameserverallocationpolicies"]
+  verbs: ["get", "list", "watch"]
 
 ---
 # Create a ServiceAccount that will be bound to the above role

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1174,9 +1174,24 @@ metadata:
     release: agones-manual
     heritage: Tiller
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 - apiGroups: ["allocation.agones.dev"]
   resources: ["gameserverallocations"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["nodes", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["agones.dev"]
+  resources: ["gameservers", "gameserversets"]
+  verbs: ["get", "list", "update", "watch"]
+- apiGroups: ["agones.dev"]
+  resources: ["gameservers"]
+  verbs: ["patch"]
+- apiGroups: ["multicluster.agones.dev"]
+  resources: ["gameserverallocationpolicies"]
+  verbs: ["get", "list", "watch"]
 
 ---
 # Create a ServiceAccount that will be bound to the above role


### PR DESCRIPTION
agones-allocator is referencing allocation extension API and this change is removing the dependency by referencing the allocator lib directly. 

Notes:
- ClusterRole for agones-allocator is now expended to access secrets, nodes and game servers
- The node game server counter is not synced with the counter used by game server controller and therefore the packed scheduling is not as accurate. (At this point packed or redistributed scheduling is not applicable for multi-cluster allocation as the destination cluster may not need the same scheduling setting as the origin cluster.)