### PR TITLE
Handling of PVM shutdown/maintenance events

### DIFF
--- a/pkg/gameservers/gameservers.go
+++ b/pkg/gameservers/gameservers.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameservers
+
+import (
+	"net"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// isGameServerPod returns if this Pod is a Pod that comes from a GameServer
+func isGameServerPod(pod *corev1.Pod) bool {
+	if agonesv1.GameServerRolePodSelector.Matches(labels.Set(pod.ObjectMeta.Labels)) {
+		owner := metav1.GetControllerOf(pod)
+		return owner != nil && owner.Kind == "GameServer"
+	}
+
+	return false
+}
+
+// address returns the IP that the given Pod is run on.
+// This will default to the ExternalIP, but if the ExternalIP is
+// not set, it will fall back to the InternalIP,
+// since we can have clusters that are private, and/or tools like minikube
+// that only report an InternalIP.
+func address(node *corev1.Node) (string, error) {
+	for _, a := range node.Status.Addresses {
+		if a.Type == corev1.NodeExternalIP && net.ParseIP(a.Address) != nil {
+			return a.Address, nil
+		}
+	}
+
+	// There might not be a public IP, so fall back to the private IP
+	for _, a := range node.Status.Addresses {
+		if a.Type == corev1.NodeInternalIP && net.ParseIP(a.Address) != nil {
+			return a.Address, nil
+		}
+	}
+
+	return "", errors.Errorf("Could not find an address for Node: %s", node.ObjectMeta.Name)
+}
+
+// applyGameServerAddressAndPort gathers the address and port details from the node and pod
+// and applies them to the GameServer that is passed in, and returns it.
+func applyGameServerAddressAndPort(gs *agonesv1.GameServer, node *corev1.Node, pod *corev1.Pod) (*agonesv1.GameServer, error) {
+	addr, err := address(node)
+	if err != nil {
+		return gs, errors.Wrapf(err, "error getting external address for GameServer %s", gs.ObjectMeta.Name)
+	}
+
+	gs.Status.Address = addr
+	gs.Status.NodeName = pod.Spec.NodeName
+	// HostPort is always going to be populated, even when dynamic
+	// This will be a double up of information, but it will be easier to read
+	gs.Status.Ports = make([]agonesv1.GameServerStatusPort, len(gs.Spec.Ports))
+	for i, p := range gs.Spec.Ports {
+		gs.Status.Ports[i] = p.Status()
+	}
+
+	return gs, nil
+}

--- a/pkg/gameservers/gameservers_test.go
+++ b/pkg/gameservers/gameservers_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameservers
+
+import (
+	"testing"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsGameServerPod(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it is a game server pod", func(t *testing.T) {
+		gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gameserver", UID: "1234"}, Spec: newSingleContainerSpec()}
+		gs.ApplyDefaults()
+		pod, err := gs.Pod()
+		assert.Nil(t, err)
+
+		assert.True(t, isGameServerPod(pod))
+	})
+
+	t.Run("it is not a game server pod", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		assert.False(t, isGameServerPod(pod))
+	})
+}
+
+func TestAddress(t *testing.T) {
+	t.Parallel()
+
+	fixture := map[string]struct {
+		node            *corev1.Node
+		expectedAddress string
+	}{
+		"node with external ip": {
+			node:            &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeFixtureName}, Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Address: "12.12.12.12", Type: corev1.NodeExternalIP}}}},
+			expectedAddress: "12.12.12.12",
+		},
+		"node with an internal ip": {
+			node:            &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeFixtureName}, Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Address: "11.11.11.11", Type: corev1.NodeInternalIP}}}},
+			expectedAddress: "11.11.11.11",
+		},
+		"node with internal and external ip": {
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeFixtureName},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+					{Address: "9.9.9.8", Type: corev1.NodeExternalIP},
+					{Address: "12.12.12.12", Type: corev1.NodeInternalIP},
+				}}},
+			expectedAddress: "9.9.9.8",
+		},
+	}
+
+	dummyGS := &agonesv1.GameServer{}
+	dummyGS.Name = "some-gs"
+
+	for name, fixture := range fixture {
+		t.Run(name, func(t *testing.T) {
+			addr, err := address(fixture.node)
+			assert.Nil(t, err)
+			assert.Equal(t, fixture.expectedAddress, addr)
+		})
+	}
+}
+
+func TestApplyGameServerAddressAndPort(t *testing.T) {
+	t.Parallel()
+
+	gsFixture := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{State: agonesv1.GameServerStateRequestReady}}
+	gsFixture.ApplyDefaults()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeFixtureName}, Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Address: ipFixture, Type: corev1.NodeExternalIP}}}}
+	pod, err := gsFixture.Pod()
+	assert.Nil(t, err)
+	pod.Spec.NodeName = node.ObjectMeta.Name
+
+	gs, err := applyGameServerAddressAndPort(gsFixture, node, pod)
+	assert.Nil(t, err)
+	assert.Equal(t, gs.Spec.Ports[0].HostPort, gs.Status.Ports[0].Port)
+	assert.Equal(t, ipFixture, gs.Status.Address)
+	assert.Equal(t, node.ObjectMeta.Name, gs.Status.NodeName)
+}

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -85,16 +85,14 @@ func NewHealthController(health healthcheck.Handler,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			pod := newObj.(*corev1.Pod)
 			if isGameServerPod(pod) && hc.isUnhealthy(pod) {
-				owner := metav1.GetControllerOf(pod)
-				hc.workerqueue.Enqueue(cache.ExplicitKey(pod.ObjectMeta.Namespace + "/" + owner.Name))
+				hc.workerqueue.Enqueue(pod)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			// Could be a DeletedFinalStateUnknown, in which case, just ignore it
 			pod, ok := obj.(*corev1.Pod)
 			if ok && isGameServerPod(pod) {
-				owner := metav1.GetControllerOf(pod)
-				hc.workerqueue.Enqueue(cache.ExplicitKey(pod.ObjectMeta.Namespace + "/" + owner.Name))
+				hc.workerqueue.Enqueue(pod)
 			}
 		},
 	})
@@ -157,7 +155,7 @@ func (hc *HealthController) loggerForGameServerKey(key string) *logrus.Entry {
 }
 
 func (hc *HealthController) loggerForGameServer(gs *agonesv1.GameServer) *logrus.Entry {
-	gsName := "NilGameServer"
+	gsName := logfields.NilGameServer
 	if gs != nil {
 		gsName = gs.Namespace + "/" + gs.Name
 	}

--- a/pkg/gameservers/migration.go
+++ b/pkg/gameservers/migration.go
@@ -1,0 +1,203 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameservers
+
+import (
+	"agones.dev/agones/pkg/apis/agones"
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"agones.dev/agones/pkg/client/clientset/versioned"
+	getterv1 "agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1"
+	"agones.dev/agones/pkg/client/informers/externalversions"
+	listerv1 "agones.dev/agones/pkg/client/listers/agones/v1"
+	"agones.dev/agones/pkg/util/logfields"
+	"agones.dev/agones/pkg/util/runtime"
+	"agones.dev/agones/pkg/util/workerqueue"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+// MigrationController watches for if a Pod is migrated/a maintenance
+// event happens on a node, and a Pod is recreated with a new Address for a
+// GameServer
+type MigrationController struct {
+	baseLogger       *logrus.Entry
+	podSynced        cache.InformerSynced
+	podLister        corelisterv1.PodLister
+	gameServerSynced cache.InformerSynced
+	gameServerGetter getterv1.GameServersGetter
+	gameServerLister listerv1.GameServerLister
+	nodeLister       corelisterv1.NodeLister
+	nodeSynced       cache.InformerSynced
+	workerqueue      *workerqueue.WorkerQueue
+	recorder         record.EventRecorder
+}
+
+// NewMigrationController returns a MigrationController
+func NewMigrationController(health healthcheck.Handler,
+	kubeClient kubernetes.Interface,
+	agonesClient versioned.Interface,
+	kubeInformerFactory informers.SharedInformerFactory,
+	agonesInformerFactory externalversions.SharedInformerFactory) *MigrationController {
+
+	podInformer := kubeInformerFactory.Core().V1().Pods().Informer()
+	gameserverInformer := agonesInformerFactory.Agones().V1().GameServers()
+	mc := &MigrationController{
+		podSynced:        podInformer.HasSynced,
+		podLister:        kubeInformerFactory.Core().V1().Pods().Lister(),
+		gameServerSynced: gameserverInformer.Informer().HasSynced,
+		gameServerGetter: agonesClient.AgonesV1(),
+		gameServerLister: gameserverInformer.Lister(),
+		nodeLister:       kubeInformerFactory.Core().V1().Nodes().Lister(),
+		nodeSynced:       kubeInformerFactory.Core().V1().Nodes().Informer().HasSynced,
+	}
+
+	mc.baseLogger = runtime.NewLoggerWithType(mc)
+	mc.workerqueue = workerqueue.NewWorkerQueue(mc.syncGameServer, mc.baseLogger, logfields.GameServerKey, agones.GroupName+".MigrationController")
+	health.AddLivenessCheck("gameserver-migration-workerqueue", healthcheck.Check(mc.workerqueue.Healthy))
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(mc.baseLogger.Debugf)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	mc.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "migration-controller"})
+
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod := obj.(*corev1.Pod)
+			if isActiveGameServerWithNode(pod) {
+				mc.workerqueue.Enqueue(pod)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			pod := newObj.(*corev1.Pod)
+			if isActiveGameServerWithNode(pod) {
+				mc.workerqueue.Enqueue(pod)
+			}
+		},
+	})
+	return mc
+}
+
+// Run processes the rate limited queue.
+// Will block until stop is closed
+func (mc *MigrationController) Run(stop <-chan struct{}) error {
+	mc.baseLogger.Debug("Wait for cache sync")
+	if !cache.WaitForCacheSync(stop, mc.nodeSynced, mc.gameServerSynced, mc.podSynced) {
+		return errors.New("failed to wait for caches to sync")
+	}
+
+	mc.workerqueue.Run(1, stop)
+	return nil
+}
+
+func (mc *MigrationController) loggerForGameServerKey(key string) *logrus.Entry {
+	return logfields.AugmentLogEntry(mc.baseLogger, logfields.GameServerKey, key)
+}
+
+func (mc *MigrationController) loggerForGameServer(gs *agonesv1.GameServer) *logrus.Entry {
+	gsName := logfields.NilGameServer
+	if gs != nil {
+		gsName = gs.Namespace + "/" + gs.Name
+	}
+	return mc.loggerForGameServerKey(gsName).WithField("gs", gs)
+}
+
+// isActiveGameServerWithNode tests to see if a Pod is active and has a Node assigned.
+func isActiveGameServerWithNode(pod *corev1.Pod) bool {
+	return pod.Spec.NodeName != "" && pod.ObjectMeta.DeletionTimestamp.IsZero() && isGameServerPod(pod)
+}
+
+// syncGameServer will check if the Pod for the GameServer
+// has been migrated to a new node (or a node with the same name, but different address)
+// and will either update it, or move it to Unhealthy, depending on its State
+func (mc *MigrationController) syncGameServer(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		// don't return an error, as we don't want this retried
+		runtime.HandleError(mc.loggerForGameServerKey(key), errors.Wrapf(err, "invalid resource key"))
+		return nil
+	}
+
+	gs, err := mc.gameServerLister.GameServers(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			mc.loggerForGameServerKey(key).Debug("GameServer is no longer available for syncing")
+			return nil
+		}
+		return errors.Wrapf(err, "error retrieving GameServer %s from namespace %s", name, namespace)
+	}
+
+	// Either the address has not been set, or we're being deleted already
+	if gs.Status.NodeName == "" || gs.IsBeingDeleted() || gs.Status.State == agonesv1.GameServerStateUnhealthy {
+		return nil
+	}
+
+	pod, err := mc.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			mc.loggerForGameServerKey(key).Debug("Pod is no longer available for syncing")
+			return nil
+		}
+		return errors.Wrapf(err, "error retrieving Pod %s from namespace %s", name, namespace)
+	}
+	if !pod.ObjectMeta.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	node, err := mc.nodeLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving node %s for Pod %s", pod.Spec.NodeName, pod.ObjectMeta.Name)
+	}
+	address, err := address(node)
+	if err != nil {
+		return err
+	}
+
+	if pod.Spec.NodeName != gs.Status.NodeName || address != gs.Status.Address {
+		gsCopy := gs.DeepCopy()
+
+		var eventMsg string
+		// If the GameServer has yet to become ready, we will reapply the Address and Port
+		// otherwise, we move it to Unhealthy so that a new GameServer will be recreated.
+		if gsCopy.IsBeforeReady() {
+			gsCopy, err = applyGameServerAddressAndPort(gsCopy, node, pod)
+			if err != nil {
+				return err
+			}
+			eventMsg = "Address updated due to Node migration"
+		} else {
+			gsCopy.Status.State = agonesv1.GameServerStateUnhealthy
+			eventMsg = "Node migration occurred"
+		}
+
+		if _, err = mc.gameServerGetter.GameServers(gsCopy.ObjectMeta.Namespace).Update(gsCopy); err != nil {
+			return err
+		}
+
+		mc.loggerForGameServer(gs).Debug("GameServer migration occurred")
+		mc.recorder.Event(gs, corev1.EventTypeWarning, string(gsCopy.Status.State), eventMsg)
+	}
+
+	return nil
+}

--- a/pkg/gameservers/migration_test.go
+++ b/pkg/gameservers/migration_test.go
@@ -1,0 +1,316 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameservers
+
+import (
+	"testing"
+	"time"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	agtesting "agones.dev/agones/pkg/testing"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestMigrationControllerIsRunningGameServer(t *testing.T) {
+	fixtures := map[string]struct {
+		setup    func(*corev1.Pod) *corev1.Pod
+		expected bool
+	}{
+		"not a gameserver pod": {
+			setup: func(pod *corev1.Pod) *corev1.Pod {
+				return &corev1.Pod{}
+			},
+			expected: false,
+		},
+		"game server pod": {
+			setup: func(pod *corev1.Pod) *corev1.Pod {
+				return pod
+			},
+			expected: false,
+		},
+		"game server pod that has a nodename": {
+			setup: func(pod *corev1.Pod) *corev1.Pod {
+				pod.Spec.NodeName = "x"
+				return pod
+			},
+			expected: true,
+		},
+		"game server pod that has a node, but is being deleted": {
+			setup: func(pod *corev1.Pod) *corev1.Pod {
+				pod.Spec.NodeName = "z"
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
+				return pod
+			},
+			expected: false,
+		},
+	}
+
+	for k, v := range fixtures {
+		t.Run(k, func(t *testing.T) {
+			gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: newSingleContainerSpec()}
+			gs.ApplyDefaults()
+
+			gsPod, err := gs.Pod()
+			assert.NoError(t, err)
+
+			pod := v.setup(gsPod)
+			assert.Equal(t, v.expected, isActiveGameServerWithNode(pod))
+		})
+	}
+}
+
+func TestMigrationControllerSyncGameServer(t *testing.T) {
+	t.Parallel()
+
+	ipChangeFixture := "99.99.99.99"
+	nodeNameChangeFixture := "nodeChange"
+
+	type expected struct {
+		updated     bool
+		updateTests func(t *testing.T, gs *agonesv1.GameServer)
+		postTests   func(t *testing.T, mocks agtesting.Mocks)
+	}
+	fixtures := map[string]struct {
+		setup    func(*agonesv1.GameServer, *corev1.Pod, *corev1.Node) (*agonesv1.GameServer, *corev1.Pod, *corev1.Node)
+		expected expected
+	}{
+		"no change, gameserver nodeName not yet set": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod, node *corev1.Node) (*agonesv1.GameServer, *corev1.Pod, *corev1.Node) {
+				return gs, pod, node
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {},
+				postTests: func(t *testing.T, m agtesting.Mocks) {
+					agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
+				},
+			},
+		},
+		"no change, with same address": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod, node *corev1.Node) (*agonesv1.GameServer, *corev1.Pod, *corev1.Node) {
+				gs.Status.NodeName = nodeFixtureName
+				gs.Status.Address = ipFixture
+				return gs, pod, node
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {},
+				postTests: func(t *testing.T, m agtesting.Mocks) {
+					agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
+				},
+			},
+		},
+		"change before ready, ip only change": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod, node *corev1.Node) (*agonesv1.GameServer, *corev1.Pod, *corev1.Node) {
+				gs.Status.NodeName = nodeFixtureName
+				gs.Status.Address = ipFixture
+				gs.Status.State = agonesv1.GameServerStateScheduled
+				node.Status.Addresses[0].Address = ipChangeFixture
+				return gs, pod, node
+			},
+			expected: expected{
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					assert.Equal(t, ipChangeFixture, gs.Status.Address)
+				},
+				postTests: func(t *testing.T, m agtesting.Mocks) {
+					agtesting.AssertEventContains(t, m.FakeRecorder.Events, "Warning Scheduled Address updated due to Node migration")
+				},
+			},
+		},
+		"change before ready, full node change": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod, node *corev1.Node) (*agonesv1.GameServer, *corev1.Pod, *corev1.Node) {
+				gs.Status.NodeName = nodeFixtureName
+				gs.Status.Address = ipFixture
+				gs.Status.State = agonesv1.GameServerStateScheduled
+
+				// full node name change
+				pod.Spec.NodeName = nodeNameChangeFixture
+				node.ObjectMeta.Name = nodeNameChangeFixture
+				node.Status.Addresses[0].Address = ipChangeFixture
+				return gs, pod, node
+			},
+			expected: expected{
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					assert.Equal(t, ipChangeFixture, gs.Status.Address)
+					assert.Equal(t, nodeNameChangeFixture, gs.Status.NodeName)
+				},
+				postTests: func(t *testing.T, m agtesting.Mocks) {
+					agtesting.AssertEventContains(t, m.FakeRecorder.Events, "Warning Scheduled Address updated due to Node migration")
+				},
+			},
+		},
+		"change after ready": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod, node *corev1.Node) (*agonesv1.GameServer, *corev1.Pod, *corev1.Node) {
+				gs.Status.NodeName = nodeFixtureName
+				gs.Status.Address = ipFixture
+				gs.Status.State = agonesv1.GameServerStateAllocated
+
+				// full node name change
+				pod.Spec.NodeName = nodeNameChangeFixture
+				node.ObjectMeta.Name = nodeNameChangeFixture
+				node.Status.Addresses[0].Address = ipChangeFixture
+
+				return gs, pod, node
+			},
+			expected: expected{
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					assert.Equal(t, agonesv1.GameServerStateUnhealthy, gs.Status.State)
+				},
+				postTests: func(t *testing.T, m agtesting.Mocks) {
+					agtesting.AssertEventContains(t, m.FakeRecorder.Events, "Warning Unhealthy Node migration occurred")
+				},
+			},
+		},
+	}
+
+	for k, v := range fixtures {
+		t.Run(k, func(t *testing.T) {
+			m := agtesting.NewMocks()
+			c := NewMigrationController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
+			c.recorder = m.FakeRecorder
+
+			gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{}}
+			gs.ApplyDefaults()
+
+			pod, err := gs.Pod()
+			pod.Spec.NodeName = nodeFixtureName
+			assert.NoError(t, err)
+
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeFixtureName},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Address: ipFixture, Type: corev1.NodeExternalIP}}}}
+
+			gs, pod, node = v.setup(gs, pod, node)
+
+			// populate
+			m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{*gs}}, nil
+			})
+			m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true,
+					&corev1.NodeList{Items: []corev1.Node{*node}}, nil
+			})
+			m.KubeClient.AddReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &corev1.PodList{Items: []corev1.Pod{*pod}}, nil
+			})
+
+			//check values
+			updated := false
+			m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				updated = true
+				ua := action.(k8stesting.UpdateAction)
+				gs := ua.GetObject().(*agonesv1.GameServer)
+				v.expected.updateTests(t, gs)
+				return true, gs, nil
+			})
+
+			_, cancel := agtesting.StartInformers(m, c.nodeSynced, c.gameServerSynced, c.podSynced)
+			defer cancel()
+
+			err = c.syncGameServer("default/test")
+			assert.NoError(t, err)
+			assert.Equal(t, v.expected.updated, updated)
+			v.expected.postTests(t, m)
+		})
+	}
+}
+
+func TestMigrationControllerRun(t *testing.T) {
+	m := agtesting.NewMocks()
+	c := NewMigrationController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
+	gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{}}
+	gs.ApplyDefaults()
+	gsPod, err := gs.Pod()
+	gsPod.Spec.NodeName = nodeFixtureName
+	assert.NoError(t, err)
+
+	received := make(chan string)
+	h := func(name string) error {
+		assert.Equal(t, "default/test", name)
+		received <- name
+		return nil
+	}
+
+	podWatch := watch.NewFake()
+	m.KubeClient.AddWatchReactor("pods", k8stesting.DefaultWatchReactor(podWatch, nil))
+
+	c.workerqueue.SyncHandler = h
+
+	stop, cancel := agtesting.StartInformers(m, c.gameServerSynced)
+	defer cancel()
+
+	go func() {
+		err := c.Run(stop)
+		assert.Nil(t, err, "Run should not error")
+	}()
+
+	noChange := func() {
+		assert.True(t, cache.WaitForCacheSync(stop, c.podSynced))
+		select {
+		case <-received:
+			assert.Fail(t, "should not be updated")
+		default:
+		}
+	}
+
+	result := func() {
+		select {
+		case res := <-received:
+			assert.Equal(t, "default/test", res)
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "did not receive queue")
+		}
+	}
+
+	// initial pod
+	podWatch.Add(gsPod.DeepCopy())
+	result()
+
+	gsPod.Spec.NodeName += "+changed"
+	podWatch.Modify(gsPod.DeepCopy())
+	result()
+
+	// deleted pod
+	now := metav1.Now()
+	gsPod.ObjectMeta.DeletionTimestamp = &now
+	podWatch.Modify(gsPod.DeepCopy())
+	noChange()
+
+	// non gameserver pod
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test2",
+		Namespace: "default",
+	}}
+	pod.Spec.NodeName = nodeFixtureName
+	podWatch.Add(pod.DeepCopy())
+	noChange()
+
+	pod.Spec.NodeName += "+changed"
+	podWatch.Modify(pod.DeepCopy())
+	noChange()
+}

--- a/pkg/util/logfields/logfields.go
+++ b/pkg/util/logfields/logfields.go
@@ -18,6 +18,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// NilGameServer is the value to show in logging when the GameServer is a nil value
+	NilGameServer = "NilGameServer"
+)
+
 // ResourceType identifies the type of a resource for the purpose of putting it in structural logs.
 type ResourceType string
 


### PR DESCRIPTION
When PVMs get deleted and then replaced in a GKE cluster, they are often given the same name, but a different IP.

Also, Pods on the PVM don't receive any type of Update or Delete event, but are instead removed and replaced with the new Address details - thereby breaking the GameServer status connection details.

This PR watches for Pod additions and Updates, and ensures the Address and Nodename information match what is currently in place for a GameServer, and if it doesn't match, reapplies it (for before Ready) or moves the GameServer to Unhealthy (after Ready), so it can be replaced when in a Fleet.

I haven't written a e2e test for this, as I'm not sure the best way to handle it. Happy to take suggestions for implementation in a subsequent PR.

Closes #1245.