### PR TITLE
Update the default gRPC and HTTP ports for the sdkserver for the 1.2.0 release

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -123,7 +123,7 @@ ensure-build-sdk-image:
 run-sdk-conformance-local: TIMEOUT ?= 30
 run-sdk-conformance-local: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
 run-sdk-conformance-local: ensure-agones-sdk-image
-	docker run -e "ADDRESS=" -p 59357:59357 -p 59358:59358 \
+	docker run -e "ADDRESS=" -p 9357:9357 -p 9358:9358 \
 	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" $(sidecar_tag)
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
@@ -132,8 +132,8 @@ run-sdk-conformance-no-build: TIMEOUT ?= 30
 run-sdk-conformance-no-build: RANDOM := $(shell bash -c 'echo $$RANDOM')
 run-sdk-conformance-no-build: DELAY ?= $(shell bash -c "echo $$[ ($(RANDOM) % 5 ) + 1 ]")
 run-sdk-conformance-no-build: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
-run-sdk-conformance-no-build: GRPC_PORT ?= 59357
-run-sdk-conformance-no-build: HTTP_PORT ?= 59358
+run-sdk-conformance-no-build: GRPC_PORT ?= 9357
+run-sdk-conformance-no-build: HTTP_PORT ?= 9358
 run-sdk-conformance-no-build: ensure-agones-sdk-image
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	DOCKER_RUN_ARGS="--net host -e AGONES_SDK_GRPC_PORT=$(GRPC_PORT) -e AGONES_SDK_HTTP_PORT=$(HTTP_PORT) $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -41,8 +41,8 @@ import (
 )
 
 const (
-	defaultGRPCPort = 59357
-	defaultHTTPPort = 59358
+	defaultGRPCPort = 9357
+	defaultHTTPPort = 9358
 
 	// specifically env vars
 	gameServerNameEnv = "GAMESERVER_NAME"

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -68,10 +68,10 @@ spec:
     #  - "Error" The SDK server will only output error messages
     logLevel: Info
     # grpcPort and httpPort control what ports the sdkserver listens on.
-    # The defaults in Agones 1.0 used high port numbers (in the ephemeral port
-    # range on most systems) which can conflict with other TCP connections
-    # within the pod. It is recommended to set these to a non-ephemeral port
-    # and the default port will be changed in a future release of Agones.
+    # Starting with Agones 1.2 the default grpcPort is 9357 and the default
+    # httpPort is 9358. In earlier releases, the defaults were 59357 and 59358
+    # respectively but as these were in the ephemeral port range they could
+    # conflict with other TCP connections.
     grpcPort: 9357
     httpPort: 9358
   # Pod template configuration

--- a/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
@@ -110,18 +110,14 @@ properties:
           grpcPort:
             title: The port on which the SDK server binds the gRPC server to accept incoming connections
             description: |
-              The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-              encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-              of Agones.
+              Starting with Agones 1.2 the default gRPC port is 9357. In earlier releases, the default was 59357.
             type: integer
             minimum: 1
             maximum: 65535
           httpPort:
             title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
             description: |
-              The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-              encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-              of Agones.
+              Starting with Agones 1.2 the default HTTP port is 9358. In earlier releases, the default was 59358.
             type: integer
             minimum: 1
             maximum: 65535

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -357,18 +357,14 @@ spec:
                         grpcPort:
                           title: The port on which the SDK server binds the gRPC server to accept incoming connections
                           description: |
-                            The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-                            encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-                            of Agones.
+                            Starting with Agones 1.2 the default gRPC port is 9357. In earlier releases, the default was 59357.
                           type: integer
                           minimum: 1
                           maximum: 65535
                         httpPort:
                           title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
                           description: |
-                            The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-                            encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-                            of Agones.
+                            Starting with Agones 1.2 the default HTTP port is 9358. In earlier releases, the default was 59358.
                           type: integer
                           minimum: 1
                           maximum: 65535
@@ -645,18 +641,14 @@ spec:
                 grpcPort:
                   title: The port on which the SDK server binds the gRPC server to accept incoming connections
                   description: |
-                    The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-                    encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-                    of Agones.
+                    Starting with Agones 1.2 the default gRPC port is 9357. In earlier releases, the default was 59357.
                   type: integer
                   minimum: 1
                   maximum: 65535
                 httpPort:
                   title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
                   description: |
-                    The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-                    encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-                    of Agones.
+                    Starting with Agones 1.2 the default HTTP port is 9358. In earlier releases, the default was 59358.
                   type: integer
                   minimum: 1
                   maximum: 65535
@@ -944,18 +936,14 @@ spec:
                         grpcPort:
                           title: The port on which the SDK server binds the gRPC server to accept incoming connections
                           description: |
-                            The default gRPC port in Agones 1.0 was 59357 which is in the ephemeral port range and can
-                            encounter conflicts in rare cases. The default will be changed to 9357 in a future release
-                            of Agones.
+                            Starting with Agones 1.2 the default gRPC port is 9357. In earlier releases, the default was 59357.
                           type: integer
                           minimum: 1
                           maximum: 65535
                         httpPort:
                           title: The port on which the SDK server binds the HTTP gRPC gateway server to accept incoming connections
                           description: |
-                            The default HTTP port in Agones 1.0 was 59358 which is in the ephemeral port range and can
-                            encounter conflicts in rare cases. The default will be changed to 9358 in a future release
-                            of Agones.
+                            Starting with Agones 1.2 the default HTTP port is 9358. In earlier releases, the default was 59358.
                           type: integer
                           minimum: 1
                           maximum: 65535

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -248,12 +248,10 @@ func (gss *GameServerSpec) applySdkServerDefaults() {
 		gss.SdkServer.LogLevel = SdkServerLogLevelInfo
 	}
 	if gss.SdkServer.GRPCPort == 0 {
-		// TODO(roberthbailey): Change to 9357 in the 1.2.0 release
-		gss.SdkServer.GRPCPort = 59357
+		gss.SdkServer.GRPCPort = 9357
 	}
 	if gss.SdkServer.HTTPPort == 0 {
-		// TODO(roberthbailey): Change to 9358 in the 1.2.0 release
-		gss.SdkServer.HTTPPort = 59358
+		gss.SdkServer.HTTPPort = 9358
 	}
 }
 

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -96,8 +96,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelInfo,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -124,8 +124,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelInfo,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -151,8 +151,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 					},
 					SdkServer: SdkServer{
 						LogLevel: SdkServerLogLevelInfo,
-						GRPCPort: 59357,
-						HTTPPort: 59358,
+						GRPCPort: 9357,
+						HTTPPort: 9358,
 					},
 				},
 				Status: GameServerStatus{State: "TestState"}},
@@ -170,8 +170,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelInfo,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -196,8 +196,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelInfo,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -220,8 +220,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelInfo,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -249,8 +249,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				health:     Health{Disabled: true},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelInfo,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -278,8 +278,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelDebug,
-					GRPCPort: 59357,
-					HTTPPort: 59358,
+					GRPCPort: 9357,
+					HTTPPort: 9358,
 				},
 			},
 		},
@@ -289,8 +289,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 					Ports: []GameServerPort{{ContainerPort: 999}},
 					SdkServer: SdkServer{
 						LogLevel: SdkServerLogLevelError,
-						GRPCPort: 9357,
-						HTTPPort: 9358,
+						GRPCPort: 19357,
+						HTTPPort: 19358,
 					},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{Containers: []corev1.Container{
@@ -311,8 +311,8 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				},
 				sdkServer: SdkServer{
 					LogLevel: SdkServerLogLevelError,
-					GRPCPort: 9357,
-					HTTPPort: 9358,
+					GRPCPort: 19357,
+					HTTPPort: 19358,
 				},
 			},
 		},

--- a/sdks/cpp/src/agones/sdk.cc
+++ b/sdks/cpp/src/agones/sdk.cc
@@ -29,7 +29,7 @@ struct SDK::SDKImpl {
 
 SDK::SDK() : pimpl_{std::make_unique<SDKImpl>()} {
   const char* port = std::getenv("AGONES_SDK_GRPC_PORT");
-  pimpl_->host_ = std::string("localhost:") + (port ? port : "59357");
+  pimpl_->host_ = std::string("localhost:") + (port ? port : "9357");
   pimpl_->channel_ =
       grpc::CreateChannel(pimpl_->host_, grpc::InsecureChannelCredentials());
 }

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -39,12 +39,12 @@ type SDK struct {
 }
 
 // NewSDK starts a new SDK instance, and connects to
-// localhost on port 59357. Blocks until connection and handshake are made.
+// localhost on port 9357. Blocks until connection and handshake are made.
 // Times out after 30 seconds.
 func NewSDK() (*SDK, error) {
 	p := os.Getenv("AGONES_SDK_GRPC_PORT")
 	if p == "" {
-		p = "59357"
+		p = "9357"
 	}
 	addr := fmt.Sprintf("localhost:%s", p)
 	s := &SDK{

--- a/sdks/nodejs/spec/agonesSDK.spec.js
+++ b/sdks/nodejs/spec/agonesSDK.spec.js
@@ -29,7 +29,7 @@ describe('agones', () => {
 	describe('port', () => {
 		it('returns the default port if $AGONES_SDK_GRPC_PORT is not defined', async () => {
 			let port = agonesSDK.port;
-			expect(port).toEqual('59357');
+			expect(port).toEqual('9357');
 		});
 
 		it('returns a valid port set in $AGONES_SDK_GRPC_PORT', async () => {

--- a/sdks/nodejs/src/agonesSDK.js
+++ b/sdks/nodejs/src/agonesSDK.js
@@ -25,7 +25,7 @@ class AgonesSDK {
 	}
 
 	get port() {
-		return process.env.AGONES_SDK_GRPC_PORT || '59357';
+		return process.env.AGONES_SDK_GRPC_PORT || '9357';
 	}
 
 	async connect() {

--- a/sdks/rust/src/sdk.rs
+++ b/sdks/rust/src/sdk.rs
@@ -33,11 +33,11 @@ pub struct Sdk {
 }
 
 impl Sdk {
-    /// Starts a new SDK instance, and connects to localhost on port 59357.
+    /// Starts a new SDK instance, and connects to localhost on port 9357.
     /// Blocks until connection and handshake are made.
     /// Times out after ~30 seconds.
     pub fn new() -> Result<Sdk> {
-        let port = env::var("AGONES_SDK_GRPC_PORT").unwrap_or("59357".to_string());
+        let port = env::var("AGONES_SDK_GRPC_PORT").unwrap_or("9357".to_string());
         let addr = format!("localhost:{}", port);
         let env = Arc::new(grpcio::EnvBuilder::new().build());
         let ch = grpcio::ChannelBuilder::new(env)

--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -62,7 +62,7 @@ namespace Agones
         private void Start()
         {
             String port = Environment.GetEnvironmentVariable("AGONES_SDK_HTTP_PORT");
-            sidecarAddress = "http://localhost:" + (port ?? "59358");
+            sidecarAddress = "http://localhost:" + (port ?? "9358");
             HealthCheckAsync();
         }
 

--- a/sdks/unreal/Agones/Source/Agones/AgonesHook.cpp
+++ b/sdks/unreal/Agones/Source/Agones/AgonesHook.cpp
@@ -23,7 +23,7 @@ DEFINE_LOG_CATEGORY(LogAgonesHook);
 static FString GetSidecarAddress()
 {
 	FString port = FPlatformMisc::GetEnvironmentVariable(TEXT("AGONES_SDK_HTTP_PORT"));
-	return FString(TEXT("http://localhost:")) + (!port.IsEmpty() ? port : FString(TEXT("59358")));
+	return FString(TEXT("http://localhost:")) + (!port.IsEmpty() ? port : FString(TEXT("9358")));
 }
 
 FAgonesHook::FAgonesHook()

--- a/site/content/en/docs/Guides/Client SDKs/local.md
+++ b/site/content/en/docs/Guides/Client SDKs/local.md
@@ -32,6 +32,7 @@ To run in local mode, pass the flag `--local` to the executable.
 
 For example:
 
+{{% feature expiryVersion="1.2.0" %}}
 ```console
 $ ./sdk-server.linux.amd64 --local
 {"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"","Delay":0,"Timeout":0,"Test":"","GRPCPort":59357,"HTTPPort":59358},"message":"Starting sdk sidecar","severity":"info","source":"main","time":"2019-10-30T21:44:37.973139+03:00","version":"1.1.0"}
@@ -42,6 +43,19 @@ $ ./sdk-server.linux.amd64 --local
 {"message":"Shutdown request has been received!","severity":"info","time":"2019-10-30T21:46:18.179341+03:00"}
 {"message":"gameserver update received","severity":"info","time":"2019-10-30T21:46:18.179459+03:00"}
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```console
+$ ./sdk-server.linux.amd64 --local
+{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"","Delay":0,"Timeout":0,"Test":"","GRPCPort":9357,"HTTPPort":9358},"message":"Starting sdk sidecar","severity":"info","source":"main","time":"2019-10-30T21:44:37.973139+03:00","version":"1.1.0"}
+{"grpcEndpoint":"localhost:9357","message":"Starting SDKServer grpc service...","severity":"info","source":"main","time":"2019-10-30T21:44:37.974585+03:00"}
+{"httpEndpoint":"localhost:9358","message":"Starting SDKServer grpc-gateway...","severity":"info","source":"main","time":"2019-10-30T21:44:37.975086+03:00"}
+{"message":"Ready request has been received!","severity":"info","time":"2019-10-30T21:45:47.031989+03:00"}
+{"message":"gameserver update received","severity":"info","time":"2019-10-30T21:45:47.03225+03:00"}
+{"message":"Shutdown request has been received!","severity":"info","time":"2019-10-30T21:46:18.179341+03:00"}
+{"message":"gameserver update received","severity":"info","time":"2019-10-30T21:46:18.179459+03:00"}
+```
+{{% /feature %}}
 
 ### Providing your own `GameServer` configuration for local development
 
@@ -62,6 +76,7 @@ happen when live as well.
 
 For example:
 
+{{% feature expiryVersion="1.2.0" %}}
 ```console
 $ wget https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/gameserver.yaml
 $ ./sdk-server.linux.amd64 --local -f ./gameserver.yaml
@@ -70,6 +85,17 @@ $ ./sdk-server.linux.amd64 --local -f ./gameserver.yaml
 {"grpcEndpoint":"localhost:59357","message":"Starting SDKServer grpc service...","severity":"info","source":"main","time":"2019-10-30T21:47:45.759692+03:00"}
 {"httpEndpoint":"localhost:59358","message":"Starting SDKServer grpc-gateway...","severity":"info","source":"main","time":"2019-10-30T21:47:45.760312+03:00"}
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```console
+$ wget https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/examples/simple-udp/gameserver.yaml
+$ ./sdk-server.linux.amd64 --local -f ./gameserver.yaml
+{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"./gameserver.yaml","Delay":0,"Timeout":0,"Test":"","GRPCPort":9357,"HTTPPort":9358},"message":"Starting sdk sidecar","severity":"info","source":"main","time":"2019-10-30T21:47:45.742776+03:00","version":"1.1.0"}
+{"filePath":"/Users/alexander.apalikov/Downloads/agonessdk-server-1.1.0/gameserver.yaml","message":"Reading GameServer configuration","severity":"info","time":"2019-10-30T21:47:45.743369+03:00"}
+{"grpcEndpoint":"localhost:9357","message":"Starting SDKServer grpc service...","severity":"info","source":"main","time":"2019-10-30T21:47:45.759692+03:00"}
+{"httpEndpoint":"localhost:9358","message":"Starting SDKServer grpc-gateway...","severity":"info","source":"main","time":"2019-10-30T21:47:45.760312+03:00"}
+```
+{{% /feature %}}
 
 ### Changing State of a Local GameServer
 
@@ -87,6 +113,7 @@ All changes to the GameServer state could be observed and retrieved using Watch(
 
 Example of using HTTP gateway locally:
 
+{{% feature expiryVersion="1.2.0" %}}
 ```console
 $ curl -X POST "http://localhost:59358/ready" -H "accept: application/json" -H "Content-Type: application/json" -d "{}"
 {}
@@ -96,3 +123,15 @@ $ curl -X PUT "http://localhost:59358/metadata/label" -H "accept: application/js
 $ curl -GET "http://localhost:59358/gameserver" -H "accept: application/json"}"
 {"object_meta":{"creation_timestamp":"-62135596800","labels":{"agones.dev/sdk-foo":"bar"}},"spec":{"health":{}},"status":{"state":"Ready"}}
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```console
+$ curl -X POST "http://localhost:9358/ready" -H "accept: application/json" -H "Content-Type: application/json" -d "{}"
+{}
+$ curl -GET "http://localhost:9358/gameserver" -H "accept: application/json"
+{"object_meta":{"creation_timestamp":"-62135596800"},"spec":{"health":{}},"status":{"state":"Ready"}}
+$ curl -X PUT "http://localhost:9358/metadata/label" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"key\": \"foo\", \"value\": \"bar\"}"
+$ curl -GET "http://localhost:9358/gameserver" -H "accept: application/json"}"
+{"object_meta":{"creation_timestamp":"-62135596800","labels":{"agones.dev/sdk-foo":"bar"}},"spec":{"health":{}},"status":{"state":"Ready"}}
+```
+{{% /feature %}}

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -9,6 +9,7 @@ description: >
 
 A full GameServer specification is available below and in the {{< ghlink href="examples/gameserver.yaml" >}}example folder{{< /ghlink >}} for reference :
 
+{{% feature expiryVersion="1.2.0" %}}
 ```yaml
 apiVersion: "agones.dev/v1"
 kind: GameServer
@@ -77,6 +78,77 @@ spec:
         image:  gcr.io/agones-images/udp-server:0.17
         imagePullPolicy: Always
 ```
+{{% /feature %}}
+{{% feature publishversion="1.2.0" %}}
+```yaml
+apiVersion: "agones.dev/v1"
+kind: GameServer
+# GameServer Metadata
+# https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectmeta-v1-meta
+metadata:
+  # generateName: "gds-example" # generate a unique name, with the given prefix
+  name: "gds-example" # set a fixed name
+spec:
+  # if there is more than one container, specify which one is the game server
+  container: example-server
+  # Array of ports that can be exposed as direct connections to the game server container
+  ports:
+    # name is a descriptive name for the port
+  - name: default
+    # portPolicy has three options:
+    # - "Dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
+    # - "Static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
+    # port is available. When static is the policy specified, `hostPort` is required to be populated
+    # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
+    #      This will mean that users will need to lookup what port has been opened through the server side SDK.
+    portPolicy: Static
+    # the port that is being opened on the game server process
+    containerPort: 7654
+    # the port exposed on the host, only required when `portPolicy` is "Static". Overwritten when portPolicy is "Dynamic".
+    hostPort: 7777
+    # protocol being used. Defaults to UDP. TCP is the only other option
+    protocol: UDP
+  # Health checking for the running game server
+  health:
+    # Disable health checking. defaults to false, but can be set to true
+    disabled: false
+    # Number of seconds after the container has started before health check is initiated. Defaults to 5 seconds
+    initialDelaySeconds: 5
+    # If the `Health()` function doesn't get called at least once every period (seconds), then
+    # the game server is not healthy. Defaults to 5
+    periodSeconds: 5
+    # Minimum consecutive failures for the health probe to be considered failed after having succeeded.
+    # Defaults to 3. Minimum value is 1
+    failureThreshold: 3
+  # Parameters for game server sidecar
+  sdkServer:
+    # sdkServer log level parameter has three options:
+    #  - "Info" (default) The SDK server will output all messages except for debug messages
+    #  - "Debug" The SDK server will output all messages including debug messages
+    #  - "Error" The SDK server will only output error messages
+    logLevel: Info
+    # grpcPort and httpPort control what ports the sdkserver listens on.
+    # Starting with Agones 1.2 the default grpcPort is 9357 and the default
+    # httpPort is 9358. In earlier releases, the defaults were 59357 and 59358
+    # respectively but as these were in the ephemeral port range they could
+    # conflict with other TCP connections.
+    grpcPort: 9357
+    httpPort: 9358
+  # Pod template configuration
+  # https://v1-12.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podtemplate-v1-core
+  template:
+    # pod metadata. Name & Namespace is overwritten
+    metadata:
+      labels:
+        myspeciallabel: myspecialvalue
+    # Pod Specification
+    spec:
+      containers:
+      - name: simple-udp
+        image:  gcr.io/agones-images/udp-server:0.17
+        imagePullPolicy: Always
+```
+{{% /feature %}}
 
 Since Agones defines a new [Custom Resources Definition (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) we can define a new resource using the kind `GameServer` with the custom group `agones.dev` and API version `v1`.
 


### PR DESCRIPTION
Fixes https://github.com/googleforgames/agones/issues/851. 