### PR TITLE
Update e2e Kubectl to 1.13.12

### DIFF
--- a/build/e2e-image/Dockerfile
+++ b/build/e2e-image/Dockerfile
@@ -15,7 +15,7 @@ RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:/go/bin:$PATH
 
 # install kubectl without gcloud as we want the last version
-ENV KUBECTL_VER 1.11.5
+ENV KUBECTL_VER 1.13.12
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/linux/amd64/kubectl && \
     chmod go+rx ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
Bringing the e2e test kubectl inline with our supported version