### PR TITLE
Mitigate panic when no ports allocated in E2E tests

### DIFF
--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -38,9 +38,9 @@ spec:
     # portPolicy has three options:
     # - "Dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
     # - "Static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+    # port is available. When static is the policy specified, `hostPort` is required to be populated
     # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
     #      This will mean that users will need to lookup what port has been opened through the server side SDK.
-    # port is available. When static is the policy specified, `hostPort` is required to be populated
     portPolicy: Static
     # the port that is being opened on the game server process
     containerPort: 7654

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -27,9 +27,9 @@ spec:
     # portPolicy has three options:
     # - "Dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
     # - "Static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+    # port is available. When static is the policy specified, `hostPort` is required to be populated
     # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
     #      This will mean that users will need to lookup what port has been opened through the server side SDK.
-    # port is available. When static is the policy specified, `hostPort` is required to be populated
     portPolicy: Static
     # the port that is being opened on the game server process
     containerPort: 7654

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -300,8 +300,12 @@ func (f *Framework) CreateAndApplyAllocation(t *testing.T, flt *agonesv1.Fleet) 
 }
 
 // SendGameServerUDP sends a message to a gameserver and returns its reply
-// assumes the first port is the port to send the message to
+// assumes the first port is the port to send the message to,
+// returns error if no Ports were allocated
 func SendGameServerUDP(gs *agonesv1.GameServer, msg string) (string, error) {
+	if len(gs.Status.Ports) == 0 {
+		return "", errors.New("Empty Ports array")
+	}
 	address := fmt.Sprintf("%s:%d", gs.Status.Address, gs.Status.Ports[0].Port)
 	return SendUDP(address, msg)
 }


### PR DESCRIPTION
There could be a situation when no ports are allocated to GameServer.
Now E2E test would return fail not Panic.
Minor example comments fix.