### PR TITLE
Add dynamic configuration of the sidecar http port to the unreal sdk.

### DIFF
--- a/sdks/unreal/Agones/Agones.uplugin
+++ b/sdks/unreal/Agones/Agones.uplugin
@@ -1,7 +1,7 @@
 {
-  "FileVersion": 3,
+  "FileVersion": 4,
   "Version": 1,
-  "VersionName": "0.1",
+  "VersionName": "0.2",
   "FriendlyName": "Agones",
   "Description": "Unreal Engine Plugin for Agones Game Server Client",
   "Category": "Google",

--- a/sdks/unreal/Agones/Source/Agones/AgonesHook.h
+++ b/sdks/unreal/Agones/Source/Agones/AgonesHook.h
@@ -57,6 +57,7 @@ private:
 	/** Agones settings */
 	const class UAgonesSettings* Settings;
 
+	const FString SidecarAddress;
 	const FString ReadySuffix;
 	const FString HealthSuffix;
 	const FString ShutdownSuffix;

--- a/sdks/unreal/Agones/Source/Agones/AgonesSettings.cpp
+++ b/sdks/unreal/Agones/Source/Agones/AgonesSettings.cpp
@@ -16,7 +16,6 @@
 
 UAgonesSettings::UAgonesSettings()
 	: Super()
-	, AgonesSidecarAddress("http://localhost:59358")
 	, bHealthPingEnabled(true)
 	, HealthPingSeconds(5.0f)
 	, bDebugLogEnabled(false)

--- a/sdks/unreal/Agones/Source/Agones/Public/AgonesSettings.h
+++ b/sdks/unreal/Agones/Source/Agones/Public/AgonesSettings.h
@@ -32,9 +32,6 @@ public:
 	/** Default constructor */
 	UAgonesSettings();
 
-	UPROPERTY(EditAnywhere, config, Category = "Agones", meta = (DisplayName = "Agones Sidecar IP Address"))
-	FString AgonesSidecarAddress;
-
 	UPROPERTY(EditAnywhere, config, Category = "Agones", meta = (DisplayName = "Health Ping Enabled"))
 	bool bHealthPingEnabled;
 

--- a/site/content/en/docs/Guides/Client SDKs/unreal.md
+++ b/site/content/en/docs/Guides/Client SDKs/unreal.md
@@ -34,9 +34,6 @@ Available settings:
 {{% feature expiryVersion="1.1.0" %}}
 - Agones Sidecar IP. (default: `http://localhost:59358`)
 {{% /feature %}}
-{{% feature publishVersion="1.1.0" %}}
-- Agones Sidecar IP. (default: `http://localhost:${AGONES_SDK_HTTP_PORT}`)
-{{% /feature %}}
 - Health Ping Enabled. Whether the server sends a health ping to the Agones sidecar. (default: `true`)
 - Health Ping Seconds. Interval of the server sending a health ping to the Agones sidecar. (default: `5`)
 - Debug Logging Enabled. Debug logging for development of this Plugin. (default: `false`)


### PR DESCRIPTION
So I've been banging my head against UE4 today. The new code certainly does the right thing when the environment variable isn't set. But I can't convince my system to set the environment so that UE4 will actually see any values when the game is run. 

It turns out that cross compilation only works on Windows, so I can't compile a game to Linux to try and run it in a docker container (which is how I've tested setting environment variables for the other SDKs). And no matter what tricks I try, it always returns empty string when the example game I'm using is run on my mac. 

So... this _might_ work. Based on the documentation, it _should_ work, but without being able to actually test it I can't be sure if it does. 

Part of #851.