### PR TITLE
Site: Add video & podcasts to third party section

### DIFF
--- a/site/content/en/docs/Third Party Content/podcasts.md
+++ b/site/content/en/docs/Third Party Content/podcasts.md
@@ -1,0 +1,19 @@
+---
+title: "Third Party Podcasts"
+linkTitle: "Podcasts"
+date: 2020-01-15
+description: "Community contributed podcasts on Agones."
+weight: 20
+---
+
+## 2019
+
+- Nov 6 - [Google Cloud Platform Podcast: Supersolid with Kami May]
+    (https://gcppodcast.com/post/episode-202-supersolid-with-kami-may/)
+
+## 2018
+
+- Oct 23 - [Kubernetes Podcast: Agones, with Cyril Tovena and Mark Mandel]
+    (https://kubernetespodcast.com/episode/026-agones/)
+- Aug 15 - [Google Cloud Platform Podcast: Agones with Mark Mandel and Cyril Tovena]
+    (https://gcppodcast.com/post/episode-142-agones-with-mark-mandel-and-cyril-tovena/)

--- a/site/content/en/docs/Third Party Content/videos-and-presentations.md
+++ b/site/content/en/docs/Third Party Content/videos-and-presentations.md
@@ -3,9 +3,14 @@ title: "Third Party Videos and Presentations"
 linkTitle: "Videos and Presentations"
 date: 2019-01-03T08:37:35Z
 description: "Community contributed videos and presentations on Agones."
+weight: 10
 ---
 
 ## Presentations
+
+### Large-Scale Multiplayer Gaming on Kubernetes (Cloud Next '19)
+
+{{< youtube "Imf_urBB7SI" >}}
 
 ### Agones: Scaling Multiplayer Game Servers with Open Source (GDC 2019)
 


### PR DESCRIPTION
New podcast section under "Third Party", and added last year's Cloud Next event.