### PR TITLE
Update documentation for the 1.2 release to use Kubernetes 1.13.

### DIFF
--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -21,7 +21,7 @@
 apiVersion: "agones.dev/v1"
 kind: Fleet
 # Fleet Metadata
-# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+# https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta
 metadata:
   name: fleet-example
 spec:

--- a/examples/fleetautoscaler.yaml
+++ b/examples/fleetautoscaler.yaml
@@ -20,7 +20,7 @@
 apiVersion: "autoscaling.agones.dev/v1"
 kind: FleetAutoscaler
 # FleetAutoscaler Metadata
-# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+# https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta
 metadata:
   name: fleet-autoscaler-example
 spec:

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -24,7 +24,7 @@
 apiVersion: "agones.dev/v1"
 kind: GameServer
 # GameServer Metadata
-# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+# https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta
 metadata:
   # generateName: "gds-example" # generate a unique name, with the given prefix
   name: "gds-example" # set a fixed name
@@ -75,7 +75,7 @@ spec:
     grpcPort: 9357
     httpPort: 9358
   # Pod template configuration
-  # https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podtemplate-v1-core
+  # https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplate-v1-core
   template:
     # pod metadata. Name & Namespace is overwritten
     metadata:

--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -17,6 +17,7 @@ If no dedicated nodes are available, Agones will run on regular nodes.
 
 ## Usage Requirements
 
+{{% feature expiryVersion="1.2.0" %}}
 - Kubernetes cluster version 1.12
     - [Minikube](https://github.com/kubernetes/minikube), [Kind](https://github.com/kubernetes-sigs/kind), [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/),
       [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) and [Amazon EKS](https://aws.amazon.com/eks/) have been tested
@@ -28,11 +29,35 @@ If no dedicated nodes are available, Agones will run on regular nodes.
     [recommended set of admission controllers](https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).
 - Firewall access for the range of ports that Game Servers can be connected to in the cluster.
 - Game Servers must have the [game server SDK]({{< ref "/docs/Guides/Client SDKs/_index.md"  >}}) integrated, to manage Game Server state, health checking, etc.
+{{% /feature %}}
 
+{{% feature publishversion="1.2.0" %}}
+- Kubernetes cluster version 1.13
+    - [Minikube](https://github.com/kubernetes/minikube), [Kind](https://github.com/kubernetes-sigs/kind), [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/),
+      [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) and [Amazon EKS](https://aws.amazon.com/eks/) have been tested
+    - If you are creating and managing your own Kubernetes cluster, the
+    [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook-beta-in-19), and
+    [ValidatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#validatingadmissionwebhook-alpha-in-18-beta-in-19)
+    admission controllers are required.
+    We also recommend following the
+    [recommended set of admission controllers](https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).
+- Firewall access for the range of ports that Game Servers can be connected to in the cluster.
+- Game Servers must have the [game server SDK]({{< ref "/docs/Guides/Client SDKs/_index.md"  >}}) integrated, to manage Game Server state, health checking, etc.
+{{% /feature %}}
+
+{{% feature expiryVersion="1.2.0" %}}
 {{< alert title="Warning" color="warning">}}
 Later versions of Kubernetes may work, but this project is tested against 1.12, and is therefore the supported version.
 Agones will update its support to n-1 version of what is available across all major cloud providers - GKE, EKS and AKS
 {{< /alert >}}
+{{% /feature %}}
+
+{{% feature publishversion="1.2.0" %}}
+{{< alert title="Warning" color="warning">}}
+Later versions of Kubernetes may work, but this project is tested against 1.13, and is therefore the supported version.
+Agones will update its support to n-1 version of what is available across all major cloud providers - GKE, EKS and AKS
+{{< /alert >}}
+{{% /feature %}}
 
 ## Setting up a Google Kubernetes Engine (GKE) cluster
 
@@ -100,6 +125,7 @@ To install `gcloud` and `kubectl`, perform the following steps:
 
 A [cluster][cluster] consists of at least one *cluster master* machine and multiple worker machines called *nodes*: [Compute Engine virtual machine][vms] instances that run the Kubernetes processes necessary to make them part of the cluster.
 
+{{% feature expiryVersion="1.2.0" %}}
 ```bash
 gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.12 \
   --tags=game-server \
@@ -108,10 +134,26 @@ gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.12 \
   --no-enable-autoupgrade \
   --machine-type=n1-standard-4
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```bash
+gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.13 \
+  --tags=game-server \
+  --scopes=gke-default \
+  --num-nodes=4 \
+  --no-enable-autoupgrade \
+  --machine-type=n1-standard-4
+```
+{{% /feature %}}
 
 Flag explanations:
 
+{{% feature expiryVersion="1.2.0" %}}
 * cluster-version: Agones requires Kubernetes version 1.12.
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+* cluster-version: Agones requires Kubernetes version 1.13.
+{{% /feature %}}
 * tags: Defines the tags that will be attached to new nodes in the cluster. This is to grant access through ports via the firewall created in the next step.
 * scopes: Defines the Oauth scopes required by the nodes.
 * num-nodes: The number of nodes to be created in each of the cluster's zones. Default: 4. Depending on the needs of your game, this parameter should be adjusted.
@@ -171,6 +213,10 @@ gcloud compute firewall-rules create game-server-firewall \
   --description "Firewall to allow game server udp traffic"
 ```
 
+### Follow Normal Instructions to Install
+
+Continue to [Installing Agones](#installing-agones).
+
 ## Setting up a Minikube cluster
 
 This will setup a [Minikube](https://github.com/kubernetes/minikube) cluster, running on an `agones` profile.
@@ -196,9 +242,20 @@ minikube profile agones
 The following command starts a local minikube cluster via virtualbox - but this can be
 replaced by a [vm-driver](https://github.com/kubernetes/minikube#requirements) of your choice.
 
+{{% feature expiryVersion="1.2.0" %}}
 ```bash
 minikube start --kubernetes-version v1.12.10 --vm-driver virtualbox
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```bash
+minikube start --kubernetes-version v1.13.12 --vm-driver virtualbox
+```
+{{% /feature %}}
+
+### Follow Normal Instructions to Install
+
+Continue to [Installing Agones](#installing-agones).
 
 ## Setting up an Amazon Web Services EKS cluster
 
@@ -210,6 +267,7 @@ Possible steps are the following:
 1. Create new IAM role for cluster management.
 1. Run `aws configure` to authorize your `awscli` with proper `AWS Access Key ID` and `AWS Secret Access Key`.
 1. Create an example cluster:
+{{% feature expiryVersion="1.2.0" %}}
 ```
 eksctl create cluster \
 --name prod \
@@ -221,6 +279,20 @@ eksctl create cluster \
 --nodes-max 4 \
 --node-ami auto
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```
+eksctl create cluster \
+--name prod \
+--version 1.13 \
+--nodegroup-name standard-workers \
+--node-type t3.medium \
+--nodes 3 \
+--nodes-min 3 \
+--nodes-max 4 \
+--node-ami auto
+```
+{{% /feature %}}
 
 {{< alert title="Note" color="info">}}
 EKS does not use the normal Kubernetes networking since it is [incompatible with Amazon VPC networking](https://www.contino.io/insights/kubernetes-is-hard-why-eks-makes-it-easier-for-network-and-security-architects).
@@ -254,6 +326,7 @@ If you are using Azure CLI from your local shell, you need to login to your Azur
 
 Here are the steps you need to follow to create a new AKS cluster (additional instructions and clarifications are listed [here](https://docs.microsoft.com/azure/aks/kubernetes-walkthrough)):
 
+{{% feature expiryVersion="1.2.0" %}}
 ```bash
 # Declare necessary variables, modify them according to your needs
 AKS_RESOURCE_GROUP=akstestrg     # Name of the resource group your AKS cluster will be created in
@@ -273,6 +346,28 @@ sudo az aks install-cli
 # Get credentials for your new AKS cluster
 az aks get-credentials --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```bash
+# Declare necessary variables, modify them according to your needs
+AKS_RESOURCE_GROUP=akstestrg     # Name of the resource group your AKS cluster will be created in
+AKS_NAME=akstest     # Name of your AKS cluster
+AKS_LOCATION=westeurope     # Azure region in which you'll deploy your AKS cluster
+
+# Create the Resource Group where your AKS resource will be installed
+az group create --name $AKS_RESOURCE_GROUP --location $AKS_LOCATION
+
+# Create the AKS cluster - this might take some time. Type 'az aks create -h' to see all available options
+# The following command will create a four Node AKS cluster. Node size is Standard A1 v1 and Kubernetes version is 1.13.12. Plus, SSH keys will be generated for you, use --ssh-key-value to provide your values
+az aks create --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME --node-count 4 --generate-ssh-keys --node-vm-size Standard_A4_v2 --kubernetes-version 1.13.12
+
+# Install kubectl
+sudo az aks install-cli
+
+# Get credentials for your new AKS cluster
+az aks get-credentials --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME
+```
+{{% /feature %}}
 
 Alternatively, you can use the [Azure Portal](https://portal.azure.com) to create a new AKS cluster [(instructions)](https://docs.microsoft.com/azure/aks/kubernetes-walkthrough-portal).
 
@@ -304,6 +399,8 @@ az network nsg rule create \
 #### Creating and assigning Public IPs to Nodes
 
 Nodes in AKS don't get a Public IP by default. To assign a Public IP to a Node, find the Resource Group where the AKS resources are installed on the [portal](https://portal.azure.com) (it should have a name like `MC_resourceGroupName_AKSName_westeurope`). Then, you can follow the instructions [here](https://docs.microsoft.com/en-us/azure/site-recovery/concepts-public-ip-address-with-site-recovery) to create a new Public IP and assign it to the Node/VM. For more information on Public IPs for VM NICs, see [this document](https://docs.microsoft.com/azure/virtual-network/virtual-network-network-interface-addresses). If you are looking for an automated way to create and assign Public IPs for your AKS Nodes, check [this project](https://github.com/dgkanatsios/AksNodePublicIPController).
+
+### Follow Normal Instructions to Install
 
 Continue to [Installing Agones](#installing-agones).
 

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -10,7 +10,12 @@ description: >
 ## Prerequisites
 
 - [Helm](https://docs.helm.sh/helm/) package manager 2.10.0+
+{{% feature expiryVersion="1.2.0" %}}
 - Kubernetes 1.11+
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+- Kubernetes 1.13
+{{% /feature %}}
 - Role-based access controls (RBAC) activated
 - MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission controllers activated, see [recommendation](https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use)
 

--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -12,6 +12,7 @@ Like any other Kubernetes resource you describe a `Fleet`'s desired state via a 
 
 A full `Fleet` specification is available below and in the {{< ghlink href="examples/fleet.yaml" >}}example folder{{< /ghlink >}} for reference :
 
+{{% feature expiryVersion="1.2.0" %}}
 ```yaml
 apiVersion: "agones.dev/v1"
 kind: Fleet
@@ -69,6 +70,66 @@ spec:
           - name: simple-udp
             image: gcr.io/agones-images/udp-server:0.17
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```yaml
+apiVersion: "agones.dev/v1"
+kind: Fleet
+# Fleet Metadata
+# https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta
+metadata:
+  name: fleet-example
+spec:
+  # the number of GameServers to keep Ready or Allocated in this Fleet
+  replicas: 2
+  # defines how GameServers are organised across the cluster.
+  # Options include:
+  # "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack
+  # resources
+  # "Distributed" is aimed at static Kubernetes clusters, wherein we want to distribute resources across the entire
+  # cluster
+  scheduling: Packed
+  # a GameServer template - see:
+  # https://agones.dev/site/docs/reference/gameserver/ for all the options
+  strategy:
+    # The replacement strategy for when the GameServer template is changed. Default option is "RollingUpdate",
+    # "RollingUpdate" will increment by maxSurge value on each iteration, while decrementing by maxUnavailable on each
+    # iteration, until all GameServers have been switched from one version to another.
+    # "Recreate" terminates all non-allocated GameServers, and starts up a new set with the new details to replace them.
+    type: RollingUpdate
+    # Only relevant when `type: RollingUpdate`
+    rollingUpdate:
+      # the amount to increment the new GameServers by. Defaults to 25%
+      maxSurge: 25%
+      # the amount to decrements GameServers by. Defaults to 25%
+      maxUnavailable: 25%
+  template:
+    # GameServer metadata
+    metadata:
+      labels:
+        foo: bar
+    # GameServer specification
+    spec:
+      ports:
+      - name: default
+        portPolicy: Dynamic
+        containerPort: 26000
+      health:
+        initialDelaySeconds: 30
+        periodSeconds: 60
+      # Parameters for game server sidecar
+      sdkServer:
+        logLevel: Info
+        grpcPort: 9357
+        httpPort: 9358
+      # The GameServer's Pod template
+      template:
+        spec:
+          containers:
+          - name: simple-udp
+            image: gcr.io/agones-images/udp-server:0.17
+```
+{{% /feature %}}
 
 Since Agones defines a new 
 [Custom Resources Definition (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) 

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -9,6 +9,7 @@ weight: 30
 A full `FleetAutoscaler` specification is available below and in the 
 {{< ghlink href="examples/fleetautoscaler.yaml" >}}example folder{{< /ghlink >}} for reference :
 
+{{% feature expiryVersion="1.2.0" %}}
 ```yaml
 apiVersion: "autoscaling.agones.dev/v1"
 kind: FleetAutoscaler
@@ -39,6 +40,38 @@ spec:
       # required
       maxReplicas: 20
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```yaml
+apiVersion: "autoscaling.agones.dev/v1"
+kind: FleetAutoscaler
+# FleetAutoscaler Metadata
+# https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta
+metadata:
+  name: fleet-autoscaler-example
+spec:
+  # The name of the fleet to attach to and control. Must be an existing Fleet in the same namespace
+  # as this FleetAutoscaler
+  fleetName: fleet-example
+  # The autoscaling policy
+  policy:
+    # type of the policy. for now, only Buffer is available
+    type: Buffer
+    # parameters of the buffer policy
+    buffer:
+      # Size of a buffer of "ready" game server instances
+      # The FleetAutoscaler will scale the fleet up and down trying to maintain this buffer, 
+      # as instances are being allocated or terminated
+      # it can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
+      bufferSize: 5
+      # minimum fleet size to be set by this FleetAutoscaler. 
+      # if not specified, the actual minimum fleet size will be bufferSize
+      minReplicas: 10
+      # maximum fleet size that can be set by this FleetAutoscaler
+      # required
+      maxReplicas: 20
+```
+{{% /feature %}}
 
 Or for Webhook FleetAutoscaler below and in {{< ghlink href="examples/webhookfleetautoscaler.yaml" >}}example folder{{< /ghlink >}}:
 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -84,7 +84,7 @@ spec:
 apiVersion: "agones.dev/v1"
 kind: GameServer
 # GameServer Metadata
-# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+# https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta
 metadata:
   # generateName: "gds-example" # generate a unique name, with the given prefix
   name: "gds-example" # set a fixed name
@@ -135,7 +135,7 @@ spec:
     grpcPort: 9357
     httpPort: 9358
   # Pod template configuration
-  # https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podtemplate-v1-core
+  # https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplate-v1-core
   template:
     # pod metadata. Name & Namespace is overwritten
     metadata:


### PR DESCRIPTION
Also update links from examples to Kubernetes 1.13 docs.

Closes https://github.com/googleforgames/agones/issues/1044

/hold

Adding a hold until we can test Kubernetes 1.13 on EKS & AKS. 