### PR TITLE
FleetAutoScaler add reserved into consideration

### DIFF
--- a/examples/fleetautoscaler.yaml
+++ b/examples/fleetautoscaler.yaml
@@ -29,14 +29,15 @@ spec:
   fleetName: fleet-example
   # The autoscaling policy
   policy:
-    # type of the policy. for now, only Buffer is available
+    # type of the policy. Buffer or Webhook types are available
     type: Buffer
     # parameters of the buffer policy
     buffer:
-      # Size of a buffer of "ready" game server instances
+      # Size of a buffer of "ready" and "reserved" game server instances.
       # The FleetAutoscaler will scale the fleet up and down trying to maintain this buffer, 
-      # as instances are being allocated or terminated
-      # it can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
+      # as instances are being allocated or terminated.
+      # Note that "reserved" game servers could not be scaled down.
+      # It can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
       bufferSize: 5
       # minimum fleet size to be set by this FleetAutoscaler. 
       # if not specified, the actual minimum fleet size will be bufferSize

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -150,14 +150,14 @@ but doesn't trigger a FleetAutoscaler scale up. This is where `Reserve(seconds)`
 
 `Reserve(seconds)` will move the `GameServer` into the Reserved state for the specified number of seconds (0 is forever), and then it will be
 moved back to `Ready` state. While in `Reserved` state, the `GameServer` will not be deleted on scale down or `Fleet` update,
-and also will not be Allocated.
+and also it could not be Allocated using [GameServerAllocation]({{< ref "/docs/Reference/gameserverallocation.md" >}}).
 
 This is often used when a game server process must register itself with an external system, such as a matchmaker,
 that requires it to designate itself as available for a game session for a certain period. Once a game session has started,
 it should call `SDK.Allocate()` to designate that players are currently active on it.
 
 Calling other state changing SDK commands such as `Ready` or `Allocate` will turn off the timer to reset the `GameServer` back
-to the `Ready` state.
+to the `Ready` state or to promote it to an `Allocated` state accordingly.
 
 ## Writing your own SDK
 

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -22,14 +22,15 @@ spec:
   fleetName: fleet-example
   # The autoscaling policy
   policy:
-    # type of the policy. for now, only Buffer is available
+    # type of the policy. Buffer or Webhook types are available
     type: Buffer
     # parameters of the buffer policy
     buffer:
-      # Size of a buffer of "ready" game server instances
+      # Size of a buffer of "ready" and "reserved" game server instances.
       # The FleetAutoscaler will scale the fleet up and down trying to maintain this buffer, 
-      # as instances are being allocated or terminated
-      # it can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
+      # as instances are being allocated or terminated.
+      # Note that "reserved" game servers could not be scaled down.
+      # It can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
       bufferSize: 5
       # minimum fleet size to be set by this FleetAutoscaler. 
       # if not specified, the actual minimum fleet size will be bufferSize
@@ -75,10 +76,11 @@ The `spec` field is the actual `FleetAutoscaler` specification and it is compose
 - `policy` is the autoscaling policy
   - `type` is type of the policy. "Buffer" and "Webhook" are available
   - `buffer` parameters of the buffer policy type
-    - `bufferSize`  is the size of a buffer of "ready" game server instances
+    - `bufferSize`  is the size of a buffer of "ready" and "reserved" game server instances.
                     The FleetAutoscaler will scale the fleet up and down trying to maintain this buffer, 
-                    as instances are being allocated or terminated
-                    it can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
+                    as instances are being allocated or terminated.
+                    Note that "reserved" game servers could not be scaled down.
+                    It can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
     - `minReplicas` is the minimum fleet size to be set by this FleetAutoscaler. 
                     if not specified, the minimum fleet size will be bufferSize if absolute value is used.
                     When `bufferSize` in percentage format is used, `minReplicas` should be more than 0.


### PR DESCRIPTION
Reserved Replicas should count as Ready replicas and could not lead to
scale up in certain cases.

Closes #1195 