### PR TITLE
Update golangci-lint, add more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,7 @@ output:
 
 linters:
   enable:
+    - deadcode
     - megacheck
     - govet
     - golint
@@ -53,16 +54,39 @@ linters:
     - unconvert
     - dupl
     - goconst
+    - gocritic
     - gocyclo
     - goimports
+    - interfacer
     - maligned
     - megacheck
+    - scopelint
+    - staticcheck
+    - structcheck
     - misspell
     - unparam
     - nakedret
     - bodyclose
 
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - performance
+      - opinionated
+      - diagnostic
+    disabled-checks:
+      - paramTypeCombine
+      - unnamedResult
+    settings: # settings passed to gocritic
+      hugeParam:
+        sizeThreshold: 512
+      rangeValCopy:
+        sizeThreshold: 512
+        skipTestFuncs: true
+
 issues:
   # This turns off the default excludes - which was causing the linter
   # to miss things like erroneous comments
   exclude-use-default: false
+  exclude:
+    - Using the variable on range scope .* in function literal

--- a/build/Makefile
+++ b/build/Makefile
@@ -304,7 +304,7 @@ build-controller-binary: $(ensure-build-image)
 lint: LINT_TIMEOUT ?= 15m
 lint: $(ensure-build-image)
 	docker run -t -e "TERM=xterm-256color" -e "$(gomod_on)" --rm $(common_mounts) -w $(workdir_path) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
-		"golangci-lint run ./examples/... && golangci-lint run --deadline $(LINT_TIMEOUT) ./..."
+		"golangci-lint run ./examples/... && golangci-lint run --timeout $(LINT_TIMEOUT) ./..."
 
 # Extract licenses from source tree
 build-licenses:

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -68,7 +68,7 @@ RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
 RUN echo "source <(helm completion bash)" >> /root/.bashrc
 
 # install golang-ci linter
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.18.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.22.2
 
 #
 #  \ \      / /__| |__  ___(_) |_ ___

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -359,7 +359,7 @@ type config struct {
 }
 
 // validate ensures the ctlConfig data is valid.
-func (c config) validate() error {
+func (c *config) validate() error {
 	if c.MinPort <= 0 || c.MaxPort <= 0 {
 		return errors.New("min Port and Max Port values are required")
 	}

--- a/cmd/ping/udp_test.go
+++ b/cmd/ping/udp_test.go
@@ -120,9 +120,9 @@ func TestUDPServerHealth(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func defaultFixture(clock clock.Clock) (*udpServer, error) {
+func defaultFixture(cl clock.Clock) (*udpServer, error) {
 	u := newUDPServer(5)
-	u.clock = clock
+	u.clock = cl
 	var err error
 	u.conn, err = net.ListenPacket("udp", ":0")
 	return u, err

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -90,7 +90,8 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if ctlConf.IsLocal {
+	switch {
+	case ctlConf.IsLocal:
 		localSDK, err := registerLocal(grpcServer, ctlConf)
 		if err != nil {
 			logger.WithError(err).Fatal("Could not start local sdk server")
@@ -103,7 +104,7 @@ func main() {
 				close(timedStop)
 			}()
 		}
-	} else if ctlConf.Test != "" {
+	case ctlConf.Test != "":
 		localSDK, err := registerTestSdkServer(grpcServer, ctlConf)
 		if err != nil {
 			logger.WithError(err).Fatal("Could not start test sdk server")
@@ -116,7 +117,7 @@ func main() {
 				close(timedStop)
 			}()
 		}
-	} else {
+	default:
 		var config *rest.Config
 		config, err := rest.InClusterConfig()
 		if err != nil {

--- a/pkg/allocation/converters/converter.go
+++ b/pkg/allocation/converters/converter.go
@@ -127,6 +127,7 @@ func convertInternalLabelSelectorToLabelSelector(in *metav1.LabelSelector) *pb.L
 func convertInternalLabelSelectorsToLabelSelectors(in []metav1.LabelSelector) []*pb.LabelSelector {
 	var result []*pb.LabelSelector
 	for _, l := range in {
+		l := l
 		c := convertInternalLabelSelectorToLabelSelector(&l)
 		result = append(result, c)
 	}

--- a/pkg/apis/agones/v1/common.go
+++ b/pkg/apis/agones/v1/common.go
@@ -74,7 +74,7 @@ func validateGSSpec(gs gsSpec) []metav1.StatusCause {
 
 // validateObjectMeta Check ObjectMeta specification
 // Used by Fleet, GameServerSet and GameServer
-func validateObjectMeta(objMeta metav1.ObjectMeta) []metav1.StatusCause {
+func validateObjectMeta(objMeta *metav1.ObjectMeta) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	errs := metav1validation.ValidateLabels(objMeta.Labels, field.NewPath("labels"))

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -179,7 +179,7 @@ func (f *Fleet) Validate() ([]metav1.StatusCause, bool) {
 	if len(gsCauses) > 0 {
 		causes = append(causes, gsCauses...)
 	}
-	objMetaCauses := validateObjectMeta(f.Spec.Template.ObjectMeta)
+	objMetaCauses := validateObjectMeta(&f.Spec.Template.ObjectMeta)
 	if len(objMetaCauses) > 0 {
 		causes = append(causes, objMetaCauses...)
 	}

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -312,7 +312,7 @@ func (gss *GameServerSpec) applySchedulingDefaults() {
 // devAddress is a specific IP address used for local Gameservers, for fleets "" is used
 // If a GameServer Spec is invalid there will be > 0 values in
 // the returned array
-func (gss GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, bool) {
+func (gss *GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, bool) {
 	var causes []metav1.StatusCause
 	if devAddress != "" {
 		// verify that the value is a valid IP address.
@@ -342,7 +342,7 @@ func (gss GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, boo
 		}
 	} else {
 		// make sure a name is specified when there is multiple containers in the pod.
-		if len(gss.Container) == 0 && len(gss.Template.Spec.Containers) > 1 {
+		if gss.Container == "" && len(gss.Template.Spec.Containers) > 1 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Field:   "container",
@@ -389,7 +389,7 @@ func (gss GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, boo
 			})
 		}
 	}
-	objMetaCauses := validateObjectMeta(gss.Template.ObjectMeta)
+	objMetaCauses := validateObjectMeta(&gss.Template.ObjectMeta)
 	if len(objMetaCauses) > 0 {
 		causes = append(causes, objMetaCauses...)
 	}

--- a/pkg/apis/agones/v1/gameserverset.go
+++ b/pkg/apis/agones/v1/gameserverset.go
@@ -79,9 +79,9 @@ type GameServerSetStatus struct {
 
 // ValidateUpdate validates when updates occur. The argument
 // is the new GameServerSet, being passed into the old GameServerSet
-func (gsSet *GameServerSet) ValidateUpdate(new *GameServerSet) ([]metav1.StatusCause, bool) {
-	causes := validateName(new)
-	if !apiequality.Semantic.DeepEqual(gsSet.Spec.Template, new.Spec.Template) {
+func (gsSet *GameServerSet) ValidateUpdate(newGSS *GameServerSet) ([]metav1.StatusCause, bool) {
+	causes := validateName(newGSS)
+	if !apiequality.Semantic.DeepEqual(gsSet.Spec.Template, newGSS.Spec.Template) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Field:   "template",
@@ -102,7 +102,7 @@ func (gsSet *GameServerSet) Validate() ([]metav1.StatusCause, bool) {
 		causes = append(causes, gsCauses...)
 	}
 
-	objMetaCauses := validateObjectMeta(gsSet.Spec.Template.ObjectMeta)
+	objMetaCauses := validateObjectMeta(&gsSet.Spec.Template.ObjectMeta)
 	if len(objMetaCauses) > 0 {
 		causes = append(causes, objMetaCauses...)
 	}

--- a/pkg/apis/agones/v1/register.go
+++ b/pkg/apis/agones/v1/register.go
@@ -53,8 +53,8 @@ func init() {
 }
 
 // Adds the list of known types to api.Scheme.
-func addKnownTypes(scheme *k8sruntime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+func addKnownTypes(apiScheme *k8sruntime.Scheme) error {
+	apiScheme.AddKnownTypes(SchemeGroupVersion,
 		&GameServer{},
 		&GameServerList{},
 		&GameServerSet{},
@@ -62,6 +62,6 @@ func addKnownTypes(scheme *k8sruntime.Scheme) error {
 		&Fleet{},
 		&FleetList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	metav1.AddToGroupVersion(apiScheme, SchemeGroupVersion)
 	return nil
 }

--- a/pkg/apis/allocation/v1/gameserverallocation.go
+++ b/pkg/apis/allocation/v1/gameserverallocation.go
@@ -101,6 +101,7 @@ func (gsas *GameServerAllocationSpec) PreferredSelectors() ([]labels.Selector, e
 
 	var err error
 	for i, p := range gsas.Preferred {
+		p := p
 		list[i], err = metav1.LabelSelectorAsSelector(&p)
 		if err != nil {
 			break

--- a/pkg/apis/allocation/v1/register.go
+++ b/pkg/apis/allocation/v1/register.go
@@ -49,11 +49,11 @@ func init() {
 }
 
 // Adds the list of known types to api.Scheme.
-func addKnownTypes(scheme *k8sruntime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+func addKnownTypes(apiScheme *k8sruntime.Scheme) error {
+	apiScheme.AddKnownTypes(SchemeGroupVersion,
 		&GameServerAllocation{},
 		&GameServerAllocationList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	metav1.AddToGroupVersion(apiScheme, SchemeGroupVersion)
 	return nil
 }

--- a/pkg/apis/autoscaling/v1/register.go
+++ b/pkg/apis/autoscaling/v1/register.go
@@ -49,11 +49,11 @@ func init() {
 }
 
 // Adds the list of known types to api.Scheme.
-func addKnownTypes(scheme *k8sruntime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+func addKnownTypes(apiScheme *k8sruntime.Scheme) error {
+	apiScheme.AddKnownTypes(SchemeGroupVersion,
 		&FleetAutoscaler{},
 		&FleetAutoscalerList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	metav1.AddToGroupVersion(apiScheme, SchemeGroupVersion)
 	return nil
 }

--- a/pkg/apis/multicluster/v1alpha1/gameserverallocationpolicy.go
+++ b/pkg/apis/multicluster/v1alpha1/gameserverallocationpolicy.go
@@ -175,11 +175,11 @@ func selectRandomWeighted(connections []*ClusterConnectionInfo, weights []int) *
 		return nil
 	}
 
-	rand := rand.Intn(sum)
+	randValue := rand.Intn(sum)
 	sum = 0
 	for i, weight := range weights {
 		sum += weight
-		if rand < sum {
+		if randValue < sum {
 			return connections[i]
 		}
 	}

--- a/pkg/apis/multicluster/v1alpha1/register.go
+++ b/pkg/apis/multicluster/v1alpha1/register.go
@@ -49,11 +49,11 @@ func init() {
 }
 
 // Adds the list of known types to api.Scheme.
-func addKnownTypes(scheme *k8sruntime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+func addKnownTypes(apiScheme *k8sruntime.Scheme) error {
+	apiScheme.AddKnownTypes(SchemeGroupVersion,
 		&GameServerAllocationPolicy{},
 		&GameServerAllocationPolicyList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	metav1.AddToGroupVersion(apiScheme, SchemeGroupVersion)
 	return nil
 }

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -340,7 +340,7 @@ func TestControllerRun(t *testing.T) {
 
 	// test updating fleet
 	fCopy := fleet.DeepCopy()
-	fCopy.Spec.Replicas = fCopy.Spec.Replicas + 10
+	fCopy.Spec.Replicas += 10
 	fleetWatch.Modify(fCopy)
 	assert.Equal(t, expected, f())
 

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -238,11 +238,12 @@ func (c *Allocator) allocateFromLocalCluster(gsa *allocationv1.GameServerAllocat
 		return nil, err
 	}
 
-	if err == ErrNoGameServerReady {
+	switch err {
+	case ErrNoGameServerReady:
 		gsa.Status.State = allocationv1.GameServerAllocationUnAllocated
-	} else if err == ErrConflictInGameServerSelection {
+	case ErrConflictInGameServerSelection:
 		gsa.Status.State = allocationv1.GameServerAllocationContention
-	} else {
+	default:
 		gsa.ObjectMeta.Name = gs.ObjectMeta.Name
 		gsa.Status.State = allocationv1.GameServerAllocationAllocated
 		gsa.Status.GameServerName = gs.ObjectMeta.Name
@@ -532,7 +533,7 @@ func (c *Allocator) allocationUpdateWorkers(workerCount int, stop <-chan struct{
 			for {
 				select {
 				case res := <-updateQueue:
-					gs, err := c.readyGameServerCache.PatchGameServerMetadata(res.request.gsa.Spec.MetaPatch, *res.gs)
+					gs, err := c.readyGameServerCache.PatchGameServerMetadata(res.request.gsa.Spec.MetaPatch, res.gs)
 					if err != nil {
 						// since we could not allocate, we should put it back
 						c.readyGameServerCache.AddToReadyGameServer(gs)

--- a/pkg/gameserverallocations/cache_test.go
+++ b/pkg/gameserverallocations/cache_test.go
@@ -44,11 +44,8 @@ func TestGameServerCacheEntry(t *testing.T) {
 
 	count := 0
 	cache.Range(func(key string, gs *agonesv1.GameServer) bool {
-		if count++; count == 2 {
-			return false
-		}
-
-		return true
+		count++
+		return count != 2
 	})
 
 	assert.Equal(t, 2, count, "Should only process one item")

--- a/pkg/gameserverallocations/ready_cache.go
+++ b/pkg/gameserverallocations/ready_cache.go
@@ -202,11 +202,11 @@ func (c *ReadyGameServerCache) ListSortedReadyGameServers() []*agonesv1.GameServ
 }
 
 // PatchGameServerMetadata patches the input gameserver with allocation meta patch and returns the updated gameserver
-func (c *ReadyGameServerCache) PatchGameServerMetadata(fam allocationv1.MetaPatch, gs agonesv1.GameServer) (*agonesv1.GameServer, error) {
-	c.patchMetadata(&gs, fam)
+func (c *ReadyGameServerCache) PatchGameServerMetadata(fam allocationv1.MetaPatch, gs *agonesv1.GameServer) (*agonesv1.GameServer, error) {
+	c.patchMetadata(gs, fam)
 	gs.Status.State = agonesv1.GameServerStateAllocated
 
-	return c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(&gs)
+	return c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(gs)
 }
 
 // patch the labels and annotations of an allocated GameServer with metadata from a GameServerAllocation

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -315,7 +315,7 @@ func (c *Controller) syncGameServerSet(key string) error {
 	for _, gs := range list {
 		key := "gsCount" + string(gs.Status.State)
 		if gs.ObjectMeta.DeletionTimestamp != nil {
-			key = key + "Deleted"
+			key += "Deleted"
 		}
 		v, ok := fields[key]
 		if !ok {

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -589,9 +589,9 @@ func TestControllerUpdateValidationHandler(t *testing.T) {
 	assert.Nil(t, err)
 
 	t.Run("valid gameserverset update", func(t *testing.T) {
-		new := fixture.DeepCopy()
-		new.Spec.Replicas = 10
-		newRaw, err := json.Marshal(new)
+		newGSS := fixture.DeepCopy()
+		newGSS.Spec.Replicas = 10
+		newRaw, err := json.Marshal(newGSS)
 		assert.Nil(t, err)
 
 		review := admv1beta1.AdmissionReview{
@@ -614,13 +614,13 @@ func TestControllerUpdateValidationHandler(t *testing.T) {
 	})
 
 	t.Run("invalid gameserverset update", func(t *testing.T) {
-		new := fixture.DeepCopy()
-		new.Spec.Template = agonesv1.GameServerTemplateSpec{
+		newGSS := fixture.DeepCopy()
+		newGSS.Spec.Template = agonesv1.GameServerTemplateSpec{
 			Spec: agonesv1.GameServerSpec{
 				Ports: []agonesv1.GameServerPort{{PortPolicy: agonesv1.Static}},
 			},
 		}
-		newRaw, err := json.Marshal(new)
+		newRaw, err := json.Marshal(newGSS)
 		assert.Nil(t, err)
 
 		assert.NotEqual(t, string(raw), string(newRaw))

--- a/pkg/metrics/controller.go
+++ b/pkg/metrics/controller.go
@@ -96,8 +96,8 @@ func NewController(
 
 	fInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.recordFleetChanges,
-		UpdateFunc: func(old, new interface{}) {
-			c.recordFleetChanges(new)
+		UpdateFunc: func(old, next interface{}) {
+			c.recordFleetChanges(next)
 		},
 		DeleteFunc: c.recordFleetDeletion,
 	})
@@ -117,9 +117,9 @@ func NewController(
 	return c
 }
 
-func (c *Controller) recordFleetAutoScalerChanges(old, new interface{}) {
+func (c *Controller) recordFleetAutoScalerChanges(old, next interface{}) {
 
-	fas, ok := new.(*autoscalingv1.FleetAutoscaler)
+	fas, ok := next.(*autoscalingv1.FleetAutoscaler)
 	if !ok {
 		return
 	}
@@ -246,8 +246,8 @@ func (c *Controller) recordFleetReplicas(fleetName string, total, allocated, rea
 // per second.
 // Addition to the cache are not handled, otherwise resync would make metrics inaccurate by doubling
 // current gameservers states.
-func (c *Controller) recordGameServerStatusChanges(old, new interface{}) {
-	newGs, ok := new.(*agonesv1.GameServer)
+func (c *Controller) recordGameServerStatusChanges(old, next interface{}) {
+	newGs, ok := next.(*agonesv1.GameServer)
 	if !ok {
 		return
 	}

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -80,16 +80,16 @@ func RegisterStackdriverExporter(projectID string, defaultLabels string) (*stack
 
 // SetReportingPeriod set appropriate reporting period which depends on exporters
 // we are going to use
-func SetReportingPeriod(prometheus, stackdriver bool) {
+func SetReportingPeriod(forPrometheus, forStackdriver bool) {
 	// if we're using only prometheus we can report faster as we're only exposing metrics in memory
 	reportingPeriod := 15 * time.Second
-	if stackdriver {
+	if forStackdriver {
 		// There is a limitation on Stackdriver that reporting should
 		// be equal or more than 1 minute
 		reportingPeriod = 60 * time.Second
 	}
 
-	if stackdriver || prometheus {
+	if forStackdriver || forPrometheus {
 		view.SetReportingPeriod(reportingPeriod)
 	}
 }

--- a/pkg/util/crd/crd.go
+++ b/pkg/util/crd/crd.go
@@ -36,8 +36,7 @@ func WaitForEstablishedCRD(crdGetter extv1beta1.CustomResourceDefinitionInterfac
 		}
 
 		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiv1beta1.Established:
+			if cond.Type == apiv1beta1.Established {
 				if cond.Status == apiv1beta1.ConditionTrue {
 					logger.WithField("crd", crd.ObjectMeta.Name).Info("custom resource definition established")
 					return true, err

--- a/pkg/util/runtime/runtime_test.go
+++ b/pkg/util/runtime/runtime_test.go
@@ -37,7 +37,7 @@ func TestHandleError(t *testing.T) {
 	assert.Nil(t, result, "No Errors for now")
 
 	err := fmt.Errorf("test")
-	//test nil logger
+	// test nil logger
 	logger := NewLoggerWithSource("test")
 	HandleError(logger.WithError(err), err)
 	if result != err {

--- a/sdks/go/sdk_test.go
+++ b/sdks/go/sdk_test.go
@@ -35,7 +35,7 @@ func TestSDK(t *testing.T) {
 		health: sm.hm,
 	}
 
-	//gate
+	// gate
 	assert.False(t, sm.ready)
 	assert.False(t, sm.shutdown)
 	assert.False(t, sm.hm.healthy)

--- a/site/handler.go
+++ b/site/handler.go
@@ -131,7 +131,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *handler) serveIndex(w http.ResponseWriter, r *http.Request) {
 	// Just redirect to the first one
 	// just commenting out, in case we want to soft launch
-	//http.Redirect(w, r, h.paths[0].repo, http.StatusTemporaryRedirect)
+	// http.Redirect(w, r, h.paths[0].repo, http.StatusTemporaryRedirect)
 	http.Redirect(w, r, "/site/", http.StatusTemporaryRedirect)
 }
 

--- a/test/e2e/allocator_test.go
+++ b/test/e2e/allocator_test.go
@@ -297,7 +297,8 @@ func restartAllocator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listing pods failed: %s", err)
 	}
-	for _, pod := range pods.Items {
+	for i := range pods.Items {
+		pod := &pods.Items[i]
 		if !strings.HasPrefix(pod.Name, allocatorServiceName) {
 			continue
 		}

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -385,7 +385,7 @@ func TestFleetUpdates(t *testing.T) {
 				defer client.Fleets(defaultNs).Delete(flt.ObjectMeta.Name, nil) // nolint:errcheck
 			}
 
-			err = framework.WaitForFleetGameServersCondition(flt, func(gs agonesv1.GameServer) bool {
+			err = framework.WaitForFleetGameServersCondition(flt, func(gs *agonesv1.GameServer) bool {
 				return gs.ObjectMeta.Annotations[key] == red
 			})
 			assert.Nil(t, err)
@@ -408,7 +408,7 @@ func TestFleetUpdates(t *testing.T) {
 			})
 			assert.Nil(t, err)
 
-			err = framework.WaitForFleetGameServersCondition(flt, func(gs agonesv1.GameServer) bool {
+			err = framework.WaitForFleetGameServersCondition(flt, func(gs *agonesv1.GameServer) bool {
 				return gs.ObjectMeta.Annotations[key] == green
 			})
 			assert.Nil(t, err)
@@ -429,7 +429,7 @@ func TestUpdateGameServerConfigurationInFleet(t *testing.T) {
 		PortPolicy:    agonesv1.Dynamic,
 		Protocol:      corev1.ProtocolUDP,
 	}}
-	flt := fleetWithGameServerSpec(gsSpec, defaultNs)
+	flt := fleetWithGameServerSpec(&gsSpec, defaultNs)
 	flt, err := client.Fleets(defaultNs).Create(flt)
 	assert.Nil(t, err, "could not create fleet")
 	defer client.Fleets(defaultNs).Delete(flt.ObjectMeta.Name, nil) // nolint:errcheck
@@ -463,7 +463,7 @@ func TestUpdateGameServerConfigurationInFleet(t *testing.T) {
 	_, err = framework.AgonesClient.AgonesV1().Fleets(defaultNs).Update(fltCopy)
 	assert.Nil(t, err, "could not update fleet")
 
-	err = framework.WaitForFleetGameServersCondition(flt, func(gs agonesv1.GameServer) bool {
+	err = framework.WaitForFleetGameServersCondition(flt, func(gs *agonesv1.GameServer) bool {
 		containerPort := gs.Spec.Ports[0].ContainerPort
 		return (gs.Name == gsa.Status.GameServerName && containerPort == oldPort) ||
 			(gs.Name != gsa.Status.GameServerName && containerPort == newPort)
@@ -831,7 +831,7 @@ func TestScaleUpAndDownInParallelStressTest(t *testing.T) {
 			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(defaultReplicas))
 		}
 	}
-	errors := make(chan error)
+	errorsChan := make(chan error)
 	var wg sync.WaitGroup
 	finished := make(chan bool, 1)
 
@@ -849,7 +849,7 @@ func TestScaleUpAndDownInParallelStressTest(t *testing.T) {
 				duration, err := scaleAndWait(t, flt, 0)
 				if err != nil {
 					fmt.Println(err)
-					errors <- err
+					errorsChan <- err
 					return
 				}
 				scaleDownStats.ReportDuration(duration, nil)
@@ -861,14 +861,14 @@ func TestScaleUpAndDownInParallelStressTest(t *testing.T) {
 				duration, err := scaleAndWait(t, flt, fleetSize)
 				if err != nil {
 					fmt.Println(err)
-					errors <- err
+					errorsChan <- err
 					return
 				}
 				scaleUpStats.ReportDuration(duration, nil)
 				duration, err = scaleAndWait(t, flt, 0)
 				if err != nil {
 					fmt.Println(err)
-					errors <- err
+					errorsChan <- err
 					return
 				}
 				scaleDownStats.ReportDuration(duration, nil)
@@ -882,7 +882,7 @@ func TestScaleUpAndDownInParallelStressTest(t *testing.T) {
 
 	select {
 	case <-finished:
-	case err := <-errors:
+	case err := <-errorsChan:
 		t.Fatalf("Error in waiting for a fleet to scale: %s", err)
 	}
 	fmt.Println("We are Done")
@@ -1024,6 +1024,7 @@ func TestFleetRecreateGameServers(t *testing.T) {
 			podClient := framework.KubeClient.CoreV1().Pods(defaultNs)
 
 			for _, gs := range list.Items {
+				gs := gs
 				pod, err := podClient.Get(gs.ObjectMeta.Name, metav1.GetOptions{})
 				assert.NoError(t, err)
 
@@ -1035,6 +1036,7 @@ func TestFleetRecreateGameServers(t *testing.T) {
 		}},
 		"gameserver shutdown": {f: func(t *testing.T, list *agonesv1.GameServerList) {
 			for _, gs := range list.Items {
+				gs := gs
 				var reply string
 				reply, err := e2e.SendGameServerUDP(&gs, "EXIT")
 				if err != nil {
@@ -1046,6 +1048,7 @@ func TestFleetRecreateGameServers(t *testing.T) {
 		}},
 		"gameserver unhealthy": {f: func(t *testing.T, list *agonesv1.GameServerList) {
 			for _, gs := range list.Items {
+				gs := gs
 				var reply string
 				reply, err := e2e.SendGameServerUDP(&gs, "UNHEALTHY")
 				if err != nil {
@@ -1109,7 +1112,8 @@ func listGameServers(flt *agonesv1.Fleet, getter typedagonesv1.GameServersGetter
 // Counts the number of gameservers with the specified scheduling strategy in a fleet
 func countFleetScheduling(gsList []agonesv1.GameServer, scheduling apis.SchedulingStrategy) int {
 	count := 0
-	for _, gs := range gsList {
+	for i := range gsList {
+		gs := &gsList[i]
 		if gs.Spec.Scheduling == scheduling {
 			count++
 		}
@@ -1190,17 +1194,17 @@ func scaleFleetSubresource(t *testing.T, f *agonesv1.Fleet, scale int32) *agones
 // defaultFleet returns a default fleet configuration
 func defaultFleet(namespace string) *agonesv1.Fleet {
 	gs := defaultGameServer(namespace)
-	return fleetWithGameServerSpec(gs.Spec, namespace)
+	return fleetWithGameServerSpec(&gs.Spec, namespace)
 }
 
 // fleetWithGameServerSpec returns a fleet with specified gameserver spec
-func fleetWithGameServerSpec(gsSpec agonesv1.GameServerSpec, namespace string) *agonesv1.Fleet {
+func fleetWithGameServerSpec(gsSpec *agonesv1.GameServerSpec, namespace string) *agonesv1.Fleet {
 	return &agonesv1.Fleet{
 		ObjectMeta: metav1.ObjectMeta{GenerateName: "simple-fleet-", Namespace: namespace},
 		Spec: agonesv1.FleetSpec{
 			Replicas: replicasCount,
 			Template: agonesv1.GameServerTemplateSpec{
-				Spec: gsSpec,
+				Spec: *gsSpec,
 			},
 		},
 	}


### PR DESCRIPTION
Fix minor issues, but plenty of them. Add new linters.
Add pointers when it is necessary for the sake of performance (avoid coping structures over 512 B in size).
Most fixes come from gocritic linter.
https://go-critic.github.io/overview.html
