### PR TITLE
Revert: Make it possible to create a Fleet with 0 replicas

### DIFF
--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -25,7 +25,7 @@ kind: Fleet
 metadata:
   name: fleet-example
 spec:
-  # the number of GameServers to keep Ready or Allocated in this Fleet. Defaults to 1
+  # the number of GameServers to keep Ready or Allocated in this Fleet. Defaults to 0
   replicas: 2
   # defines how GameServers are organised across the cluster.
   # Options include:

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -55,7 +55,7 @@ type FleetList struct {
 
 // FleetSpec is the spec for a Fleet
 type FleetSpec struct {
-	// Replicas are the number of GameServers that should be in this set. Defaults to 1
+	// Replicas are the number of GameServers that should be in this set. Defaults to 0.
 	Replicas int32 `json:"replicas,omitempty"`
 	// Deployment strategy
 	Strategy appsv1.DeploymentStrategy `json:"strategy"`
@@ -110,9 +110,6 @@ func (f *Fleet) GameServerSet() *GameServerSet {
 
 // ApplyDefaults applies default values to the Fleet
 func (f *Fleet) ApplyDefaults() {
-	if f.Spec.Replicas == 0 {
-		f.Spec.Replicas = 1
-	}
 	if f.Spec.Strategy.Type == "" {
 		f.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 	}

--- a/pkg/apis/agones/v1/fleet_test.go
+++ b/pkg/apis/agones/v1/fleet_test.go
@@ -73,7 +73,7 @@ func TestFleetApplyDefaults(t *testing.T) {
 	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxUnavailable.String())
 	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxSurge.String())
 	assert.Equal(t, apis.Packed, f.Spec.Scheduling)
-	assert.Equal(t, int32(1), f.Spec.Replicas)
+	assert.Equal(t, int32(0), f.Spec.Replicas)
 }
 
 func TestFleetUpperBoundReplicas(t *testing.T) {

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -2338,7 +2338,7 @@ int32
 </em>
 </td>
 <td>
-<p>Replicas are the number of GameServers that should be in this set. Defaults to 1</p>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
 </td>
 </tr>
 <tr>
@@ -2684,7 +2684,7 @@ int32
 </em>
 </td>
 <td>
-<p>Replicas are the number of GameServers that should be in this set. Defaults to 1</p>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -21,7 +21,7 @@ kind: Fleet
 metadata:
   name: fleet-example
 spec:
-  # the number of GameServers to keep Ready or Allocated in this Fleet. {{% feature publishVersion="1.2.0" %}}Defaults to 1{{% /feature %}}
+  # the number of GameServers to keep Ready or Allocated in this Fleet. {{% feature publishVersion="1.2.0" %}}Defaults to 0{{% /feature %}}
   replicas: 2
   # defines how GameServers are organised across the cluster.
   # Options include:

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -926,6 +926,25 @@ func TestUpdateFleetScheduling(t *testing.T) {
 		})
 }
 
+// TestFleetWithZeroReplicas ensures that we can always create 0 replica
+// fleets, which is useful!
+func TestFleetWithZeroReplicas(t *testing.T) {
+	t.Parallel()
+	client := framework.AgonesClient.AgonesV1()
+
+	flt := defaultFleet(defaultNs)
+	flt.Spec.Replicas = 0
+	flt, err := client.Fleets(defaultNs).Create(flt)
+	assert.NoError(t, err)
+
+	// can't think of a better way to wait for a bit before checking.
+	time.Sleep(time.Second)
+
+	list, err := framework.ListGameServersFromFleet(flt)
+	assert.NoError(t, err)
+	assert.Empty(t, list)
+}
+
 // TestFleetRecreateGameServers tests various gameserver shutdown scenarios to ensure
 // that recreation happens as expected
 func TestFleetRecreateGameServers(t *testing.T) {


### PR DESCRIPTION
This reverts some of the changes in #1168, which introduced a breaking change that defaulted Fleets to have 1 replica.

Due to the nature of Go, this also meant that if you attempted to create a Fleet with 0 replicas, it would change it to being 1 replica.

Implemented this fix to ensure there is no breaking change in the release and its also useful to be able to create Fleets with 0 replicas in them.

Also including an extra e2e test to make sure creating a Fleet with 0 replicas continues to function into the future.