### PR TITLE
Setting Unreal plugin version to 3

### DIFF
--- a/sdks/unreal/Agones/Agones.uplugin
+++ b/sdks/unreal/Agones/Agones.uplugin
@@ -1,5 +1,5 @@
 {
-  "FileVersion": 4,
+  "FileVersion": 3,
   "Version": 1,
   "VersionName": "0.2",
   "FriendlyName": "Agones",


### PR DESCRIPTION
Think the `FileVersion` on the UE Pluigin was bumped by accident.

See docs:

```
"FileVersion" gives the version of the Plugin descriptor file, and should usually set to the highest version that is allowed by the Engine (currently, this is "3")
``` 

Link https://docs.unrealengine.com/en-US/Programming/Plugins/index.html

Signed-off-by: Dominic Green <dominicgreen1@gmail.com>