### PR TITLE
Rust SDK: Add passthrough openssl feature

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -16,9 +16,13 @@
 name = "agones"
 version = "0.1.0"
 
+[features]
+openssl = ["grpcio/openssl"]
+openssl-vendored = ["grpcio/openssl-vendored"]
+
 [dependencies]
-grpcio = "0.3.0"
-grpcio-proto = "0.3.0"
+grpcio = "0.4.0"
+grpcio-proto = "0.4.0"
 protobuf = "2.0.2"
 futures = "^0.1.15"
 error-chain = "0.11.0"


### PR DESCRIPTION
Grpc-rs depends on boringssl by default which can conflict with crates
that depend on openssl.

Newer versions of grpc-rs expose an "openssl" feature to optionally use
openssl instead. To make Agones' Rust SDK compatible with openssl, this
bumps the grpc-rs dependency version and adds "openssl" and
"openssl-vendored" features that simply forward to grpc-rs.

Fixes #1201