### PR TITLE
Disable Auto Upgrade for Deployment Manager

### DIFF
--- a/build/gke-test-cluster/cluster.yml.jinja
+++ b/build/gke-test-cluster/cluster.yml.jinja
@@ -25,6 +25,8 @@ resources:
       nodePools:
         - name: "default"
           initialNodeCount: {{ properties["cluster.nodePool.initialNodeCount"] }}
+          management:
+            autoUpgrade: false
           config:
             machineType: {{ properties["cluster.nodePool.machineType"] }}
             tags:
@@ -38,6 +40,8 @@ resources:
               - https://www.googleapis.com/auth/trace.append
         - name: "agones-system"
           initialNodeCount: 1
+          management:
+            autoUpgrade: false
           config:
             machineType: n1-standard-4
             oauthScopes:
@@ -55,6 +59,8 @@ resources:
                 effect: "NO_EXECUTE"
         - name: "agones-metrics"
           initialNodeCount: 1
+          management:
+            autoUpgrade: false
           config:
             machineType: n1-standard-4
             oauthScopes:


### PR DESCRIPTION
Create development clusters with auto-upgrade disabled.

Part of #1140.
Relates to #1141.