### PR TITLE
Use a numeric User ID for the "agones" user in the SDK sidecar

### DIFF
--- a/cmd/allocator/Dockerfile
+++ b/cmd/allocator/Dockerfile
@@ -15,10 +15,10 @@
 FROM alpine:3.11
 
 RUN apk --update add ca-certificates && \
-    adduser -D agones
+    adduser -D -u 1000 agones
 
 COPY --chown=agones:root ./bin/allocator /home/agones/allocator
 COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
-USER agones
+USER 1000
 ENTRYPOINT ["/home/agones/allocator"]

--- a/cmd/allocator/Dockerfile
+++ b/cmd/allocator/Dockerfile
@@ -17,8 +17,8 @@ FROM alpine:3.11
 RUN apk --update add ca-certificates && \
     adduser -D -u 1000 agones
 
-COPY --chown=agones:root ./bin/allocator /home/agones/allocator
-COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY --chown=agones:agones ./bin/allocator /home/agones/allocator
+COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
 USER 1000
 ENTRYPOINT ["/home/agones/allocator"]

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -15,10 +15,10 @@
 FROM alpine:3.11
 
 RUN apk --update add ca-certificates && \
-    adduser -D agones
+    adduser -D -u 1000 agones
 
 COPY --chown=agones:root ./bin/controller /home/agones/controller
 COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
-USER agones
+USER 1000
 ENTRYPOINT ["/home/agones/controller"]

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -17,8 +17,8 @@ FROM alpine:3.11
 RUN apk --update add ca-certificates && \
     adduser -D -u 1000 agones
 
-COPY --chown=agones:root ./bin/controller /home/agones/controller
-COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY --chown=agones:agones ./bin/controller /home/agones/controller
+COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
 USER 1000
 ENTRYPOINT ["/home/agones/controller"]

--- a/cmd/ping/Dockerfile
+++ b/cmd/ping/Dockerfile
@@ -17,8 +17,8 @@ FROM alpine:3.11
 RUN apk --update add ca-certificates && \
     adduser -D -u 1000 agones
 
-COPY --chown=agones:root ./bin/ping /home/agones/ping
-COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY --chown=agones:agones ./bin/ping /home/agones/ping
+COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
 USER 1000
 ENTRYPOINT ["/home/agones/ping"]

--- a/cmd/ping/Dockerfile
+++ b/cmd/ping/Dockerfile
@@ -15,10 +15,10 @@
 FROM alpine:3.11
 
 RUN apk --update add ca-certificates && \
-    adduser -D agones
+    adduser -D -u 1000 agones
 
 COPY --chown=agones:root ./bin/ping /home/agones/ping
 COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
-USER agones
+USER 1000
 ENTRYPOINT ["/home/agones/ping"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -15,10 +15,10 @@
 FROM alpine:3.11
 
 RUN apk --update add ca-certificates && \
-    adduser -D agones
+    adduser -D -u 1000 agones
 
 COPY --chown=agones:root ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
 COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
-USER agones
+USER 1000
 ENTRYPOINT ["/home/agones/sdk-server"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -17,8 +17,8 @@ FROM alpine:3.11
 RUN apk --update add ca-certificates && \
     adduser -D -u 1000 agones
 
-COPY --chown=agones:root ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
-COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY --chown=agones:agones ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
+COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
 USER 1000
 ENTRYPOINT ["/home/agones/sdk-server"]

--- a/examples/allocator-service/Dockerfile
+++ b/examples/allocator-service/Dockerfile
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o service .
 # Create the final image that will run the allocator service
 FROM alpine:3.8
 RUN apk add --update ca-certificates
-RUN adduser -D service
+RUN adduser -D -u 1000 service
 
 COPY --from=builder /go/src/agones.dev/agones/examples/allocator-service \
                     /home/service
@@ -35,5 +35,5 @@ COPY --from=builder /go/src/agones.dev/agones/examples/allocator-service \
 RUN chown -R service /home/service && \
     chmod o+x /home/service/service
 
-USER service
+USER 1000
 ENTRYPOINT /home/service/service

--- a/examples/autoscaler-webhook/Dockerfile
+++ b/examples/autoscaler-webhook/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
 
 # Create the final image that will run the webhook server for FleetAutoscaler webhook policy
 FROM alpine:3.8
-RUN adduser -D server
+RUN adduser -D -u 1000 server
 
 COPY --from=builder /go/src/autoscaler-webhook \
                     /home/server
@@ -30,5 +30,5 @@ COPY --from=builder /go/src/autoscaler-webhook \
 RUN chown -R server /home/server && \
     chmod o+x /home/server/server
 
-USER server
+USER 1000
 ENTRYPOINT /home/server/server

--- a/examples/autoscaler-webhook/Makefile
+++ b/examples/autoscaler-webhook/Makefile
@@ -27,7 +27,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-autoscaler_webhook_tag = $(REPOSITORY)/autoscaler-webhook:0.2
+autoscaler_webhook_tag = $(REPOSITORY)/autoscaler-webhook:0.3
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/cpp-simple/Dockerfile
+++ b/examples/cpp-simple/Dockerfile
@@ -35,11 +35,11 @@ RUN cd cpp-simple && mkdir -p .build && \
     cmake --build . --target install
 
 FROM debian:stretch
-RUN useradd -m server
+RUN useradd -u 1000 -m server
 
 COPY --from=builder /project/cpp-simple/.build/.bin/cpp-simple /home/server/cpp-simple
 RUN chown -R server /home/server && \
     chmod o+x /home/server/cpp-simple
 
-USER server
+USER 1000
 ENTRYPOINT /home/server/cpp-simple

--- a/examples/cpp-simple/Makefile
+++ b/examples/cpp-simple/Makefile
@@ -28,7 +28,7 @@ REPOSITORY = gcr.io/agones-images
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/cpp-simple-server:0.11
+server_tag = $(REPOSITORY)/cpp-simple-server:0.12
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/crd-client/Dockerfile
+++ b/examples/crd-client/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o client .
 
 # Create the final image that will run the webhook server for FleetAutoscaler webhook policy
 FROM alpine:3.8
-RUN adduser -D client
+RUN adduser -D -u 1000 client
 
 COPY --from=builder /go/src/crd-client \
                     /home/client
@@ -30,5 +30,5 @@ COPY --from=builder /go/src/crd-client \
 RUN chown -R client /home/client && \
     chmod o+x /home/client/client
 
-USER client
+USER 1000
 ENTRYPOINT /home/client/client

--- a/examples/crd-client/Makefile
+++ b/examples/crd-client/Makefile
@@ -25,7 +25,7 @@
 
 REPOSITORY ?= gcr.io/agones-images
 
-server_tag = $(REPOSITORY)/crd-client:0.1
+server_tag = $(REPOSITORY)/crd-client:0.2
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___

--- a/examples/nodejs-simple/Dockerfile
+++ b/examples/nodejs-simple/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM debian:stretch
-RUN useradd -m server
+RUN useradd -u 1000 -m server
 RUN apt-get update && apt-get install -y curl  && apt-get clean
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
     apt-get install -y nodejs
@@ -25,5 +25,5 @@ COPY ./examples/nodejs-simple examples/nodejs-simple
 RUN cd examples/nodejs-simple && \
     npm install
 
-USER server
+USER 1000
 ENTRYPOINT cd /home/server/examples/nodejs-simple && npm start

--- a/examples/nodejs-simple/Makefile
+++ b/examples/nodejs-simple/Makefile
@@ -28,7 +28,7 @@ REPOSITORY = gcr.io/agones-images
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/nodejs-simple-server:0.2
+server_tag = $(REPOSITORY)/nodejs-simple-server:0.3
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/rust-simple/Dockerfile
+++ b/examples/rust-simple/Dockerfile
@@ -52,11 +52,11 @@ WORKDIR /home/builder/agones/examples/rust-simple
 RUN make build
 
 FROM debian:stretch
-RUN useradd -m server
+RUN useradd -u 1000 -m server
 
 COPY --from=builder /home/builder/agones/examples/rust-simple/target/release/rust-simple /home/server/rust-simple
 RUN chown -R server /home/server && \
     chmod o+x /home/server/rust-simple
 
-USER server
+USER 1000
 ENTRYPOINT /home/server/rust-simple

--- a/examples/rust-simple/Makefile
+++ b/examples/rust-simple/Makefile
@@ -27,7 +27,7 @@ REPOSITORY ?= gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/rust-simple-server:0.6
+server_tag = $(REPOSITORY)/rust-simple-server:0.7
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___

--- a/examples/simple-tcp/Dockerfile
+++ b/examples/simple-tcp/Dockerfile
@@ -23,10 +23,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
 # final image
 FROM alpine:3.10
 
-RUN adduser -D server
+RUN adduser -D -u 1000 server
 COPY --from=builder /go/src/simple-tcp/server /home/server/server
 RUN chown -R server /home/server && \
     chmod o+x /home/server/server
 
-USER server
+USER 1000
 ENTRYPOINT ["/home/server/server"]

--- a/examples/simple-tcp/Makefile
+++ b/examples/simple-tcp/Makefile
@@ -27,7 +27,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/tcp-server:0.3
+server_tag = $(REPOSITORY)/tcp-server:0.4
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/simple-udp/Dockerfile
+++ b/examples/simple-udp/Dockerfile
@@ -23,10 +23,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
 # final image
 FROM alpine:3.10
 
-RUN adduser -D server
+RUN adduser -D -u 1000 server
 COPY --from=builder /go/src/simple-udp/server /home/server/server
 RUN chown -R server /home/server && \
     chmod o+x /home/server/server
 
-USER server
+USER 1000
 ENTRYPOINT ["/home/server/server"]

--- a/examples/simple-udp/Makefile
+++ b/examples/simple-udp/Makefile
@@ -27,7 +27,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/udp-server:0.17
+server_tag = $(REPOSITORY)/udp-server:0.18
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/xonotic/Dockerfile
+++ b/examples/xonotic/Dockerfile
@@ -30,7 +30,7 @@ FROM debian:stretch
 
 WORKDIR /home/xonotic
 
-RUN useradd -m xonotic
+RUN useradd -u 1000 -m xonotic
 
 #
 # To learn about setting up a Xonotic dedicated server, read the `readme.txt` in the
@@ -45,5 +45,5 @@ COPY examples/xonotic/server.cfg ./.xonotic/data
 
 RUN chown -R xonotic:xonotic . && chmod +x wrapper
 
-USER xonotic
+USER 1000
 ENTRYPOINT /home/xonotic/wrapper -i /home/xonotic/Xonotic/server_linux.sh

--- a/examples/xonotic/Makefile
+++ b/examples/xonotic/Makefile
@@ -28,7 +28,7 @@ REPOSITORY = gcr.io/agones-images
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
 root_path := $(realpath $(project_path)/../..)
-image_tag = $(REPOSITORY)/xonotic-example:0.7
+image_tag = $(REPOSITORY)/xonotic-example:0.8
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___


### PR DESCRIPTION
This fixes failure of the sdk sidecar container to start when run on a system with a `PodSecurityPolicy` specifying [`RunAsUser`](https://v1-13.docs.kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups) as "MustRunAsNonRoot".

Kubernetes cannot determine if a non-numeric User in the container metadata is 'root' or not.

Fixes: #1287