### PR TITLE
improve stackdriver metric type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module agones.dev/agones
 go 1.12
 
 require (
-	cloud.google.com/go v0.34.0 // indirect
+	cloud.google.com/go v0.34.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.8.0
 	fortio.org/fortio v1.3.1
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 h1:zNBQb37RGLmJybyMcs983HfUfpkw9OTFD9tbBfAViHE=
+github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -90,6 +90,8 @@ spec:
           value: {{ .Values.agones.metrics.prometheusEnabled | quote }}
         - name: STACKDRIVER_EXPORTER
           value: {{ .Values.agones.metrics.stackdriverEnabled | quote }}
+        - name: STACKDRIVER_LABELS
+          value: {{ .Values.agones.metrics.stackdriverLabels | quote }}
         - name: GCP_PROJECT_ID
           value: {{ .Values.agones.metrics.stackdriverProjectID | quote }}
         - name: SIDECAR_CPU_LIMIT

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -108,6 +108,16 @@ spec:
         - name: LOG_SIZE_LIMIT_MB
           value: {{ .Values.agones.controller.persistentLogsSizeLimitMB | quote }}
 {{- end }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTAINER_NAME
+          value: "agones-controller"
         livenessProbe:
           httpGet:
             path: /live

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -112,6 +112,16 @@ spec:
           value: {{ .Values.agones.metrics.stackdriverEnabled | quote }}
         - name: GCP_PROJECT_ID
           value: {{ .Values.agones.metrics.stackdriverProjectID | quote }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTAINER_NAME
+          value: "agones-allocator"
         ports:
         - name: https
           containerPort: 8443
@@ -192,7 +202,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: agones-allocator
- 
+
 {{- end }}
 
 ---

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -112,6 +112,8 @@ spec:
           value: {{ .Values.agones.metrics.stackdriverEnabled | quote }}
         - name: GCP_PROJECT_ID
           value: {{ .Values.agones.metrics.stackdriverProjectID | quote }}
+        - name: STACKDRIVER_LABELS
+          value: {{ .Values.agones.metrics.stackdriverLabels | quote }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -20,6 +20,7 @@ agones:
     prometheusServiceDiscovery: true
     stackdriverEnabled: false
     stackdriverProjectID: ""
+    stackdriverLabels: ""
   rbacEnabled: true
   registerServiceAccounts: true
   registerWebhooks: true

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1137,6 +1137,16 @@ spec:
           value: "false"
         - name: GCP_PROJECT_ID
           value: ""
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTAINER_NAME
+          value: "agones-allocator"
         ports:
         - name: https
           containerPort: 8443
@@ -1368,6 +1378,16 @@ spec:
           value: "/home/agones/logs"
         - name: LOG_SIZE_LIMIT_MB
           value: "10000"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTAINER_NAME
+          value: "agones-controller"
         livenessProbe:
           httpGet:
             path: /live

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1137,6 +1137,8 @@ spec:
           value: "false"
         - name: GCP_PROJECT_ID
           value: ""
+        - name: STACKDRIVER_LABELS
+          value: ""
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -1362,6 +1364,8 @@ spec:
           value: "true"
         - name: STACKDRIVER_EXPORTER
           value: "false"
+        - name: STACKDRIVER_LABELS
+          value: ""
         - name: GCP_PROJECT_ID
           value: ""
         - name: SIDECAR_CPU_LIMIT

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -21,13 +21,12 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"contrib.go.opencensus.io/exporter/stackdriver"
+	"github.com/pkg/errors"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
 )
-
-const unknown = "unknown"
 
 // RegisterPrometheusExporter register a prometheus exporter to OpenCensus with a given prometheus metric registry.
 // It will automatically add go runtime and process metrics using default prometheus collectors.
@@ -54,22 +53,10 @@ func RegisterPrometheusExporter(registry *prom.Registry) (http.Handler, error) {
 // RegisterStackdriverExporter register a Stackdriver exporter to OpenCensus.
 // It will add Agones metrics into Stackdriver on Google Cloud.
 func RegisterStackdriverExporter(projectID string, defaultLabels string) (*stackdriver.Exporter, error) {
-	instanceID, err := metadata.InstanceID()
+	monitoredRes, err := getMonitoredResource(projectID)
 	if err != nil {
-		logger.WithError(err).Warn("error getting instance ID")
-		instanceID = unknown
+		logger.WithError(err).Warn("error discovering monitored resource")
 	}
-	zone, err := metadata.Zone()
-	if err != nil {
-		logger.WithError(err).Warn("error getting zone")
-		zone = unknown
-	}
-	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
-	if err != nil {
-		logger.WithError(err).Warn("error getting cluster-name")
-		clusterName = unknown
-	}
-
 	labels, err := parseLabels(defaultLabels)
 	if err != nil {
 		return nil, err
@@ -78,21 +65,8 @@ func RegisterStackdriverExporter(projectID string, defaultLabels string) (*stack
 	sd, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: projectID,
 		// MetricPrefix helps uniquely identify your metrics.
-		MetricPrefix: "agones",
-		Resource: &monitoredres.MonitoredResource{
-			Type: "k8s_container",
-			Labels: map[string]string{
-				"project_id":   projectID,
-				"instance_id":  instanceID,
-				"zone":         zone,
-				"cluster_name": clusterName,
-
-				// See: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-				"namespace_id":   os.Getenv("POD_NAMESPACE"),
-				"pod_id":         os.Getenv("POD_NAME"),
-				"container_name": os.Getenv("CONTAINER_NAME"),
-			},
-		},
+		MetricPrefix:            "agones",
+		Resource:                monitoredRes,
 		DefaultMonitoringLabels: labels,
 	})
 	if err != nil {
@@ -118,4 +92,34 @@ func SetReportingPeriod(prometheus, stackdriver bool) {
 	if stackdriver || prometheus {
 		view.SetReportingPeriod(reportingPeriod)
 	}
+}
+
+func getMonitoredResource(projectID string) (*monitoredres.MonitoredResource, error) {
+	instanceID, err := metadata.InstanceID()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting instance ID")
+	}
+	zone, err := metadata.Zone()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting zone")
+	}
+	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster-name")
+	}
+
+	return &monitoredres.MonitoredResource{
+		Type: "k8s_container",
+		Labels: map[string]string{
+			"project_id":   projectID,
+			"instance_id":  instanceID,
+			"zone":         zone,
+			"cluster_name": clusterName,
+
+			// See: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
+			"namespace_id":   os.Getenv("POD_NAMESPACE"),
+			"pod_id":         os.Getenv("POD_NAME"),
+			"container_name": os.Getenv("CONTAINER_NAME"),
+		},
+	}, nil
 }

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -80,7 +80,7 @@ func RegisterStackdriverExporter(projectID string, defaultLabels string) (*stack
 		// MetricPrefix helps uniquely identify your metrics.
 		MetricPrefix: "agones",
 		Resource: &monitoredres.MonitoredResource{
-			Type: "container",
+			Type: "k8s_container",
 			Labels: map[string]string{
 				"project_id":   projectID,
 				"instance_id":  instanceID,

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -16,13 +16,18 @@ package metrics
 
 import (
 	"net/http"
+	"os"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
+	"google.golang.org/genproto/googleapis/api/monitoredres"
 )
+
+const unknown = "unknown"
 
 // RegisterPrometheusExporter register a prometheus exporter to OpenCensus with a given prometheus metric registry.
 // It will automatically add go runtime and process metrics using default prometheus collectors.
@@ -49,11 +54,40 @@ func RegisterPrometheusExporter(registry *prom.Registry) (http.Handler, error) {
 // RegisterStackdriverExporter register a Stackdriver exporter to OpenCensus.
 // It will add Agones metrics into Stackdriver on Google Cloud.
 func RegisterStackdriverExporter(projectID string) (sd *stackdriver.Exporter, err error) {
-	// Default project will be used
+	instanceID, err := metadata.InstanceID()
+	if err != nil {
+		logger.WithError(err).Warn("error getting instance ID")
+		instanceID = unknown
+	}
+	zone, err := metadata.Zone()
+	if err != nil {
+		logger.WithError(err).Warn("error getting zone")
+		zone = unknown
+	}
+	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
+	if err != nil {
+		logger.WithError(err).Warn("error getting cluster-name")
+		clusterName = unknown
+	}
+
 	sd, err = stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: projectID,
 		// MetricPrefix helps uniquely identify your metrics.
 		MetricPrefix: "agones",
+		Resource: &monitoredres.MonitoredResource{
+			Type: "container",
+			Labels: map[string]string{
+				"project_id":   projectID,
+				"instance_id":  instanceID,
+				"zone":         zone,
+				"cluster_name": clusterName,
+
+				// See: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
+				"namespace_id":   os.Getenv("POD_NAMESPACE"),
+				"pod_id":         os.Getenv("POD_NAME"),
+				"container_name": os.Getenv("CONTAINER_NAME"),
+			},
+		},
 	})
 	if err != nil {
 		return
@@ -61,7 +95,7 @@ func RegisterStackdriverExporter(projectID string) (sd *stackdriver.Exporter, er
 
 	// Register it as a metrics exporter
 	view.RegisterExporter(sd)
-	return
+	return sd, nil
 }
 
 // SetReportingPeriod set appropriate reporting period which depends on exporters

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -53,7 +53,7 @@ func RegisterPrometheusExporter(registry *prom.Registry) (http.Handler, error) {
 
 // RegisterStackdriverExporter register a Stackdriver exporter to OpenCensus.
 // It will add Agones metrics into Stackdriver on Google Cloud.
-func RegisterStackdriverExporter(projectID string) (sd *stackdriver.Exporter, err error) {
+func RegisterStackdriverExporter(projectID string) (*stackdriver.Exporter, error) {
 	instanceID, err := metadata.InstanceID()
 	if err != nil {
 		logger.WithError(err).Warn("error getting instance ID")
@@ -70,7 +70,7 @@ func RegisterStackdriverExporter(projectID string) (sd *stackdriver.Exporter, er
 		clusterName = unknown
 	}
 
-	sd, err = stackdriver.NewExporter(stackdriver.Options{
+	sd, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: projectID,
 		// MetricPrefix helps uniquely identify your metrics.
 		MetricPrefix: "agones",
@@ -90,7 +90,7 @@ func RegisterStackdriverExporter(projectID string) (sd *stackdriver.Exporter, er
 		},
 	})
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// Register it as a metrics exporter

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -16,8 +16,11 @@ package metrics
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"agones.dev/agones/pkg/util/runtime"
+	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 )
@@ -47,4 +50,23 @@ func MustTagKey(key string) tag.Key {
 		panic(err)
 	}
 	return t
+}
+
+func parseLabels(s string) (*stackdriver.Labels, error) {
+	res := &stackdriver.Labels{}
+	if s == "" {
+		return res, nil
+	}
+	pairs := strings.Split(s, ",")
+	if len(pairs) == 0 {
+		return res, nil
+	}
+	for _, p := range pairs {
+		keyValue := strings.Split(p, "=")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("invalid labels format: %s, expect key=value,key2=value2", s)
+		}
+		res.Set(keyValue[0], keyValue[1], "")
+	}
+	return res, nil
 }

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -300,31 +300,23 @@ func Test_parseLabels(t *testing.T) {
 		want    *stackdriver.Labels
 		wantErr bool
 	}{
-		{
-			"",
-			labelsFromMap(nil),
-			false,
-		},
-		{
-			"a=b",
-			labelsFromMap(map[string]string{"a": "b"}),
-			false,
-		},
-		{
-			"a=b,",
-			nil,
-			true,
-		},
-		{
-			"a=b,c",
-			nil,
-			true,
-		},
-		{
-			"a=b,c=d",
-			labelsFromMap(map[string]string{"a": "b", "c": "d"}),
-			false,
-		},
+		// valids
+		{"", labelsFromMap(nil), false},
+		{"a=b", labelsFromMap(map[string]string{"a": "b"}), false},
+		{"a=b,c=d", labelsFromMap(map[string]string{"a": "b", "c": "d"}), false},
+		{"a=b, c=d", labelsFromMap(map[string]string{"a": "b", "c": "d"}), false},
+		{"a=b , c = d ", labelsFromMap(map[string]string{"a": "b", "c": "d"}), false},
+		{" a = b , c = d ", labelsFromMap(map[string]string{"a": "b", "c": "d"}), false},
+		{" a = b , c = d,c=f ", labelsFromMap(map[string]string{"a": "b", "c": "f"}), false},
+
+		// errors
+		{"e", nil, true},
+		{"a=b,", nil, true},
+		{"a= =,", nil, true},
+		{"a=b,c", nil, true},
+		{"a=b,c =", nil, true},
+		{"a=b , c ==", nil, true},
+		{"a=b , c =\xc3\x28", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -31,7 +31,11 @@ _We recommend to install Agones in its own namespaces (like `agones-system` as s
 you can use the helm `--namespace` parameter to specify a different namespace._
 
 When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers are scheduled for better isolation and resiliency. By default Agones prefers to be scheduled on nodes labeled with `agones.dev/agones-system=true` and tolerates node taint `agones.dev/agones-system=true:NoExecute`. If no dedicated nodes are available, Agones will
+<<<<<<< HEAD
 run on regular nodes, but that's not recommended for production use. For instructions on setting up a dedicated node
+=======
+run on regular nodes, but that's not recommended for production use. For instructions on setting up a decidated node
+>>>>>>> Review feedback.
 pool for Agones, see the [Agones installation instructions]({{< relref "../_index.md" >}}) for your preferred environment.
 
 The command deploys Agones on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -110,7 +114,10 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.metrics.prometheusServiceDiscovery`         | Adds annotations for Prometheus ServiceDiscovery (and also Strackdriver)                        | `true`                 |
 | `agones.metrics.prometheusEnabled`                  | Enables controller metrics on port `8080` and path `/metrics`                                   | `true`                 |
 | `agones.metrics.stackdriverEnabled`                 | Enables Stackdriver exporter of controller metrics                                              | `false`                |
-| `agones.metrics.stackdriverProjectID`               | This overrides the default gcp project id for use with Stackdriver                              | ``                     |
+| `agones.metrics.stackdriverProjectID`               | This overrides the default gcp project id for use with stackdriver                              | ``                     |
+{{% feature publishVersion="1.3.0" %}}
+| `agones.metrics.stackdriverLabels`                  | A set of default labels to add to all stackdriver metrics generated in form of key value pair (`key=value,key2=value2`). By default metadata are automatically added using Kubernetes API and GCP metadata enpoint.                              | ``                     |
+{{% /feature %}}
 | `agones.serviceaccount.controller`                  | Service account name for the controller                                                         | `agones-controller`    |
 | `agones.serviceaccount.sdk`                         | Service account name for the sdk                                                                | `agones-sdk`           |
 | `agones.image.registry`                             | Global image registry for all images                                                            | `gcr.io/agones-images` |

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -32,7 +32,7 @@ you can use the helm `--namespace` parameter to specify a different namespace._
 
 When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers are scheduled for better isolation and resiliency. By default Agones prefers to be scheduled on nodes labeled with `agones.dev/agones-system=true` and tolerates node taint `agones.dev/agones-system=true:NoExecute`. If no dedicated nodes are available, Agones will
 run on regular nodes, but that's not recommended for production use. For instructions on setting up a dedicated node
-pool for Agones, see the [Agones installation instructions]({{< relref "../_index.md" >}}) for your preferred environment. 
+pool for Agones, see the [Agones installation instructions]({{< relref "../_index.md" >}}) for your preferred environment.
 
 The command deploys Agones on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -31,11 +31,7 @@ _We recommend to install Agones in its own namespaces (like `agones-system` as s
 you can use the helm `--namespace` parameter to specify a different namespace._
 
 When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers are scheduled for better isolation and resiliency. By default Agones prefers to be scheduled on nodes labeled with `agones.dev/agones-system=true` and tolerates node taint `agones.dev/agones-system=true:NoExecute`. If no dedicated nodes are available, Agones will
-<<<<<<< HEAD
 run on regular nodes, but that's not recommended for production use. For instructions on setting up a dedicated node
-=======
-run on regular nodes, but that's not recommended for production use. For instructions on setting up a decidated node
->>>>>>> Review feedback.
 pool for Agones, see the [Agones installation instructions]({{< relref "../_index.md" >}}) for your preferred environment.
 
 The command deploys Agones on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.


### PR DESCRIPTION
As per the documentation https://godoc.org/contrib.go.opencensus.io/exporter/stackdriver

This will improve the metric typing and should now appears as a gke container in stackdriver interface.

If someone has time to test it and let me know if everything is correct, that would be awesome.