### PR TITLE
Release 1.3.0-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [v1.3.0-rc](https://github.com/googleforgames/agones/tree/v1.3.0-rc) (2020-01-14)
+
+[Full Changelog](https://github.com/googleforgames/agones/compare/v1.2.0...v1.3.0-rc)
+
+**Breaking changes:**
+
+- Node packaging [\#1264](https://github.com/googleforgames/agones/pull/1264) ([rorygarand](https://github.com/rorygarand))
+- Update GRPC to v1.20.1 [\#1215](https://github.com/googleforgames/agones/pull/1215) ([markmandel](https://github.com/markmandel))
+
+**Implemented enhancements:**
+
+- Terraform support for EKS [\#966](https://github.com/googleforgames/agones/issues/966)
+- Added Community Meetings to the community pages [\#1271](https://github.com/googleforgames/agones/pull/1271) ([markmandel](https://github.com/markmandel))
+- Fuzz Roundtrip test for v1 Agones schemas [\#1269](https://github.com/googleforgames/agones/pull/1269) ([aLekSer](https://github.com/aLekSer))
+- Add Annotations validation for Template ObjectMeta [\#1266](https://github.com/googleforgames/agones/pull/1266) ([aLekSer](https://github.com/aLekSer))
+- Add validation for Labels on Fleet and GS Template [\#1257](https://github.com/googleforgames/agones/pull/1257) ([aLekSer](https://github.com/aLekSer))
+- Feature Gate implementation [\#1256](https://github.com/googleforgames/agones/pull/1256) ([markmandel](https://github.com/markmandel))
+- Add Embark logo to Agones site [\#1237](https://github.com/googleforgames/agones/pull/1237) ([luna-duclos](https://github.com/luna-duclos))
+- Unity SDK - Watch GameServer Functionality [\#1234](https://github.com/googleforgames/agones/pull/1234) ([markmandel](https://github.com/markmandel))
+- Better error message for Health Check Failure [\#1222](https://github.com/googleforgames/agones/pull/1222) ([markmandel](https://github.com/markmandel))
+- Configurable Log Level for Agones Controller [\#1220](https://github.com/googleforgames/agones/pull/1220) ([aLekSer](https://github.com/aLekSer))
+- Add Go Client example which could create GS [\#1213](https://github.com/googleforgames/agones/pull/1213) ([aLekSer](https://github.com/aLekSer))
+- Automate confirming example images are on gcr.io [\#1207](https://github.com/googleforgames/agones/pull/1207) ([markmandel](https://github.com/markmandel))
+- improve stackdriver metric type [\#1132](https://github.com/googleforgames/agones/pull/1132) ([cyriltovena](https://github.com/cyriltovena))
+- Feature Stages Documentation [\#1080](https://github.com/googleforgames/agones/pull/1080) ([markmandel](https://github.com/markmandel))
+- Initial version of EKS terraform config [\#986](https://github.com/googleforgames/agones/pull/986) ([aLekSer](https://github.com/aLekSer))
+
+**Fixed bugs:**
+
+- GKE: Preemptible node pools make game server unreachable [\#1245](https://github.com/googleforgames/agones/issues/1245)
+- Fleet/GameServerSet Validation: Able to create a Fleet with label and annotations length \> 63 symbols [\#1244](https://github.com/googleforgames/agones/issues/1244)
+- Health Checking Documentation bug - doesn't restart before Ready [\#1229](https://github.com/googleforgames/agones/issues/1229)
+- TestMultiClusterAllocationOnLocalCluster is flakey [\#1114](https://github.com/googleforgames/agones/issues/1114)
+- Fixup Helm Configuration table [\#1255](https://github.com/googleforgames/agones/pull/1255) ([markmandel](https://github.com/markmandel))
+- Handling of PVM shutdown/maintenance events [\#1254](https://github.com/googleforgames/agones/pull/1254) ([markmandel](https://github.com/markmandel))
+- Fix cleanup Agones resources script [\#1240](https://github.com/googleforgames/agones/pull/1240) ([aLekSer](https://github.com/aLekSer))
+- Fix documentation for multi-cluster allocation [\#1235](https://github.com/googleforgames/agones/pull/1235) ([pooneh-m](https://github.com/pooneh-m))
+- Health Checking: Fix doc errors and expand [\#1233](https://github.com/googleforgames/agones/pull/1233) ([markmandel](https://github.com/markmandel))
+
+**Security fixes:**
+
+- Update Alpine image to 3.11 [\#1253](https://github.com/googleforgames/agones/pull/1253) ([markmandel](https://github.com/markmandel))
+
+**Closed issues:**
+
+- typo in README.md [\#1259](https://github.com/googleforgames/agones/issues/1259)
+- Release 1.2.0 [\#1225](https://github.com/googleforgames/agones/issues/1225)
+- Updates GRPC to v1.20.1 [\#1214](https://github.com/googleforgames/agones/issues/1214)
+
+**Merged pull requests:**
+
+- Fix broken link to Helm installation [\#1270](https://github.com/googleforgames/agones/pull/1270) ([mdanzinger](https://github.com/mdanzinger))
+- Update golangci-lint, add more linters [\#1267](https://github.com/googleforgames/agones/pull/1267) ([aLekSer](https://github.com/aLekSer))
+- Fix a minor typo in the unity example's README [\#1265](https://github.com/googleforgames/agones/pull/1265) ([roberthbailey](https://github.com/roberthbailey))
+- Update e2e Kubectl to 1.13.12 [\#1252](https://github.com/googleforgames/agones/pull/1252) ([markmandel](https://github.com/markmandel))
+- Update to Go 1.13 [\#1251](https://github.com/googleforgames/agones/pull/1251) ([markmandel](https://github.com/markmandel))
+- Events: Move logging to Debug [\#1250](https://github.com/googleforgames/agones/pull/1250) ([markmandel](https://github.com/markmandel))
+- Webhooks: Move "running" logging to Debug [\#1249](https://github.com/googleforgames/agones/pull/1249) ([markmandel](https://github.com/markmandel))
+- Workerqueue: Enqueuing & processing logs to Debug [\#1248](https://github.com/googleforgames/agones/pull/1248) ([markmandel](https://github.com/markmandel))
+- Adding retry on GameServerAllocations.Create for multi-cluster testing [\#1243](https://github.com/googleforgames/agones/pull/1243) ([pooneh-m](https://github.com/pooneh-m))
+- Half the width of the Embark Logo [\#1242](https://github.com/googleforgames/agones/pull/1242) ([luna-duclos](https://github.com/luna-duclos))
+- Remove syncGameServerSet logging. [\#1241](https://github.com/googleforgames/agones/pull/1241) ([markmandel](https://github.com/markmandel))
+- Changed the LabelSelector reference of allocator gRPC api [\#1236](https://github.com/googleforgames/agones/pull/1236) ([pooneh-m](https://github.com/pooneh-m))
+- Move conflict messaged to Debug Logging [\#1232](https://github.com/googleforgames/agones/pull/1232) ([markmandel](https://github.com/markmandel))
+- Preparation for 1.3.0 [\#1231](https://github.com/googleforgames/agones/pull/1231) ([markmandel](https://github.com/markmandel))
+- Docs Fleet add section about RollingUpdate fields [\#1228](https://github.com/googleforgames/agones/pull/1228) ([aLekSer](https://github.com/aLekSer))
+- Split installation guide into separate sections [\#1211](https://github.com/googleforgames/agones/pull/1211) ([markmandel](https://github.com/markmandel))
+
 ## [v1.2.0](https://github.com/googleforgames/agones/tree/v1.2.0) (2019-12-11)
 
 [Full Changelog](https://github.com/googleforgames/agones/compare/v1.2.0-rc...v1.2.0)
@@ -21,6 +89,7 @@
 
 **Merged pull requests:**
 
+- Release 1.2.0 [\#1230](https://github.com/googleforgames/agones/pull/1230) ([markmandel](https://github.com/markmandel))
 - Docs: allocator service should have save-config [\#1224](https://github.com/googleforgames/agones/pull/1224) ([aLekSer](https://github.com/aLekSer))
 - Add missing license headers [\#1219](https://github.com/googleforgames/agones/pull/1219) ([aLekSer](https://github.com/aLekSer))
 - Wrong date on 1.2.0-rc blog post [\#1208](https://github.com/googleforgames/agones/pull/1208) ([markmandel](https://github.com/markmandel))
@@ -107,7 +176,6 @@
 
 **Fixed bugs:**
 
-- TestMultiClusterAllocationOnLocalCluster is flakey [\#1114](https://github.com/googleforgames/agones/issues/1114)
 - TestFleetRollingUpdate/Use\_fleet\_Patch\_false\_10% test is flaky [\#1049](https://github.com/googleforgames/agones/issues/1049)
 - Broke Allocator Status in Grafana Dashboard [\#1158](https://github.com/googleforgames/agones/pull/1158) ([markmandel](https://github.com/markmandel))
 

--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -15,10 +15,11 @@ and copy it into a release issue. Fill in relevant values, found inside {}
 - [ ] `git checkout master && git pull --rebase upstream master`
 - [ ] If full release, run `make site-deploy SERVICE={version}-1`, (replace . with -)
 - [ ] Run `make gen-changelog` to generate the CHANGELOG.md (if release candidate `make gen-changelog RELEASE_VERSION={version}-rc`)
-- [ ] Ensure the [helm `tag` value][values] is correct (should be the {version} if a full release, {version}-rc if release candidate)
-- [ ] Ensure the [helm `Chart` version values][chart] are correct (should be the {version} if a full release, {version}-rc if release candidate)
+- [ ] Ensure the [helm `tag` value][values] is correct (should be {version} if a full release, {version}-rc if release candidate)
+- [ ] Ensure the [helm `Chart` version values][chart] are correct (should be {version} if a full release, {version}-rc if release candidate)
+- [ ] Ensure the [`sdks/nodejs/package.json`][nodejs] version is correct (should be {version} if a full release, {version}-rc if release candidate)
 - [ ] Run `make gen-install`
-- [ ] Run `test-examples-on-gcr` to ensure all example images exist on gcr.io/agones-images-
+- [ ] Run `make test-examples-on-gcr` to ensure all example images exist on gcr.io/agones-images-
 - [ ] Create a *draft* release with the [release template][release-template]
   - [ ] Make a `tag` with the release version.
 - [ ] Site updated
@@ -32,6 +33,7 @@ and copy it into a release issue. Fill in relevant values, found inside {}
 - [ ] Create PR with these changes, and merge them with approval
 - [ ] Confirm local git remote `upstream` points at `git@github.com:googleforgames/agones.git`
 - [ ] Run `git remote update && git checkout master && git reset --hard upstream/master` to ensure your code is in line with upstream  (unless this is a hotfix, then do the same, but for the release branch)
+- [ ] Run `make publish-sdk-packages` to deploy SDK packages to registries
 - [ ] Run `make do-release`. (if release candidate: `make do-release RELEASE_VERSION={version}-rc`) to create and push the docker images and helm chart.
 - [ ] Do a `helm repo add agones https://agones.dev/chart/stable` and verify that the new version is available via the command `helm search agones/`
 - [ ] Do a `helm install` and a smoke test to confirm everything is working.
@@ -52,3 +54,4 @@ and copy it into a release issue. Fill in relevant values, found inside {}
 [list]: https://groups.google.com/forum/#!forum/agones-discuss
 [release-template]: https://github.com/googleforgames/agones/blob/master/docs/governance/templates/release.md
 [build-makefile]: https://github.com/googleforgames/agones/blob/master/build/Makefile
+[nodejs]: https://github.com/googleforgames/agones/blob/master/sdks/nodejs/package.json

--- a/install/helm/agones/Chart.yaml
+++ b/install/helm/agones/Chart.yaml
@@ -15,8 +15,8 @@
 # Declare variables to be passed into your templates.
 
 apiVersion: v1
-appVersion: "1.3.0"
-version: 1.3.0
+appVersion: "1.3.0-rc"
+version: 1.3.0-rc
 name: agones
 description: a library for hosting, running and scaling dedicated game servers on Kubernetes.
 keywords:

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -125,7 +125,7 @@ agones:
     generateTLS: true
   image:
     registry: gcr.io/agones-images
-    tag: 1.3.0
+    tag: 1.3.0-rc
     controller:
       name: agones-controller
       pullPolicy: IfNotPresent

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 rules:
@@ -76,7 +76,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -140,7 +140,7 @@ metadata:
   namespace: default
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 ---
@@ -151,7 +151,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 rules:
@@ -169,7 +169,7 @@ metadata:
   namespace: default
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -205,7 +205,7 @@ metadata:
   labels:
     component: crd
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -429,7 +429,7 @@ metadata:
   labels:
     component: crd
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -513,7 +513,7 @@ metadata:
   labels:
     component: crd
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -703,7 +703,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
     component: crd
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
   name: gameserverallocationpolicies.multicluster.agones.dev
@@ -789,7 +789,7 @@ metadata:
   labels:
     component: crd
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1009,7 +1009,7 @@ metadata:
   labels:
     agones.dev/role: controller
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1045,7 +1045,7 @@ metadata:
   labels:
     component: allocator
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1116,7 +1116,7 @@ spec:
           secretName: allocator-client-ca
       containers:
       - name: agones-allocator
-        image: "gcr.io/agones-images/agones-allocator:1.3.0"
+        image: "gcr.io/agones-images/agones-allocator:1.3.0-rc"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1171,7 +1171,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 rules:
@@ -1203,7 +1203,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 
@@ -1216,7 +1216,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -1237,7 +1237,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones-manual
-    chart: "agones-1.3.0"
+    chart: "agones-1.3.0-rc"
     release: "agones-manual"
     heritage: "Tiller"
 data:
@@ -1254,7 +1254,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones-manual
-    chart: "agones-1.3.0"
+    chart: "agones-1.3.0-rc"
     release: "agones-manual"
     heritage: "Tiller"
 data:
@@ -1270,7 +1270,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones-manual
-    chart: "agones-1.3.0"
+    chart: "agones-1.3.0-rc"
     release: "agones-manual"
     heritage: "Tiller"
 data:
@@ -1300,7 +1300,7 @@ metadata:
   labels:
     component: controller
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1345,7 +1345,7 @@ spec:
       serviceAccountName: agones-controller
       containers:
       - name: agones-controller
-        image: "gcr.io/agones-images/agones-controller:1.3.0"
+        image: "gcr.io/agones-images/agones-controller:1.3.0-rc"
         imagePullPolicy: IfNotPresent
         env:
         # minimum port that can be exposed to GameServer traffic
@@ -1355,7 +1355,7 @@ spec:
         - name: MAX_PORT
           value: "8000"
         - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
-          value: "gcr.io/agones-images/agones-sdk:1.3.0"
+          value: "gcr.io/agones-images/agones-sdk:1.3.0-rc"
         - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
           value: "false"
         - name: SIDECAR_CPU_REQUEST
@@ -1441,7 +1441,7 @@ metadata:
   labels:
     component: ping
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1478,7 +1478,7 @@ spec:
       priorityClassName: agones-system
       containers:
         - name: agones-ping
-          image: "gcr.io/agones-images/agones-ping:1.3.0"
+          image: "gcr.io/agones-images/agones-ping:1.3.0-rc"
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -1504,7 +1504,7 @@ metadata:
   labels:
     component: ping
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1525,7 +1525,7 @@ metadata:
   labels:
     component: ping
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1560,7 +1560,7 @@ metadata:
   labels:
     component: controller
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1580,7 +1580,7 @@ metadata:
   labels:
     component: controller
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 webhooks:
@@ -1630,7 +1630,7 @@ metadata:
   labels:
     component: controller
     app: agones
-    chart: agones-1.3.0
+    chart: agones-1.3.0-rc
     release: agones-manual
     heritage: Tiller
 webhooks:
@@ -1660,7 +1660,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones-manual
-    chart: "agones-1.3.0"
+    chart: "agones-1.3.0-rc"
     release: "agones-manual"
     heritage: "Tiller"
 type: Opaque

--- a/sdks/nodejs/package.json
+++ b/sdks/nodejs/package.json
@@ -26,5 +26,5 @@
     "lint": "eslint --fix src spec",
     "test": "jasmine"
   },
-  "version": "1.2.0"
+  "version": "1.3.0-rc"
 }

--- a/site/content/en/blog/releases/1.2.0.md
+++ b/site/content/en/blog/releases/1.2.0.md
@@ -10,7 +10,7 @@ This release includes an upgrade of the supported Kubernetes version from 1.12 t
 
 Make sure to check the [Upgrading Guide](https://agones.dev/site/docs/installation/upgrading/#upgrading-kubernetes) for details on how to perform this upgrade safely.
 
-Check the <a href="https://github.com/googleforgames/agones/tree/release-1.2.0" data-proofer-ignore>README</a> for details on features, installation and usage.
+Check the <a href="https://github.com/googleforgames/agones/tree/release-1.2.0" >README</a> for details on features, installation and usage.
 
 **Breaking changes:**
 
@@ -35,7 +35,7 @@ Check the <a href="https://github.com/googleforgames/agones/tree/release-1.2.0" 
 - Refresh client CA certificate if changed [\#1145](https://github.com/googleforgames/agones/pull/1145) ([pooneh-m](https://github.com/pooneh-m))
 - Document the default ports used by the sdkserver sidecar on the website [\#1210](https://github.com/googleforgames/agones/pull/1210) ([roberthbailey](https://github.com/roberthbailey))
 
-See <a href="https://github.com/googleforgames/agones/blob/release-1.2.0/CHANGELOG.md" data-proofer-ignore>CHANGELOG</a> for more details on changes.
+See <a href="https://github.com/googleforgames/agones/blob/release-1.2.0/CHANGELOG.md" >CHANGELOG</a> for more details on changes.
 
 Images available with this release:
 
@@ -53,7 +53,7 @@ Images available with this release:
 
 Helm chart available with this release:
 
-- <a href="https://agones.dev/chart/stable/agones-1.2.0.tgz" data-proofer-ignore>
+- <a href="https://agones.dev/chart/stable/agones-1.2.0.tgz" >
   <code>helm install agones/agones --version 1.2.0</code></a>
 
 > Make sure to add our stable helm repository using `helm repo add agones https://agones.dev/chart/stable`

--- a/site/content/en/blog/releases/1.3.0-rc.md
+++ b/site/content/en/blog/releases/1.3.0-rc.md
@@ -1,0 +1,70 @@
+---
+title: "1.3.0 - Release Candidate"
+linkTitle: "1.3.0-rc"
+date: "2020-01-13"
+---
+
+
+This is the 1.3.0-rc release of Agones.
+
+This release includes the Node SDK packaged as a NPM module and hosted on github. That being said, the functionality
+of the Node SDK has not changed, and previous versions will continue to work as normal.
+
+The upgraded gRPC across Agones and SDKs is marked as a breaking change as a precaution, as we expect previous versions
+of the SDK to continue to work as per normal.
+
+We do recommend updating your SDKs to the latest version, to keep up to date and avoid any potential issues.
+
+Check the <a href="https://github.com/googleforgames/agones/tree/release-1.3.0-rc" data-proofer-ignore>README</a> for details on features, installation and usage.
+
+**Breaking changes:**
+
+- Node packaging [\#1264](https://github.com/googleforgames/agones/pull/1264) ([rorygarand](https://github.com/rorygarand))
+- Update GRPC to v1.20.1 [\#1215](https://github.com/googleforgames/agones/pull/1215) ([markmandel](https://github.com/markmandel))
+
+**Security fixes:**
+
+- Update Alpine image to 3.11 [\#1253](https://github.com/googleforgames/agones/pull/1253) ([markmandel](https://github.com/markmandel))
+
+**Implemented enhancements:**
+
+- Terraform support for EKS [\#966](https://github.com/googleforgames/agones/issues/966)
+- Added Community Meetings to the community pages [\#1271](https://github.com/googleforgames/agones/pull/1271) ([markmandel](https://github.com/markmandel))
+- Fuzz Roundtrip test for v1 Agones schemas [\#1269](https://github.com/googleforgames/agones/pull/1269) ([aLekSer](https://github.com/aLekSer))
+- Add Annotations validation for Template ObjectMeta [\#1266](https://github.com/googleforgames/agones/pull/1266) ([aLekSer](https://github.com/aLekSer))
+- Add validation for Labels on Fleet and GS Template [\#1257](https://github.com/googleforgames/agones/pull/1257) ([aLekSer](https://github.com/aLekSer))
+- Feature Gate implementation [\#1256](https://github.com/googleforgames/agones/pull/1256) ([markmandel](https://github.com/markmandel))
+- Add Embark logo to Agones site [\#1237](https://github.com/googleforgames/agones/pull/1237) ([luna-duclos](https://github.com/luna-duclos))
+- Unity SDK - Watch GameServer Functionality [\#1234](https://github.com/googleforgames/agones/pull/1234) ([markmandel](https://github.com/markmandel))
+- Better error message for Health Check Failure [\#1222](https://github.com/googleforgames/agones/pull/1222) ([markmandel](https://github.com/markmandel))
+- Configurable Log Level for Agones Controller [\#1220](https://github.com/googleforgames/agones/pull/1220) ([aLekSer](https://github.com/aLekSer))
+- Add Go Client example which could create GS [\#1213](https://github.com/googleforgames/agones/pull/1213) ([aLekSer](https://github.com/aLekSer))
+- Automate confirming example images are on gcr.io [\#1207](https://github.com/googleforgames/agones/pull/1207) ([markmandel](https://github.com/markmandel))
+- improve stackdriver metric type [\#1132](https://github.com/googleforgames/agones/pull/1132) ([cyriltovena](https://github.com/cyriltovena))
+- Feature Stages Documentation [\#1080](https://github.com/googleforgames/agones/pull/1080) ([markmandel](https://github.com/markmandel))
+- Initial version of EKS terraform config [\#986](https://github.com/googleforgames/agones/pull/986) ([aLekSer](https://github.com/aLekSer))
+
+Documentation: https://development.agones.dev/site/
+
+See <a href="https://github.com/googleforgames/agones/blob/release-1.3.0-rc/CHANGELOG.md" data-proofer-ignore>CHANGELOG</a> for more details on changes.
+
+Images available with this release:
+
+- [gcr.io/agones-images/agones-controller:1.3.0-rc](https://gcr.io/agones-images/agones-controller:1.3.0-rc)
+- [gcr.io/agones-images/agones-sdk:1.3.0-rc](https://gcr.io/agones-images/agones-sdk:1.3.0-rc)
+- [gcr.io/agones-images/agones-ping:1.3.0-rc](https://gcr.io/agones-images/agones-ping:1.3.0-rc)
+- [gcr.io/agones-images/agones-allocator:1.3.0-rc](https://gcr.io/agones-images/agones-allocator:1.3.0-rc)
+- [gcr.io/agones-images/cpp-simple-server:0.11](https://gcr.io/agones-images/cpp-simple-server:0.11)
+- [gcr.io/agones-images/nodejs-simple-server:0.2](https://gcr.io/agones-images/nodejs-simple-server:0.2)
+- [gcr.io/agones-images/rust-simple-server:0.6](https://gcr.io/agones-images/rust-simple-server:0.6)
+- [gcr.io/agones-images/unity-simple-server:0.3](https://gcr.io/agones-images/unity-simple-server:0.3)
+- [gcr.io/agones-images/udp-server:0.17](https://gcr.io/agones-images/udp-server:0.17)
+- [gcr.io/agones-images/tcp-server:0.3](https://gcr.io/agones-images/tcp-server:0.3)
+- [gcr.io/agones-images/xonotic-example:0.7](https://gcr.io/agones-images/xonotic-example:0.7)
+
+Helm chart available with this release:
+
+- <a href="https://agones.dev/chart/stable/agones-1.3.0-rc.tgz" data-proofer-ignore>
+  <code>helm install agones/agones --version 1.3.0-rc</code></a>
+
+> Make sure to add our stable helm repository using `helm repo add agones https://agones.dev/chart/stable`


### PR DESCRIPTION
This includes some update to the release checklist for the new npm publishing tools.

There is a reference to a target that has yet to be written (`publish-sdk-packages`), but will be done with the upcoming release right after this is merged, and will come in a following PR. Basically, to test it I need to run it at this stage, so it makes sense to do it together.