### PR TITLE
Nodejs docs: require for npm should switch on 1.3.0

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/nodejs.md
+++ b/site/content/en/docs/Guides/Client SDKs/nodejs.md
@@ -19,7 +19,7 @@ Download the source {{< ghlink href="sdks/nodejs" >}}directly from GitHub{{< /gh
 
 ## Usage
 
-{{% feature expiryVersion="1.2.0" %}}
+{{% feature expiryVersion="1.3.0" %}}
 Add the agones dependency to `package.json`, replacing with the download location:
 
 ```json
@@ -29,7 +29,7 @@ Add the agones dependency to `package.json`, replacing with the download locatio
 }
 ```
 {{% /feature %}}
-{{% feature publishVersion="1.2.0" %}}
+{{% feature publishVersion="1.3.0" %}}
 Add the agones dependency to your project:
 
 ```sh
@@ -39,7 +39,7 @@ $ npm install @googleforgames/agones
 
 To begin working with the SDK, create an instance of it.
 
-{{% feature expiryVersion="1.2.0" %}}
+{{% feature expiryVersion="1.3.0" %}}
 ```javascript
 const AgonesSDK = require('agones');
 
@@ -47,7 +47,7 @@ let agonesSDK = new AgonesSDK();
 ```
 {{% /feature %}}
 
-{{% feature publishVersion="1.2.0" %}}
+{{% feature publishVersion="1.3.0" %}}
 ```javascript
 const AgonesSDK = require('@googleforgames/agones');
 


### PR DESCRIPTION
Missed a typo, the new code block should show up in 1.3.0 not 1.2.0