### PR TITLE
Add validation for Labels on Fleet and GS Template

### DIFF
--- a/pkg/apis/agones/v1/common.go
+++ b/pkg/apis/agones/v1/common.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // Block of const Error messages
@@ -59,12 +61,30 @@ type gsSpec interface {
 	GetGameServerSpec() *GameServerSpec
 }
 
-// validateGSSpec Check GameserverSpec of a CRD
-// Used by Fleet and Gameserverset
+// validateGSSpec Check GameServerSpec of a CRD
+// Used by Fleet and GameServerSet
 func validateGSSpec(gs gsSpec) []metav1.StatusCause {
 	gsSpec := gs.GetGameServerSpec()
 	gsSpec.ApplyDefaults()
 	causes, _ := gsSpec.Validate("")
 
+	return causes
+}
+
+// validateObjectMeta Check ObjectMeta specification
+// Used by Fleet, GameServerSet and GameServer
+func validateObjectMeta(objMeta metav1.ObjectMeta) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	errs := metav1validation.ValidateLabels(objMeta.Labels, field.NewPath("labels"))
+	if len(errs) != 0 {
+		for _, v := range errs {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Field:   "labels",
+				Message: v.Error(),
+			})
+		}
+	}
 	return causes
 }

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -179,6 +179,10 @@ func (f *Fleet) Validate() ([]metav1.StatusCause, bool) {
 	if len(gsCauses) > 0 {
 		causes = append(causes, gsCauses...)
 	}
+	objMetaCauses := validateObjectMeta(f.Spec.Template.ObjectMeta)
+	if len(objMetaCauses) > 0 {
+		causes = append(causes, objMetaCauses...)
+	}
 
 	return causes, len(causes) == 0
 }

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -389,8 +389,12 @@ func (gss GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, boo
 			})
 		}
 	}
-	return causes, len(causes) == 0
+	objMetaCauses := validateObjectMeta(gss.Template.ObjectMeta)
+	if len(objMetaCauses) > 0 {
+		causes = append(causes, objMetaCauses...)
+	}
 
+	return causes, len(causes) == 0
 }
 
 // Validate validates the GameServer configuration.

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"agones.dev/agones/pkg"
@@ -406,22 +407,25 @@ func TestGameServerValidate(t *testing.T) {
 		},
 	}
 
-	nameLen := validation.LabelValueMaxLength + 1
-	bytes := make([]byte, nameLen)
-	for i := 0; i < nameLen; i++ {
-		bytes[i] = 'g'
-	}
-	gs.Name = string(bytes)
+	longName := strings.Repeat("f", validation.LabelValueMaxLength+1)
+	gs.Name = longName
 	causes, ok = gs.Validate()
 	assert.False(t, ok)
 	assert.Len(t, causes, 1)
 	assert.Equal(t, "Name", causes[0].Field)
 
 	gs.Name = ""
-	gs.GenerateName = string(bytes)
+	gs.GenerateName = longName
 	causes, ok = gs.Validate()
 	assert.True(t, ok)
 	assert.Len(t, causes, 0)
+
+	gs.Spec.Template.ObjectMeta.Labels = make(map[string]string)
+	gs.Spec.Template.ObjectMeta.Labels[longName] = ""
+	causes, ok = gs.Validate()
+	assert.False(t, ok)
+	assert.Len(t, causes, 1)
+	assert.Equal(t, "labels", causes[0].Field)
 
 	gs = GameServer{
 		Spec: GameServerSpec{

--- a/pkg/apis/agones/v1/gameserverset.go
+++ b/pkg/apis/agones/v1/gameserverset.go
@@ -92,7 +92,7 @@ func (gsSet *GameServerSet) ValidateUpdate(new *GameServerSet) ([]metav1.StatusC
 	return causes, len(causes) == 0
 }
 
-// Validate validates when Create occur. Check the name size
+// Validate validates when Create occurs. Check the name size
 func (gsSet *GameServerSet) Validate() ([]metav1.StatusCause, bool) {
 	causes := validateName(gsSet)
 
@@ -100,6 +100,11 @@ func (gsSet *GameServerSet) Validate() ([]metav1.StatusCause, bool) {
 	gsCauses := validateGSSpec(gsSet)
 	if len(gsCauses) > 0 {
 		causes = append(causes, gsCauses...)
+	}
+
+	objMetaCauses := validateObjectMeta(gsSet.Spec.Template.ObjectMeta)
+	if len(objMetaCauses) > 0 {
+		causes = append(causes, objMetaCauses...)
 	}
 
 	return causes, len(causes) == 0

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ValidateLabelSelector(ps *metav1.LabelSelector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ps == nil {
+		return allErrs
+	}
+	allErrs = append(allErrs, ValidateLabels(ps.MatchLabels, fldPath.Child("matchLabels"))...)
+	for i, expr := range ps.MatchExpressions {
+		allErrs = append(allErrs, ValidateLabelSelectorRequirement(expr, fldPath.Child("matchExpressions").Index(i))...)
+	}
+	return allErrs
+}
+
+func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	switch sr.Operator {
+	case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn:
+		if len(sr.Values) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'"))
+		}
+	case metav1.LabelSelectorOpExists, metav1.LabelSelectorOpDoesNotExist:
+		if len(sr.Values) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("values"), "may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
+		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), sr.Operator, "not a valid selector operator"))
+	}
+	allErrs = append(allErrs, ValidateLabelName(sr.Key, fldPath.Child("key"))...)
+	return allErrs
+}
+
+// ValidateLabelName validates that the label name is correctly defined.
+func ValidateLabelName(labelName string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, msg := range validation.IsQualifiedName(labelName) {
+		allErrs = append(allErrs, field.Invalid(fldPath, labelName, msg))
+	}
+	return allErrs
+}
+
+// ValidateLabels validates that a set of labels are correctly defined.
+func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for k, v := range labels {
+		allErrs = append(allErrs, ValidateLabelName(k, fldPath)...)
+		for _, msg := range validation.IsValidLabelValue(v) {
+			allErrs = append(allErrs, field.Invalid(fldPath, v, msg))
+		}
+	}
+	return allErrs
+}
+
+func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if options.OrphanDependents != nil && options.PropagationPolicy != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("propagationPolicy"), options.PropagationPolicy, "orphanDependents and deletionPropagation cannot be both set"))
+	}
+	if options.PropagationPolicy != nil &&
+		*options.PropagationPolicy != metav1.DeletePropagationForeground &&
+		*options.PropagationPolicy != metav1.DeletePropagationBackground &&
+		*options.PropagationPolicy != metav1.DeletePropagationOrphan {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("propagationPolicy"), options.PropagationPolicy, []string{string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground), string(metav1.DeletePropagationOrphan), "nil"}))
+	}
+	allErrs = append(allErrs, validateDryRun(field.NewPath("dryRun"), options.DryRun)...)
+	return allErrs
+}
+
+func ValidateCreateOptions(options *metav1.CreateOptions) field.ErrorList {
+	return validateDryRun(field.NewPath("dryRun"), options.DryRun)
+}
+
+func ValidateUpdateOptions(options *metav1.UpdateOptions) field.ErrorList {
+	return validateDryRun(field.NewPath("dryRun"), options.DryRun)
+}
+
+var allowedDryRunValues = sets.NewString(metav1.DryRunAll)
+
+func validateDryRun(fldPath *field.Path, dryRun []string) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if !allowedDryRunValues.HasAll(dryRun...) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, dryRun, allowedDryRunValues.List()))
+	}
+	return allErrs
+}
+
+const UninitializedStatusUpdateErrorMsg string = `must not update status when the object is uninitialized`

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateLabels(t *testing.T) {
+	successCases := []map[string]string{
+		{"simple": "bar"},
+		{"now-with-dashes": "bar"},
+		{"1-starts-with-num": "bar"},
+		{"1234": "bar"},
+		{"simple/simple": "bar"},
+		{"now-with-dashes/simple": "bar"},
+		{"now-with-dashes/now-with-dashes": "bar"},
+		{"now.with.dots/simple": "bar"},
+		{"now-with.dashes-and.dots/simple": "bar"},
+		{"1-num.2-num/3-num": "bar"},
+		{"1234/5678": "bar"},
+		{"1.2.3.4/5678": "bar"},
+		{"UpperCaseAreOK123": "bar"},
+		{"goodvalue": "123_-.BaR"},
+	}
+	for i := range successCases {
+		errs := ValidateLabels(successCases[i], field.NewPath("field"))
+		if len(errs) != 0 {
+			t.Errorf("case[%d] expected success, got %#v", i, errs)
+		}
+	}
+
+	namePartErrMsg := "name part must consist of"
+	nameErrMsg := "a qualified name must consist of"
+	labelErrMsg := "a valid label must be an empty string or consist of"
+	maxLengthErrMsg := "must be no more than"
+
+	labelNameErrorCases := []struct {
+		labels map[string]string
+		expect string
+	}{
+		{map[string]string{"nospecialchars^=@": "bar"}, namePartErrMsg},
+		{map[string]string{"cantendwithadash-": "bar"}, namePartErrMsg},
+		{map[string]string{"only/one/slash": "bar"}, nameErrMsg},
+		{map[string]string{strings.Repeat("a", 254): "bar"}, maxLengthErrMsg},
+	}
+	for i := range labelNameErrorCases {
+		errs := ValidateLabels(labelNameErrorCases[i].labels, field.NewPath("field"))
+		if len(errs) != 1 {
+			t.Errorf("case[%d]: expected failure", i)
+		} else {
+			if !strings.Contains(errs[0].Detail, labelNameErrorCases[i].expect) {
+				t.Errorf("case[%d]: error details do not include %q: %q", i, labelNameErrorCases[i].expect, errs[0].Detail)
+			}
+		}
+	}
+
+	labelValueErrorCases := []struct {
+		labels map[string]string
+		expect string
+	}{
+		{map[string]string{"toolongvalue": strings.Repeat("a", 64)}, maxLengthErrMsg},
+		{map[string]string{"backslashesinvalue": "some\\bad\\value"}, labelErrMsg},
+		{map[string]string{"nocommasallowed": "bad,value"}, labelErrMsg},
+		{map[string]string{"strangecharsinvalue": "?#$notsogood"}, labelErrMsg},
+	}
+	for i := range labelValueErrorCases {
+		errs := ValidateLabels(labelValueErrorCases[i].labels, field.NewPath("field"))
+		if len(errs) != 1 {
+			t.Errorf("case[%d]: expected failure", i)
+		} else {
+			if !strings.Contains(errs[0].Detail, labelValueErrorCases[i].expect) {
+				t.Errorf("case[%d]: error details do not include %q: %q", i, labelValueErrorCases[i].expect, errs[0].Detail)
+			}
+		}
+	}
+}
+
+func TestValidDryRun(t *testing.T) {
+	tests := [][]string{
+		{},
+		{"All"},
+		{"All", "All"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
+			if errs := validateDryRun(field.NewPath("dryRun"), test); len(errs) != 0 {
+				t.Errorf("%v should be a valid dry-run value: %v", test, errs)
+			}
+		})
+	}
+}
+
+func TestInvalidDryRun(t *testing.T) {
+	tests := [][]string{
+		{"False"},
+		{"All", "False"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
+			if len(validateDryRun(field.NewPath("dryRun"), test)) == 0 {
+				t.Errorf("%v shouldn't be a valid dry-run value", test)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Now ObjectMeta Labels part in a Fleet Template and GameServerSpec Template are
validated, as well as for GameServerSet Template field.

Closes #1244 .