### PR TITLE
Half the width of the Embark Logo

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -55,7 +55,7 @@ for backend agnostic game server metrics and monitoring dashboards
 		<a href="http://www.yager.de/"><img alt="yager" width="100" src="images/yagerdevelopment.png" /></a>
 		<a href="http://mcmahan.games/"><img alt="mcmahan.games" width="100" src="images/mcmahangames.png" /></a>
 		<a href="http://altavr.io/"><img alt="altavr" width="100" src="images/altavr-logo.png" /></a>
-		<a href="https://www.embark.games/"><img alt="Embark Studios" width="100" src="images/embark.png" /></a>
+		<a href="https://www.embark.games/"><img alt="Embark Studios" width="50" src="images/embark.png" /></a>
 	</p>
 </div>
 {{< /blocks/section >}}


### PR DESCRIPTION
The embark logo is much taller than the others and looks absolutely huge when shown the same width as the others, this halves this so it shows roughly equally big to the other logos