### PR TITLE
Add Spec and Health data to default local sdk GameServer

### DIFF
--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -46,6 +46,14 @@ var (
 			Labels:            map[string]string{"islocal": "true"},
 			Annotations:       map[string]string{"annotation": "true"},
 		},
+		Spec: &sdk.GameServer_Spec{
+			Health: &sdk.GameServer_Spec_Health{
+				Disabled:            false,
+				PeriodSeconds:       3,
+				FailureThreshold:    5,
+				InitialDelaySeconds: 10,
+			},
+		},
 		Status: &sdk.GameServer_Status{
 			State:   "Ready",
 			Address: "127.0.0.1",


### PR DESCRIPTION
Noticed when building the Unity `SDK.GameServer()`, there was no data in the Spec field that come with the GameServer that comes through the SDK.

This gives it some default values, making it easier to build SDKs against.