### PR TITLE
Fuzz Roundtrip test for v1 Agones schemas

### DIFF
--- a/pkg/apis/agones/v1/fuzz_test/roundtrip_test.go
+++ b/pkg/apis/agones/v1/fuzz_test/roundtrip_test.go
@@ -1,0 +1,32 @@
+package install
+
+import (
+	"math/rand"
+	"testing"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
+	autoscalingv1 "agones.dev/agones/pkg/apis/autoscaling/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
+	genericfuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+func TestRoundTripTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+
+	localSchemeBuilder := runtime.SchemeBuilder{
+		agonesv1.AddToScheme,
+		allocationv1.AddToScheme,
+		autoscalingv1.AddToScheme,
+	}
+	seed := rand.Int63()
+	localFuzzer := fuzzer.FuzzerFor(genericfuzzer.Funcs, rand.NewSource(seed), codecs)
+
+	assert.NoError(t, localSchemeBuilder.AddToScheme(scheme))
+	roundtrip.RoundTripExternalTypes(t, scheme, codecs, localFuzzer, nil)
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/apitesting/codec.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/apitesting/codec.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apitesting
+
+import (
+	"fmt"
+	"mime"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
+)
+
+var (
+	testCodecMediaType        string
+	testStorageCodecMediaType string
+)
+
+// TestCodec returns the codec for the API version to test against, as set by the
+// KUBE_TEST_API_TYPE env var.
+func TestCodec(codecs runtimeserializer.CodecFactory, gvs ...schema.GroupVersion) runtime.Codec {
+	if len(testCodecMediaType) != 0 {
+		serializerInfo, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), testCodecMediaType)
+		if !ok {
+			panic(fmt.Sprintf("no serializer for %s", testCodecMediaType))
+		}
+		return codecs.CodecForVersions(serializerInfo.Serializer, codecs.UniversalDeserializer(), schema.GroupVersions(gvs), nil)
+	}
+	return codecs.LegacyCodec(gvs...)
+}
+
+// TestStorageCodec returns the codec for the API version to test against used in storage, as set by the
+// KUBE_TEST_API_STORAGE_TYPE env var.
+func TestStorageCodec(codecs runtimeserializer.CodecFactory, gvs ...schema.GroupVersion) runtime.Codec {
+	if len(testStorageCodecMediaType) != 0 {
+		serializerInfo, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), testStorageCodecMediaType)
+		if !ok {
+			panic(fmt.Sprintf("no serializer for %s", testStorageCodecMediaType))
+		}
+
+		// etcd2 only supports string data - we must wrap any result before returning
+		// TODO: remove for etcd3 / make parameterizable
+		serializer := serializerInfo.Serializer
+		if !serializerInfo.EncodesAsText {
+			serializer = runtime.NewBase64Serializer(serializer, serializer)
+		}
+
+		decoder := recognizer.NewDecoder(serializer, codecs.UniversalDeserializer())
+		return codecs.CodecForVersions(serializer, decoder, schema.GroupVersions(gvs), nil)
+
+	}
+	return codecs.LegacyCodec(gvs...)
+}
+
+func init() {
+	var err error
+	if apiMediaType := os.Getenv("KUBE_TEST_API_TYPE"); len(apiMediaType) > 0 {
+		testCodecMediaType, _, err = mime.ParseMediaType(apiMediaType)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if storageMediaType := os.Getenv("KUBE_TEST_API_STORAGE_TYPE"); len(storageMediaType) > 0 {
+		testStorageCodecMediaType, _, err = mime.ParseMediaType(storageMediaType)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// InstallOrDieFunc mirrors install functions that require success
+type InstallOrDieFunc func(scheme *runtime.Scheme)
+
+// SchemeForInstallOrDie builds a simple test scheme and codecfactory pair for easy unit testing from higher level install methods
+func SchemeForInstallOrDie(installFns ...InstallOrDieFunc) (*runtime.Scheme, runtimeserializer.CodecFactory) {
+	scheme := runtime.NewScheme()
+	codecFactory := runtimeserializer.NewCodecFactory(scheme)
+	for _, installFn := range installFns {
+		installFn(scheme)
+	}
+
+	return scheme, codecFactory
+}
+
+// InstallFunc mirrors install functions that can return an error
+type InstallFunc func(scheme *runtime.Scheme) error
+
+// SchemeForOrDie builds a simple test scheme and codecfactory pair for easy unit testing from the bare registration methods.
+func SchemeForOrDie(installFns ...InstallFunc) (*runtime.Scheme, runtimeserializer.CodecFactory) {
+	scheme := runtime.NewScheme()
+	codecFactory := runtimeserializer.NewCodecFactory(scheme)
+	for _, installFn := range installFns {
+		if err := installFn(scheme); err != nil {
+			panic(err)
+		}
+	}
+
+	return scheme, codecFactory
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/fuzzer.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/fuzzer.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzer
+
+import (
+	"math/rand"
+
+	"github.com/google/gofuzz"
+
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+// FuzzerFuncs returns a list of func(*SomeType, c fuzz.Continue) functions.
+type FuzzerFuncs func(codecs runtimeserializer.CodecFactory) []interface{}
+
+// FuzzerFor can randomly populate api objects that are destined for version.
+func FuzzerFor(funcs FuzzerFuncs, src rand.Source, codecs runtimeserializer.CodecFactory) *fuzz.Fuzzer {
+	f := fuzz.New().NilChance(.5).NumElements(0, 1)
+	if src != nil {
+		f.RandSource(src)
+	}
+	f.Funcs(funcs(codecs)...)
+	return f
+}
+
+// MergeFuzzerFuncs will merge the given funcLists, overriding early funcs with later ones if there first
+// argument has the same type.
+func MergeFuzzerFuncs(funcs ...FuzzerFuncs) FuzzerFuncs {
+	return FuzzerFuncs(func(codecs runtimeserializer.CodecFactory) []interface{} {
+		result := []interface{}{}
+		for _, f := range funcs {
+			if f != nil {
+				result = append(result, f(codecs)...)
+			}
+		}
+		return result
+	})
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/valuefuzz.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/valuefuzz.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzer
+
+import (
+	"reflect"
+)
+
+// ValueFuzz recursively changes all basic type values in an object. Any kind of references will not
+// be touch, i.e. the addresses of slices, maps, pointers will stay unchanged.
+func ValueFuzz(obj interface{}) {
+	valueFuzz(reflect.ValueOf(obj))
+}
+
+func valueFuzz(obj reflect.Value) {
+	switch obj.Kind() {
+	case reflect.Array:
+		for i := 0; i < obj.Len(); i++ {
+			valueFuzz(obj.Index(i))
+		}
+	case reflect.Slice:
+		if obj.IsNil() {
+			// TODO: set non-nil value
+		} else {
+			for i := 0; i < obj.Len(); i++ {
+				valueFuzz(obj.Index(i))
+			}
+		}
+	case reflect.Interface, reflect.Ptr:
+		if obj.IsNil() {
+			// TODO: set non-nil value
+		} else {
+			valueFuzz(obj.Elem())
+		}
+	case reflect.Struct:
+		for i, n := 0, obj.NumField(); i < n; i++ {
+			valueFuzz(obj.Field(i))
+		}
+	case reflect.Map:
+		if obj.IsNil() {
+			// TODO: set non-nil value
+		} else {
+			for _, k := range obj.MapKeys() {
+				// map values are not addressable. We need a copy.
+				v := obj.MapIndex(k)
+				copy := reflect.New(v.Type())
+				copy.Elem().Set(v)
+				valueFuzz(copy.Elem())
+				obj.SetMapIndex(k, copy.Elem())
+			}
+			// TODO: set some new value
+		}
+	case reflect.Func: // ignore, we don't have function types in our API
+	default:
+		if !obj.CanSet() {
+			return
+		}
+		switch obj.Kind() {
+		case reflect.String:
+			obj.SetString(obj.String() + "x")
+		case reflect.Bool:
+			obj.SetBool(!obj.Bool())
+		case reflect.Float32, reflect.Float64:
+			obj.SetFloat(obj.Float()*2.0 + 1.0)
+		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+			obj.SetInt(obj.Int() + 1)
+		case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+			obj.SetUint(obj.Uint() + 1)
+		default:
+		}
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/valuefuzz_test.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/apitesting/fuzzer/valuefuzz_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzer
+
+import "testing"
+
+func TestValueFuzz(t *testing.T) {
+	type (
+		Y struct {
+			I int
+			B bool
+			F float32
+			U uint
+		}
+		X struct {
+			Ptr   *X
+			Y     Y
+			Map   map[string]int
+			Slice []int
+		}
+	)
+
+	x := X{
+		Ptr:   &X{},
+		Map:   map[string]int{"foo": 42},
+		Slice: []int{1, 2, 3},
+	}
+
+	p := x.Ptr
+	m := x.Map
+	s := x.Slice
+
+	ValueFuzz(x)
+
+	if x.Ptr.Y.I == 0 {
+		t.Errorf("x.Ptr.Y.I should have changed")
+	}
+
+	if x.Map["foo"] == 42 {
+		t.Errorf("x.Map[foo] should have changed")
+	}
+
+	if x.Slice[0] == 1 {
+		t.Errorf("x.Slice[0] should have changed")
+	}
+
+	if x.Ptr != p {
+		t.Errorf("x.Ptr changed")
+	}
+
+	m["foo"] = 7
+	if x.Map["foo"] != m["foo"] {
+		t.Errorf("x.Map changed")
+	}
+	s[0] = 7
+	if x.Slice[0] != s[0] {
+		t.Errorf("x.Slice changed")
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roundtrip
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/gofuzz"
+	flag "github.com/spf13/pflag"
+
+	apitesting "k8s.io/apimachinery/pkg/api/apitesting"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type InstallFunc func(scheme *runtime.Scheme)
+
+// RoundTripTestForAPIGroup is convenient to call from your install package to make sure that a "bare" install of your group provides
+// enough information to round trip
+func RoundTripTestForAPIGroup(t *testing.T, installFn InstallFunc, fuzzingFuncs fuzzer.FuzzerFuncs) {
+	scheme := runtime.NewScheme()
+	installFn(scheme)
+
+	RoundTripTestForScheme(t, scheme, fuzzingFuncs)
+}
+
+// RoundTripTestForScheme is convenient to call if you already have a scheme and want to make sure that its well-formed
+func RoundTripTestForScheme(t *testing.T, scheme *runtime.Scheme, fuzzingFuncs fuzzer.FuzzerFuncs) {
+	codecFactory := runtimeserializer.NewCodecFactory(scheme)
+	f := fuzzer.FuzzerFor(
+		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, fuzzingFuncs),
+		rand.NewSource(rand.Int63()),
+		codecFactory,
+	)
+	RoundTripTypesWithoutProtobuf(t, scheme, codecFactory, f, nil)
+}
+
+// RoundTripProtobufTestForAPIGroup is convenient to call from your install package to make sure that a "bare" install of your group provides
+// enough information to round trip
+func RoundTripProtobufTestForAPIGroup(t *testing.T, installFn InstallFunc, fuzzingFuncs fuzzer.FuzzerFuncs) {
+	scheme := runtime.NewScheme()
+	installFn(scheme)
+
+	RoundTripProtobufTestForScheme(t, scheme, fuzzingFuncs)
+}
+
+// RoundTripProtobufTestForScheme is convenient to call if you already have a scheme and want to make sure that its well-formed
+func RoundTripProtobufTestForScheme(t *testing.T, scheme *runtime.Scheme, fuzzingFuncs fuzzer.FuzzerFuncs) {
+	codecFactory := runtimeserializer.NewCodecFactory(scheme)
+	fuzzer := fuzzer.FuzzerFor(
+		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, fuzzingFuncs),
+		rand.NewSource(rand.Int63()),
+		codecFactory,
+	)
+	RoundTripTypes(t, scheme, codecFactory, fuzzer, nil)
+}
+
+var FuzzIters = flag.Int("fuzz-iters", 20, "How many fuzzing iterations to do.")
+
+// globalNonRoundTrippableTypes are kinds that are effectively reserved across all GroupVersions
+// They don't roundtrip
+var globalNonRoundTrippableTypes = sets.NewString(
+	"ExportOptions",
+	"GetOptions",
+	// WatchEvent does not include kind and version and can only be deserialized
+	// implicitly (if the caller expects the specific object). The watch call defines
+	// the schema by content type, rather than via kind/version included in each
+	// object.
+	"WatchEvent",
+	// ListOptions is now part of the meta group
+	"ListOptions",
+	// Delete options is only read in metav1
+	"DeleteOptions",
+)
+
+// RoundTripTypesWithoutProtobuf applies the round-trip test to all round-trippable Kinds
+// in the scheme.  It will skip all the GroupVersionKinds in the skip list.
+func RoundTripTypesWithoutProtobuf(t *testing.T, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool) {
+	roundTripTypes(t, scheme, codecFactory, fuzzer, nonRoundTrippableTypes, true)
+}
+
+func RoundTripTypes(t *testing.T, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool) {
+	roundTripTypes(t, scheme, codecFactory, fuzzer, nonRoundTrippableTypes, false)
+}
+
+func roundTripTypes(t *testing.T, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool, skipProtobuf bool) {
+	for _, group := range groupsFromScheme(scheme) {
+		t.Logf("starting group %q", group)
+		internalVersion := schema.GroupVersion{Group: group, Version: runtime.APIVersionInternal}
+		internalKindToGoType := scheme.KnownTypes(internalVersion)
+
+		for kind := range internalKindToGoType {
+			if globalNonRoundTrippableTypes.Has(kind) {
+				continue
+			}
+
+			internalGVK := internalVersion.WithKind(kind)
+			roundTripSpecificKind(t, internalGVK, scheme, codecFactory, fuzzer, nonRoundTrippableTypes, skipProtobuf)
+		}
+
+		t.Logf("finished group %q", group)
+	}
+}
+
+// RoundTripExternalTypes applies the round-trip test to all external round-trippable Kinds
+// in the scheme.  It will skip all the GroupVersionKinds in the nonRoundTripExternalTypes list .
+func RoundTripExternalTypes(t *testing.T, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool) {
+	kinds := scheme.AllKnownTypes()
+	for gvk := range kinds {
+		if gvk.Version == runtime.APIVersionInternal || globalNonRoundTrippableTypes.Has(gvk.Kind) {
+			continue
+		}
+
+		// FIXME: this is explicitly testing w/o protobuf which was failing if enabled
+		// the reason for that is that protobuf is not setting Kind and APIVersion fields
+		// during obj2 decode, the same then applies to DecodeInto obj3. My guess is we
+		// should be setting these two fields accordingly when protobuf is passed as codec
+		// to roundTrip method.
+		roundTripSpecificKind(t, gvk, scheme, codecFactory, fuzzer, nonRoundTrippableTypes, true)
+	}
+}
+
+func RoundTripSpecificKindWithoutProtobuf(t *testing.T, gvk schema.GroupVersionKind, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool) {
+	roundTripSpecificKind(t, gvk, scheme, codecFactory, fuzzer, nonRoundTrippableTypes, true)
+}
+
+func RoundTripSpecificKind(t *testing.T, gvk schema.GroupVersionKind, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool) {
+	roundTripSpecificKind(t, gvk, scheme, codecFactory, fuzzer, nonRoundTrippableTypes, false)
+}
+
+func roundTripSpecificKind(t *testing.T, gvk schema.GroupVersionKind, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, nonRoundTrippableTypes map[schema.GroupVersionKind]bool, skipProtobuf bool) {
+	if nonRoundTrippableTypes[gvk] {
+		t.Logf("skipping %v", gvk)
+		return
+	}
+	t.Logf("round tripping %v", gvk)
+
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < *FuzzIters; i++ {
+		if gvk.Version == runtime.APIVersionInternal {
+			roundTripToAllExternalVersions(t, scheme, codecFactory, fuzzer, gvk, nonRoundTrippableTypes, skipProtobuf)
+		} else {
+			roundTripOfExternalType(t, scheme, codecFactory, fuzzer, gvk, skipProtobuf)
+		}
+		if t.Failed() {
+			break
+		}
+	}
+}
+
+// fuzzInternalObject fuzzes an arbitrary runtime object using the appropriate
+// fuzzer registered with the apitesting package.
+func fuzzInternalObject(t *testing.T, fuzzer *fuzz.Fuzzer, object runtime.Object) runtime.Object {
+	fuzzer.Fuzz(object)
+
+	j, err := apimeta.TypeAccessor(object)
+	if err != nil {
+		t.Fatalf("Unexpected error %v for %#v", err, object)
+	}
+	j.SetKind("")
+	j.SetAPIVersion("")
+
+	return object
+}
+
+func groupsFromScheme(scheme *runtime.Scheme) []string {
+	ret := sets.String{}
+	for gvk := range scheme.AllKnownTypes() {
+		ret.Insert(gvk.Group)
+	}
+	return ret.List()
+}
+
+func roundTripToAllExternalVersions(t *testing.T, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, internalGVK schema.GroupVersionKind, nonRoundTrippableTypes map[schema.GroupVersionKind]bool, skipProtobuf bool) {
+	object, err := scheme.New(internalGVK)
+	if err != nil {
+		t.Fatalf("Couldn't make a %v? %v", internalGVK, err)
+	}
+	if _, err := apimeta.TypeAccessor(object); err != nil {
+		t.Fatalf("%q is not a TypeMeta and cannot be tested - add it to nonRoundTrippableInternalTypes: %v", internalGVK, err)
+	}
+
+	fuzzInternalObject(t, fuzzer, object)
+
+	// find all potential serializations in the scheme.
+	// TODO fix this up to handle kinds that cross registered with different names.
+	for externalGVK, externalGoType := range scheme.AllKnownTypes() {
+		if externalGVK.Version == runtime.APIVersionInternal {
+			continue
+		}
+		if externalGVK.GroupKind() != internalGVK.GroupKind() {
+			continue
+		}
+		if nonRoundTrippableTypes[externalGVK] {
+			t.Logf("\tskipping  %v %v", externalGVK, externalGoType)
+			continue
+		}
+		t.Logf("\tround tripping to %v %v", externalGVK, externalGoType)
+
+		roundTrip(t, scheme, apitesting.TestCodec(codecFactory, externalGVK.GroupVersion()), object)
+
+		// TODO remove this hack after we're past the intermediate steps
+		if !skipProtobuf && externalGVK.Group != "kubeadm.k8s.io" {
+			s := protobuf.NewSerializer(scheme, scheme, "application/arbitrary.content.type")
+			protobufCodec := codecFactory.CodecForVersions(s, s, externalGVK.GroupVersion(), nil)
+			roundTrip(t, scheme, protobufCodec, object)
+		}
+	}
+}
+
+func roundTripOfExternalType(t *testing.T, scheme *runtime.Scheme, codecFactory runtimeserializer.CodecFactory, fuzzer *fuzz.Fuzzer, externalGVK schema.GroupVersionKind, skipProtobuf bool) {
+	object, err := scheme.New(externalGVK)
+	if err != nil {
+		t.Fatalf("Couldn't make a %v? %v", externalGVK, err)
+	}
+	typeAcc, err := apimeta.TypeAccessor(object)
+	if err != nil {
+		t.Fatalf("%q is not a TypeMeta and cannot be tested - add it to nonRoundTrippableInternalTypes: %v", externalGVK, err)
+	}
+
+	fuzzInternalObject(t, fuzzer, object)
+
+	externalGoType := reflect.TypeOf(object).PkgPath()
+	t.Logf("\tround tripping external type %v %v", externalGVK, externalGoType)
+
+	typeAcc.SetKind(externalGVK.Kind)
+	typeAcc.SetAPIVersion(externalGVK.GroupVersion().String())
+
+	roundTrip(t, scheme, json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, false), object)
+
+	// TODO remove this hack after we're past the intermediate steps
+	if !skipProtobuf {
+		roundTrip(t, scheme, protobuf.NewSerializer(scheme, scheme, "application/protobuf"), object)
+	}
+}
+
+// roundTrip applies a single round-trip test to the given runtime object
+// using the given codec.  The round-trip test ensures that an object can be
+// deep-copied, converted, marshaled and back without loss of data.
+//
+// For internal types this means
+//
+//   internal -> external -> json/protobuf -> external -> internal.
+//
+// For external types this means
+//
+//   external -> json/protobuf -> external.
+func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object runtime.Object) {
+	printer := spew.ConfigState{DisableMethods: true}
+	original := object
+
+	// deep copy the original object
+	object = object.DeepCopyObject()
+	name := reflect.TypeOf(object).Elem().Name()
+	if !apiequality.Semantic.DeepEqual(original, object) {
+		t.Errorf("%v: DeepCopy altered the object, diff: %v", name, diff.ObjectReflectDiff(original, object))
+		t.Errorf("%s", spew.Sdump(original))
+		t.Errorf("%s", spew.Sdump(object))
+		return
+	}
+
+	// encode (serialize) the deep copy using the provided codec
+	data, err := runtime.Encode(codec, object)
+	if err != nil {
+		if runtime.IsNotRegisteredError(err) {
+			t.Logf("%v: not registered: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		} else {
+			t.Errorf("%v: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		}
+		return
+	}
+
+	// ensure that the deep copy is equal to the original; neither the deep
+	// copy or conversion should alter the object
+	// TODO eliminate this global
+	if !apiequality.Semantic.DeepEqual(original, object) {
+		t.Errorf("%v: encode altered the object, diff: %v", name, diff.ObjectReflectDiff(original, object))
+		return
+	}
+
+	// encode (serialize) a second time to verify that it was not varying
+	secondData, err := runtime.Encode(codec, object)
+	if err != nil {
+		if runtime.IsNotRegisteredError(err) {
+			t.Logf("%v: not registered: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		} else {
+			t.Errorf("%v: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		}
+		return
+	}
+
+	// serialization to the wire must be stable to ensure that we don't write twice to the DB
+	// when the object hasn't changed.
+	if !bytes.Equal(data, secondData) {
+		t.Errorf("%v: serialization is not stable: %s", name, printer.Sprintf("%#v", object))
+	}
+
+	// decode (deserialize) the encoded data back into an object
+	obj2, err := runtime.Decode(codec, data)
+	if err != nil {
+		t.Errorf("%v: %v\nCodec: %#v\nData: %s\nSource: %#v", name, err, codec, dataAsString(data), printer.Sprintf("%#v", object))
+		panic("failed")
+	}
+
+	// ensure that the object produced from decoding the encoded data is equal
+	// to the original object
+	if !apiequality.Semantic.DeepEqual(original, obj2) {
+		t.Errorf("%v: diff: %v\nCodec: %#v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, diff.ObjectReflectDiff(original, obj2), codec, printer.Sprintf("%#v", original), dataAsString(data), printer.Sprintf("%#v", obj2))
+		return
+	}
+
+	// decode the encoded data into a new object (instead of letting the codec
+	// create a new object)
+	obj3 := reflect.New(reflect.TypeOf(object).Elem()).Interface().(runtime.Object)
+	if err := runtime.DecodeInto(codec, data, obj3); err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+
+	// special case for kinds which are internal and external at the same time (many in meta.k8s.io are). For those
+	// runtime.DecodeInto above will return the external variant and set the APIVersion and kind, while the input
+	// object might be internal. Hence, we clear those values for obj3 for that case to correctly compare.
+	intAndExt, err := internalAndExternalKind(scheme, object)
+	if err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+	if intAndExt {
+		typeAcc, err := apimeta.TypeAccessor(object)
+		if err != nil {
+			t.Fatalf("%v: error accessing TypeMeta: %v", name, err)
+		}
+		if len(typeAcc.GetAPIVersion()) == 0 {
+			typeAcc, err := apimeta.TypeAccessor(obj3)
+			if err != nil {
+				t.Fatalf("%v: error accessing TypeMeta: %v", name, err)
+			}
+			typeAcc.SetAPIVersion("")
+			typeAcc.SetKind("")
+		}
+	}
+
+	// ensure that the new runtime object is equal to the original after being
+	// decoded into
+	if !apiequality.Semantic.DeepEqual(object, obj3) {
+		t.Errorf("%v: diff: %v\nCodec: %#v", name, diff.ObjectReflectDiff(object, obj3), codec)
+		return
+	}
+
+	// do structure-preserving fuzzing of the deep-copied object. If it shares anything with the original,
+	// the deep-copy was actually only a shallow copy. Then original and obj3 will be different after fuzzing.
+	// NOTE: we use the encoding+decoding here as an alternative, guaranteed deep-copy to compare against.
+	fuzzer.ValueFuzz(object)
+	if !apiequality.Semantic.DeepEqual(original, obj3) {
+		t.Errorf("%v: fuzzing a copy altered the original, diff: %v", name, diff.ObjectReflectDiff(original, obj3))
+		return
+	}
+}
+
+func internalAndExternalKind(scheme *runtime.Scheme, object runtime.Object) (bool, error) {
+	kinds, _, err := scheme.ObjectKinds(object)
+	if err != nil {
+		return false, err
+	}
+	internal, external := false, false
+	for _, k := range kinds {
+		if k.Version == runtime.APIVersionInternal {
+			internal = true
+		} else {
+			external = true
+		}
+	}
+	return internal && external, nil
+}
+
+// dataAsString returns the given byte array as a string; handles detecting
+// protocol buffers.
+func dataAsString(data []byte) string {
+	dataString := string(data)
+	if !strings.HasPrefix(dataString, "{") {
+		dataString = "\n" + hex.Dump(data)
+		proto.NewBuffer(make([]byte, 0, 1024)).DebugPrint("decoded object", data)
+	}
+	return dataString
+}

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzer
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/gofuzz"
+
+	apitesting "k8s.io/apimachinery/pkg/api/apitesting"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func genericFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		func(q *resource.Quantity, c fuzz.Continue) {
+			*q = *resource.NewQuantity(c.Int63n(1000), resource.DecimalExponent)
+		},
+		func(j *int, c fuzz.Continue) {
+			*j = int(c.Int31())
+		},
+		func(j **int, c fuzz.Continue) {
+			if c.RandBool() {
+				i := int(c.Int31())
+				*j = &i
+			} else {
+				*j = nil
+			}
+		},
+		func(j *runtime.TypeMeta, c fuzz.Continue) {
+			// We have to customize the randomization of TypeMetas because their
+			// APIVersion and Kind must remain blank in memory.
+			j.APIVersion = ""
+			j.Kind = ""
+		},
+		func(j *runtime.Object, c fuzz.Continue) {
+			// TODO: uncomment when round trip starts from a versioned object
+			if true { //c.RandBool() {
+				*j = &runtime.Unknown{
+					// We do not set TypeMeta here because it is not carried through a round trip
+					Raw:         []byte(`{"apiVersion":"unknown.group/unknown","kind":"Something","someKey":"someValue"}`),
+					ContentType: runtime.ContentTypeJSON,
+				}
+			} else {
+				types := []runtime.Object{&metav1.Status{}, &metav1.APIGroup{}}
+				t := types[c.Rand.Intn(len(types))]
+				c.Fuzz(t)
+				*j = t
+			}
+		},
+		func(r *runtime.RawExtension, c fuzz.Continue) {
+			// Pick an arbitrary type and fuzz it
+			types := []runtime.Object{&metav1.Status{}, &metav1.APIGroup{}}
+			obj := types[c.Rand.Intn(len(types))]
+			c.Fuzz(obj)
+
+			// Find a codec for converting the object to raw bytes.  This is necessary for the
+			// api version and kind to be correctly set be serialization.
+			var codec = apitesting.TestCodec(codecs, metav1.SchemeGroupVersion)
+
+			// Convert the object to raw bytes
+			bytes, err := runtime.Encode(codec, obj)
+			if err != nil {
+				panic(fmt.Sprintf("Failed to encode object: %v", err))
+			}
+
+			// strip trailing newlines which do not survive roundtrips
+			for len(bytes) >= 1 && bytes[len(bytes)-1] == 10 {
+				bytes = bytes[:len(bytes)-1]
+			}
+
+			// Set the bytes field on the RawExtension
+			r.Raw = bytes
+		},
+	}
+}
+
+// taken from gofuzz internals for RandString
+type charRange struct {
+	first, last rune
+}
+
+func (c *charRange) choose(r *rand.Rand) rune {
+	count := int64(c.last - c.first + 1)
+	ch := c.first + rune(r.Int63n(count))
+
+	return ch
+}
+
+// randomLabelPart produces a valid random label value or name-part
+// of a label key.
+func randomLabelPart(c fuzz.Continue, canBeEmpty bool) string {
+	validStartEnd := []charRange{{'0', '9'}, {'a', 'z'}, {'A', 'Z'}}
+	validMiddle := []charRange{{'0', '9'}, {'a', 'z'}, {'A', 'Z'},
+		{'.', '.'}, {'-', '-'}, {'_', '_'}}
+
+	partLen := c.Rand.Intn(64) // len is [0, 63]
+	if !canBeEmpty {
+		partLen = c.Rand.Intn(63) + 1 // len is [1, 63]
+	}
+
+	runes := make([]rune, partLen)
+	if partLen == 0 {
+		return string(runes)
+	}
+
+	runes[0] = validStartEnd[c.Rand.Intn(len(validStartEnd))].choose(c.Rand)
+	for i := range runes[1:] {
+		runes[i+1] = validMiddle[c.Rand.Intn(len(validMiddle))].choose(c.Rand)
+	}
+	runes[len(runes)-1] = validStartEnd[c.Rand.Intn(len(validStartEnd))].choose(c.Rand)
+
+	return string(runes)
+}
+
+func randomDNSLabel(c fuzz.Continue) string {
+	validStartEnd := []charRange{{'0', '9'}, {'a', 'z'}}
+	validMiddle := []charRange{{'0', '9'}, {'a', 'z'}, {'-', '-'}}
+
+	partLen := c.Rand.Intn(63) + 1 // len is [1, 63]
+	runes := make([]rune, partLen)
+
+	runes[0] = validStartEnd[c.Rand.Intn(len(validStartEnd))].choose(c.Rand)
+	for i := range runes[1:] {
+		runes[i+1] = validMiddle[c.Rand.Intn(len(validMiddle))].choose(c.Rand)
+	}
+	runes[len(runes)-1] = validStartEnd[c.Rand.Intn(len(validStartEnd))].choose(c.Rand)
+
+	return string(runes)
+}
+
+func randomLabelKey(c fuzz.Continue) string {
+	namePart := randomLabelPart(c, false)
+	prefixPart := ""
+
+	usePrefix := c.RandBool()
+	if usePrefix {
+		// we can fit, with dots, at most 3 labels in the 253 allotted characters
+		prefixPartsLen := c.Rand.Intn(2) + 1
+		prefixParts := make([]string, prefixPartsLen)
+		for i := range prefixParts {
+			prefixParts[i] = randomDNSLabel(c)
+		}
+		prefixPart = strings.Join(prefixParts, ".") + "/"
+	}
+
+	return prefixPart + namePart
+}
+
+func v1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+
+	return []interface{}{
+		func(j *metav1.TypeMeta, c fuzz.Continue) {
+			// We have to customize the randomization of TypeMetas because their
+			// APIVersion and Kind must remain blank in memory.
+			j.APIVersion = ""
+			j.Kind = ""
+		},
+		func(j *metav1.ObjectMeta, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+
+			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+			j.UID = types.UID(c.RandString())
+
+			var sec, nsec int64
+			c.Fuzz(&sec)
+			c.Fuzz(&nsec)
+			j.CreationTimestamp = metav1.Unix(sec, nsec).Rfc3339Copy()
+
+			if j.DeletionTimestamp != nil {
+				c.Fuzz(&sec)
+				c.Fuzz(&nsec)
+				t := metav1.Unix(sec, nsec).Rfc3339Copy()
+				j.DeletionTimestamp = &t
+			}
+
+			if len(j.Labels) == 0 {
+				j.Labels = nil
+			} else {
+				delete(j.Labels, "")
+			}
+			if len(j.Annotations) == 0 {
+				j.Annotations = nil
+			} else {
+				delete(j.Annotations, "")
+			}
+			if len(j.OwnerReferences) == 0 {
+				j.OwnerReferences = nil
+			}
+			if len(j.Finalizers) == 0 {
+				j.Finalizers = nil
+			}
+		},
+		func(j *metav1.Initializers, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			if len(j.Pending) == 0 {
+				j.Pending = nil
+			}
+		},
+		func(j *metav1.ListMeta, c fuzz.Continue) {
+			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+			j.SelfLink = c.RandString()
+		},
+		func(j *metav1.LabelSelector, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			// we can't have an entirely empty selector, so force
+			// use of MatchExpression if necessary
+			if len(j.MatchLabels) == 0 && len(j.MatchExpressions) == 0 {
+				j.MatchExpressions = make([]metav1.LabelSelectorRequirement, c.Rand.Intn(2)+1)
+			}
+
+			if j.MatchLabels != nil {
+				fuzzedMatchLabels := make(map[string]string, len(j.MatchLabels))
+				for i := 0; i < len(j.MatchLabels); i++ {
+					fuzzedMatchLabels[randomLabelKey(c)] = randomLabelPart(c, true)
+				}
+				j.MatchLabels = fuzzedMatchLabels
+			}
+
+			validOperators := []metav1.LabelSelectorOperator{
+				metav1.LabelSelectorOpIn,
+				metav1.LabelSelectorOpNotIn,
+				metav1.LabelSelectorOpExists,
+				metav1.LabelSelectorOpDoesNotExist,
+			}
+
+			if j.MatchExpressions != nil {
+				// NB: the label selector parser code sorts match expressions by key, and sorts the values,
+				// so we need to make sure ours are sorted as well here to preserve round-trip comparison.
+				// In practice, not sorting doesn't hurt anything...
+
+				for i := range j.MatchExpressions {
+					req := metav1.LabelSelectorRequirement{}
+					c.Fuzz(&req)
+					req.Key = randomLabelKey(c)
+					req.Operator = validOperators[c.Rand.Intn(len(validOperators))]
+					if req.Operator == metav1.LabelSelectorOpIn || req.Operator == metav1.LabelSelectorOpNotIn {
+						if len(req.Values) == 0 {
+							// we must have some values here, so randomly choose a short length
+							req.Values = make([]string, c.Rand.Intn(2)+1)
+						}
+						for i := range req.Values {
+							req.Values[i] = randomLabelPart(c, true)
+						}
+						sort.Strings(req.Values)
+					} else {
+						req.Values = nil
+					}
+					j.MatchExpressions[i] = req
+				}
+
+				sort.Slice(j.MatchExpressions, func(a, b int) bool { return j.MatchExpressions[a].Key < j.MatchExpressions[b].Key })
+			}
+		},
+	}
+}
+
+func v1alpha1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		func(r *metav1beta1.TableRow, c fuzz.Continue) {
+			c.Fuzz(&r.Object)
+			c.Fuzz(&r.Conditions)
+			if len(r.Conditions) == 0 {
+				r.Conditions = nil
+			}
+			n := c.Intn(10)
+			if n > 0 {
+				r.Cells = make([]interface{}, n)
+			}
+			for i := range r.Cells {
+				t := c.Intn(6)
+				switch t {
+				case 0:
+					r.Cells[i] = c.RandString()
+				case 1:
+					r.Cells[i] = c.Int63()
+				case 2:
+					r.Cells[i] = c.RandBool()
+				case 3:
+					x := map[string]interface{}{}
+					for j := c.Intn(10) + 1; j >= 0; j-- {
+						x[c.RandString()] = c.RandString()
+					}
+					r.Cells[i] = x
+				case 4:
+					x := make([]interface{}, c.Intn(10))
+					for i := range x {
+						x[i] = c.Int63()
+					}
+					r.Cells[i] = x
+				default:
+					r.Cells[i] = nil
+				}
+			}
+		},
+	}
+}
+
+var Funcs = fuzzer.MergeFuzzerFuncs(
+	genericFuzzerFuncs,
+	v1FuzzerFuncs,
+	v1alpha1FuzzerFuncs,
+)


### PR DESCRIPTION
Add Roundtrip tests for agones.dev external types.
Skip multicluster v1alpha1 API schema for now.
For #1098 .