### PR TITLE
Simplify the selection of the dynamic port in the nodejs sdk.

### DIFF
--- a/sdks/nodejs/spec/agonesSDK.spec.js
+++ b/sdks/nodejs/spec/agonesSDK.spec.js
@@ -32,28 +32,16 @@ describe('agones', () => {
 			expect(port).toEqual('59357');
 		});
 
-		it('returns the default port if $AGONES_SDK_GRPC_PORT is not an integer', async () => {
-			process.env.AGONES_SDK_GRPC_PORT = "random string";
-			let port = agonesSDK.port;
-			expect(port).toEqual('59357');
-		});
-
-		it('returns the default port if $AGONES_SDK_GRPC_PORT is to large of an integer', async () => {
-			process.env.AGONES_SDK_GRPC_PORT = '4455667788';
-			let port = agonesSDK.port;
-			expect(port).toEqual('59357');
-		});
-
-		it('returns the default port if $AGONES_SDK_GRPC_PORT is to small of an integer', async () => {
-			process.env.AGONES_SDK_GRPC_PORT = '0';
-			let port = agonesSDK.port;
-			expect(port).toEqual('59357');
-		});
-
-		it('returns the port set in $AGONES_SDK_GRPC_PORT', async () => {
+		it('returns a valid port set in $AGONES_SDK_GRPC_PORT', async () => {
 			process.env.AGONES_SDK_GRPC_PORT = '6789';
 			let port = agonesSDK.port;
 			expect(port).toEqual('6789');
+		});
+
+		it('returns an invalid port set in $AGONES_SDK_GRPC_PORT', async () => {
+			process.env.AGONES_SDK_GRPC_PORT = 'foo';
+			let port = agonesSDK.port;
+			expect(port).toEqual('foo');
 		});
 	});
 

--- a/sdks/nodejs/src/agonesSDK.js
+++ b/sdks/nodejs/src/agonesSDK.js
@@ -25,22 +25,8 @@ class AgonesSDK {
 	}
 
 	get port() {
-		const defaultPort = '59357';
 		const port = process.env.AGONES_SDK_GRPC_PORT;
-		if (port === undefined) {
-			console.log(`Environment variable AGONES_SDK_GRPC_PORT not defined, using default port ${defaultPort}`);
-			return defaultPort;
-		}
-		const portNum = parseInt(port, 10);
-		if (isNaN(portNum)) {
-			console.log(`Unable to parse '${port}' defined in AGONES_SDK_GRPC_PORT into an integer`);
-			return defaultPort;
-		}
-		if (portNum < 1 || portNum > 65535) {
-			console.log(`Invalid port ${portNum} defined in AGONES_SDK_GRPC_PORT. It must be between 1 and 65535`);
-			return defaultPort;
-		}
-		return port;
+		return port === undefined ? '59357' : port;
 	}
 
 	async connect() {


### PR DESCRIPTION
This brings the NodeJS SDK in line with the C++ / Unity / Rust SDKs.

Part of #851.