### PR TITLE
Show GameServer name in TestGameServerReserve flakiness fail

### DIFF
--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -491,8 +491,8 @@ func TestGameServerReserve(t *testing.T) {
 	assert.Equal(t, "ACK: RESERVE\n", reply)
 
 	gs, err = framework.WaitForGameServerState(readyGs, agonesv1.GameServerStateReserved, time.Minute)
-	assert.NoError(t, err)
-	assert.Equal(t, agonesv1.GameServerStateReserved, gs.Status.State)
+	assert.NoError(t, err, fmt.Sprintf("GameServer Name: %s", readyGs.ObjectMeta.Name))
+	assert.Equal(t, agonesv1.GameServerStateReserved, gs.Status.State, fmt.Sprintf("GameServer Name: %s", readyGs.ObjectMeta.Name))
 
 	// it should go back after 10 seconds
 	gs, err = framework.WaitForGameServerState(readyGs, agonesv1.GameServerStateReady, 15*time.Second)


### PR DESCRIPTION
Extra debugging, so we can dig into what is going wrong in this test.

Work on #1276