### PR TITLE
Fix sdk-server image make target

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -344,7 +344,7 @@ build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-lice
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
 
 # Build sidecar image only
-build-agones-sdk-server-image: $(ensure-build-image) build-agones-sdk-binary-linux
+build-agones-sdk-server-image: $(ensure-build-image) build-agones-sdk-binary-linux build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
 
 # Build a static binary for the ping service

--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -47,7 +47,7 @@ kind-install:
 		IMAGE_PULL_POLICY=IfNotPresent PING_SERVICE_TYPE=NodePort ALLOCATOR_SERVICE_TYPE=NodePort\
 		KUBECONFIG="$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")"
 
-# pushses the current dev version of agones to the kind single node cluster.
+# pushes the current dev version of agones to the kind single node cluster.
 kind-push:
 	kind load docker-image $(sidecar_tag) --name="$(KIND_PROFILE)"
 	kind load docker-image $(controller_tag) --name="$(KIND_PROFILE)"


### PR DESCRIPTION
SDK sidecar image is used to run conformance tests against it.
Fix for make run-sdk-conformance-local in particular.

Closes #1199.