### PR TITLE
Webhooks: Move "running" logging to Debug

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -239,8 +239,6 @@ func (c *Controller) creationMutationHandler(review admv1beta1.AdmissionReview) 
 		return review, errors.Wrapf(err, "error creating json for patch for GameServer %s", gs.ObjectMeta.Name)
 	}
 
-	c.loggerForGameServer(gs).WithField("patch", string(json)).Infof("patch created!")
-
 	pt := admv1beta1.PatchTypeJSONPatch
 	review.Response.PatchType = &pt
 	review.Response.Patch = json

--- a/pkg/util/webhooks/webhooks.go
+++ b/pkg/util/webhooks/webhooks.go
@@ -73,7 +73,7 @@ func (wh *WebHook) AddHandler(path string, gk schema.GroupKind, op v1beta1.Opera
 
 // handle Handles http requests for webhooks
 func (wh *WebHook) handle(path string, w http.ResponseWriter, r *http.Request) error { // nolint: interfacer
-	wh.logger.WithField("path", path).Info("running webhook")
+	wh.logger.WithField("path", path).Debug("running webhook")
 
 	var review v1beta1.AdmissionReview
 	err := json.NewDecoder(r.Body).Decode(&review)


### PR DESCRIPTION
Also took the liberty of removing the Info logging of the GameServer webhook entire patch logging, since it was likely leftover from issue debugging.