### PR TITLE
Move all "Synchronising" logs to debug

### DIFF
--- a/pkg/fleetautoscalers/controller.go
+++ b/pkg/fleetautoscalers/controller.go
@@ -171,7 +171,7 @@ func (c *Controller) validationHandler(review admv1beta1.AdmissionReview) (admv1
 // syncFleetAutoscaler scales the attached fleet and
 // synchronizes the FleetAutoscaler CRD
 func (c *Controller) syncFleetAutoscaler(key string) error {
-	c.loggerForFleetAutoscalerKey(key).Info("Synchronising")
+	c.loggerForFleetAutoscalerKey(key).Debug("Synchronising")
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -254,7 +254,7 @@ func (c *Controller) gameServerSetEventHandler(obj interface{}) {
 // syncFleet synchronised the fleet CRDs and configures/updates
 // backing GameServerSets
 func (c *Controller) syncFleet(key string) error {
-	c.loggerForFleetKey(key).Info("Synchronising")
+	c.loggerForFleetKey(key).Debug("Synchronising")
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -349,7 +349,7 @@ func (c *Controller) Run(workers int, stop <-chan struct{}) error {
 // syncGameServer synchronises the Pods for the GameServers.
 // and reacts to status changes that can occur through the client SDK
 func (c *Controller) syncGameServer(key string) error {
-	c.loggerForGameServerKey(key).Info("Synchronising")
+	c.loggerForGameServerKey(key).Debug("Synchronising")
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -164,7 +164,7 @@ func (hc *HealthController) loggerForGameServer(gs *agonesv1.GameServer) *logrus
 
 // syncGameServer sets the GameSerer to Unhealthy, if its state is Ready
 func (hc *HealthController) syncGameServer(key string) error {
-	hc.loggerForGameServerKey(key).Info("Synchronising")
+	hc.loggerForGameServerKey(key).Debug("Synchronising")
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)


### PR DESCRIPTION
Just more work on #1218 to reduce logging verbosity.