### PR TITLE
Fix CPP SDK archive path - created separate one

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@
 /build
 /cmd
 /sdks/cpp/.build
+/sdks/cpp/.archives
 .idea
 *.zip
 /release

--- a/build/includes/release.mk
+++ b/build/includes/release.mk
@@ -55,7 +55,7 @@ do-release:
 
 	$(MAKE) -j 4 build VERSION=$(RELEASE_VERSION) REGISTRY=$(release_registry) FULL_BUILD=1
 	cp $(agones_path)/cmd/sdk-server/bin/agonessdk-server-$(RELEASE_VERSION).zip $(agones_path)/release
-	cp $(agones_path)/sdks/cpp/.build/agonessdk-$(RELEASE_VERSION)-linux-arch_64.tar.gz $(agones_path)/release
+	cp $(agones_path)/sdks/cpp/.archives/agonessdk-$(RELEASE_VERSION)-linux-arch_64.tar.gz $(agones_path)/release
 	cd $(agones_path) &&  zip -r ./release/agones-install-$(RELEASE_VERSION).zip ./README.md ./install ./LICENSE
 
 	$(MAKE) gcloud-auth-docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -265,7 +265,7 @@ steps:
   waitFor:
     - build-sdks
     - tests
-  dir: "sdks/cpp/.build"
+  dir: "sdks/cpp/.archives"
   args: [ '-m', 'cp', '*.tar.gz', 'gs://agones-artifacts/cpp-sdk']
 - name: 'gcr.io/cloud-builders/gsutil'
   waitFor:

--- a/sdks/cpp/Makefile
+++ b/sdks/cpp/Makefile
@@ -21,9 +21,11 @@ source_path := $(dir $(mkfile_path))
 build_path := $(source_path)/.build
 package_path := $(build_path)/.install
 install_path := /opt/local
+archive_path := $(source_path)/.archives
 
 build:
 	-mkdir $(build_path)
+	-mkdir $(archive_path)
 	cd $(build_path) && cmake .. -DCMAKE_BUILD_TYPE=Release -DAGONES_SILENT_OUTPUT=ON -G "Unix Makefiles" -Wno-dev -DCMAKE_INSTALL_PREFIX=.install
 	cd $(build_path) && cmake --build . --target install -- -s
     
@@ -35,7 +37,7 @@ install:
 	
 archive: VERSION = "dev"
 archive:
-	cd $(package_path) && tar cf $(build_path)/agonessdk-$(VERSION)-linux-arch_64.tar.gz *
+	cd $(package_path) && tar cf $(archive_path)/agonessdk-$(VERSION)-linux-arch_64.tar.gz *
 	
 clean:
 	-rm -rf $(build_path)


### PR DESCRIPTION
It was a problem with using cache and putting archive to the same folder
as cached path.

Closes #1136.