### PR TITLE
Fix infinite creation of GameServerSets when 1000m CPU limit was used

### DIFF
--- a/pkg/apis/agones/v1/gameserverset.go
+++ b/pkg/apis/agones/v1/gameserverset.go
@@ -15,10 +15,9 @@
 package v1
 
 import (
-	"reflect"
-
 	"agones.dev/agones/pkg/apis"
 	"agones.dev/agones/pkg/apis/agones"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -82,7 +81,7 @@ type GameServerSetStatus struct {
 // is the new GameServerSet, being passed into the old GameServerSet
 func (gsSet *GameServerSet) ValidateUpdate(new *GameServerSet) ([]metav1.StatusCause, bool) {
 	causes := validateName(new)
-	if !reflect.DeepEqual(gsSet.Spec.Template, new.Spec.Template) {
+	if !apiequality.Semantic.DeepEqual(gsSet.Spec.Template, new.Spec.Template) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Field:   "template",

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -17,7 +17,6 @@ package fleets
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"time"
 
 	"agones.dev/agones/pkg/apis/agones"
@@ -40,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -542,7 +542,7 @@ func (c *Controller) filterGameServerSetByActive(fleet *agonesv1.Fleet, list []*
 	var rest []*agonesv1.GameServerSet
 
 	for _, gsSet := range list {
-		if reflect.DeepEqual(gsSet.Spec.Template, fleet.Spec.Template) {
+		if apiequality.Semantic.DeepEqual(gsSet.Spec.Template, fleet.Spec.Template) {
 			active = gsSet
 		} else {
 			rest = append(rest, gsSet)

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1betaext "k8s.io/api/extensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,6 +49,33 @@ const (
 	green         = "green"
 	replicasCount = 3
 )
+
+// TestFleetRequestsLimits reproduces an issue when 1000m and 1 CPU is not equal, but should be equal
+// Every fleet should create no more than 2 GameServerSet at once on a simple fleet patch
+func TestFleetRequestsLimits(t *testing.T) {
+	t.Parallel()
+
+	flt := defaultFleet(defaultNs)
+	flt.Spec.Template.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU] = *resource.NewScaledQuantity(1000, -3)
+
+	client := framework.AgonesClient.AgonesV1()
+	flt, err := client.Fleets(defaultNs).Create(flt)
+	if assert.Nil(t, err) {
+		defer client.Fleets(defaultNs).Delete(flt.ObjectMeta.Name, nil) // nolint:errcheck
+	}
+	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+
+	newReplicas := int32(5)
+	patch := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/template/spec/template/spec/containers/0/resources/requests/cpu", "value": "1000m"},
+				{ "op": "replace", "path": "/spec/replicas", "value": %d}]`, newReplicas)
+
+	_, err = framework.AgonesClient.AgonesV1().Fleets(defaultNs).Patch(flt.ObjectMeta.Name, types.JSONPatchType, []byte(patch))
+	assert.Nil(t, err)
+
+	// In bug scenario fleet was infinitely creating new GSSets (5 at a time), because 1000m CPU was changed to 1 CPU
+	// internally - thought as new wrong GSSet in a Fleet Controller
+	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(newReplicas))
+}
 
 func TestFleetScaleUpEditAndScaleDown(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Add Semantic.DeepEqual() to compare equal values autoupdated after
creation, for instance 1000m -> 1 CPU limit.
More accurate comparison of GSSet vs Fleet is used.

Closes #1184.