### PR TITLE
Error checking of attributes on feature shortcode

### DIFF
--- a/site/layouts/shortcodes/feature.html
+++ b/site/layouts/shortcodes/feature.html
@@ -1,4 +1,9 @@
 {{- $version := getenv "RELEASE_VERSION" | default $.Page.Site.Params.release_version }}
+
+{{- with or (.Get "publishVersion") (.Get "expiryVersion")}}
+{{- else }}
+    {{ errorf "missing value for either publishVersion or expiryVersion: %s" .Position}}
+{{- end}}
 {{- $publishVersion := (.Get "publishVersion" ) | default "0.0.0" }}
 {{- $expiryVersion := (.Get "expiryVersion") | default "9999.0.0"}}
 {{- $publDigits := split $publishVersion "." }}


### PR DESCRIPTION
This should make attribute spelling mistakes much harder to do in the future!

Example output:
![2019-12-04_09-58](https://user-images.githubusercontent.com/298370/70168067-edd2ea80-167c-11ea-8762-67541fbf1135.png)
