### PR TITLE
Flaky: TestGameServerRestartBeforeReadyCrash

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -786,6 +786,11 @@ func (c *Controller) syncGameServerRequestReadyState(gs *agonesv1.GameServer) (*
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == gs.Spec.Container {
 			if _, ok := gs.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation]; !ok {
+				// check to make sure this container is actually running. If there was a recent crash, the cache may
+				// not yet have the newer, running container.
+				if cs.State.Running == nil {
+					return nil, errors.New("game server container is not currently running, try again")
+				}
 				gsCopy.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation] = cs.ContainerID
 			}
 			break

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -232,7 +232,7 @@ func (hc *HealthController) skipUnhealthy(gs *agonesv1.GameServer) (bool, error)
 		return hc.failedContainer(pod), nil
 	}
 
-	// finally, we need to check if there a failed container happened after the gameserver was ready or before.
+	// finally, we need to check if the failed container happened after the gameserver was ready or before.
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == gs.Spec.Container {
 			if cs.State.Terminated != nil {

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -301,7 +301,7 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 		return false
 	})
 	if err != nil {
-		assert.FailNowf(t, "Could not make GameServer Ready: %v", err.Error())
+		assert.FailNowf(t, "Could not make GameServer Ready", "reason: %v", err.Error())
 	}
 	// now crash, should be unhealthy, since it's after being Ready
 	logger.Info("crashing again, should be unhealthy")


### PR DESCRIPTION
There was a race condition in which if a game server container crashes,
and then restarts and moves to ready, the crashed game server
container id could be the recorded container that was added as an
Annotation to the GameServer, which would is incorrect.

This fix has a check in place to ensure the game server container id
that is being added as the Annotation value, is from an actual running
container.

Closes #1173