### PR TITLE
Removing Interpolation-only expressions

### DIFF
--- a/install/terraform/cluster.tf
+++ b/install/terraform/cluster.tf
@@ -32,7 +32,7 @@ variable "ports" {
 # It is crucial to set valid ProjectID for "project".
 variable "cluster" {
   description = "Set of GKE cluster parameters."
-  type        = "map"
+  type        = map
 
   default = {
     "zone"             = "us-west1-c"
@@ -47,29 +47,29 @@ variable "cluster" {
 # Run `terraform taint null_resource.test-setting-variables` before second execution
 resource "null_resource" "test-setting-variables" {
   provisioner "local-exec" {
-    command = "${"${format("echo Current variables set as following - name: %s, project: %s, machineType: %s, initialNodeCount: %s, zone: %s",
-      "${var.cluster["name"]}", "${var.cluster["project"]}",
-      "${var.cluster["machineType"]}", "${var.cluster["initialNodeCount"]}",
-    "${var.cluster["zone"]}")}"}"
+    command = format("echo Current variables set as following - name: %s, project: %s, machineType: %s, initialNodeCount: %s, zone: %s",
+      var.cluster["name"], var.cluster["project"],
+      var.cluster["machineType"], var.cluster["initialNodeCount"],
+    var.cluster["zone"])
   }
 }
 
 resource "google_container_cluster" "primary" {
-  name     = "${var.cluster["name"]}"
-  location = "${var.cluster["zone"]}"
-  project  = "${var.cluster["project"]}"
-  provider = "google-beta"
+  name     = var.cluster["name"]
+  location = var.cluster["zone"]
+  project  = var.cluster["project"]
+  provider = google-beta
 
   node_pool {
     name       = "default"
-    node_count = "${var.cluster["initialNodeCount"]}"
+    node_count = var.cluster["initialNodeCount"]
 
     management {
       auto_upgrade = false
     }
 
     node_config {
-      machine_type = "${var.cluster["machineType"]}"
+      machine_type = var.cluster["machineType"]
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/devstorage.read_only",
@@ -156,22 +156,22 @@ resource "google_container_cluster" "primary" {
 
 resource "google_compute_firewall" "default" {
   name    = "game-server-firewall-firewall-${var.cluster["name"]}"
-  project = "${var.cluster["project"]}"
-  network = "${google_compute_network.default.name}"
+  project = var.cluster["project"]
+  network = google_compute_network.default.name
 
   allow {
     protocol = "udp"
-    ports    = ["${var.ports}"]
+    ports    = [var.ports]
   }
 
   source_tags = ["game-server"]
 }
 
 resource "google_compute_network" "default" {
-  project = "${var.cluster["project"]}"
+  project = var.cluster["project"]
   name    = "agones-network-${var.cluster["name"]}"
 }
 
 output "cluster_ca_certificate" {
-  value = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
+  value = google_container_cluster.primary.master_auth.0.cluster_ca_certificate
 }

--- a/install/terraform/helm.tf
+++ b/install/terraform/helm.tf
@@ -18,13 +18,13 @@ resource "kubernetes_service_account" "tiller" {
     namespace = "kube-system"
   }
 
-  depends_on = ["google_container_cluster.primary"]
+  depends_on = [google_container_cluster.primary]
 
   automount_service_account_token = true
 }
 
 resource "kubernetes_cluster_role_binding" "tiller" {
-  depends_on = ["kubernetes_service_account.tiller"]
+  depends_on = [kubernetes_service_account.tiller]
 
   metadata {
     name = "tiller"
@@ -91,8 +91,8 @@ provider "kubernetes" {
   version                = "~> 1.5"
   load_config_file       = false
   host                   = "https://${google_container_cluster.primary.endpoint}"
-  token                  = "${data.google_client_config.default.access_token}"
-  cluster_ca_certificate = "${base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
 }
 
 provider "helm" {
@@ -100,21 +100,21 @@ provider "helm" {
 
   debug           = true
   install_tiller  = true
-  service_account = "${kubernetes_service_account.tiller.metadata.0.name}"
+  service_account = kubernetes_service_account.tiller.metadata.0.name
   tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.14.2"
 
   kubernetes {
     load_config_file       = false
     host                   = "https://${google_container_cluster.primary.endpoint}"
-    token                  = "${data.google_client_config.default.access_token}"
-    cluster_ca_certificate = "${base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
   }
 }
 
 data "google_client_config" "current" {}
 
 data "helm_repository" "agones" {
-  depends_on = ["kubernetes_cluster_role_binding.tiller"]
+  depends_on = [kubernetes_cluster_role_binding.tiller]
   name       = "agones"
   url        = "https://agones.dev/chart/stable"
 }
@@ -126,63 +126,63 @@ locals {
 }
 
 resource "helm_release" "agones" {
-  depends_on   = ["null_resource.helm_init", "kubernetes_cluster_role_binding.tiller"]
+  depends_on   = [null_resource.helm_init, kubernetes_cluster_role_binding.tiller]
   name         = "agones"
   force_update = "true"
-  repository   = "${data.helm_repository.agones.metadata.0.name}"
-  chart        = "${var.chart}"
+  repository   = data.helm_repository.agones.metadata.0.name
+  chart        = var.chart
   timeout      = 420
 
   values = [
-    "${length(var.values_file) == 0 ? "" : file("${var.values_file}")}",
+    length(var.values_file) == 0 ? "" : file(var.values_file),
   ]
 
   set {
     name  = "crds.CleanupOnDelete"
-    value = "${var.crd_cleanup}"
+    value = var.crd_cleanup
   }
 
   set {
-    name  = "${local.tag_name}"
-    value = "${var.agones_version}"
+    name  = local.tag_name
+    value = var.agones_version
   }
 
   set {
     name  = "agones.image.registry"
-    value = "${var.image_registry}"
+    value = var.image_registry
   }
 
   set {
     name  = "agones.image.controller.pullPolicy"
-    value = "${var.pull_policy}"
+    value = var.pull_policy
   }
 
   set {
     name  = "agones.image.sdk.alwaysPull"
-    value = "${var.always_pull_sidecar}"
+    value = var.always_pull_sidecar
   }
 
   set {
     name  = "agones.image.controller.pullSecret"
-    value = "${var.image_pull_secret}"
+    value = var.image_pull_secret
   }
 
   set {
     name  = " agones.ping.http.serviceType"
-    value = "${var.ping_service_type}"
+    value = var.ping_service_type
   }
 
   set {
     name  = "agones.ping.udp.serviceType"
-    value = "${var.ping_service_type}"
+    value = var.ping_service_type
   }
 
   set {
     name  = " agones.allocator.http.serviceType"
-    value = "${var.allocator_service_type}"
+    value = var.allocator_service_type
   }
 
-  version   = "${var.agones_version}"
+  version   = var.agones_version
   namespace = "agones-system"
 
 }

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+terraform {
+  required_version = ">= 0.12.6"
+}
+
 provider "google-beta" {
   version = "~> 2.10"
   zone    = "${var.cluster["zone"]}"
@@ -27,26 +32,26 @@ data "google_client_config" "default" {}
 # Run `terraform taint null_resource.test-setting-variables` before second execution
 resource "null_resource" "test-setting-variables" {
   provisioner "local-exec" {
-    command = "${"${format("echo Current variables set as following - name: %s, project: %s, machineType: %s, initialNodeCount: %s, zone: %s",
-      "${var.cluster["name"]}", "${var.cluster["project"]}",
-      "${var.cluster["machineType"]}", "${var.cluster["initialNodeCount"]}",
-    "${var.cluster["zone"]}")}"}"
+    command = "${format("echo Current variables set as following - name: %s, project: %s, machineType: %s, initialNodeCount: %s, zone: %s",
+      var.cluster["name"], var.cluster["project"],
+      var.cluster["machineType"], var.cluster["initialNodeCount"],
+    var.cluster["zone"])"
   }
 }
 resource "google_container_cluster" "primary" {
-  name     = "${var.cluster["name"]}"
-  location = "${var.cluster["zone"]}"
-  project  = "${var.cluster["project"]}"
-  provider = "google-beta"
+  name     = var.cluster["name"]
+  location = var.cluster["zone"]
+  project  = var.cluster["project"]
+  provider = google-beta
 
   min_master_version = "1.13"
 
   node_pool {
     name       = "default"
-    node_count = "${var.cluster["initialNodeCount"]}"
+    node_count = var.cluster["initialNodeCount"]
 
     node_config {
-      machine_type = "${var.cluster["machineType"]}"
+      machine_type = var.cluster["machineType"]
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/devstorage.read_only",
@@ -122,18 +127,18 @@ resource "google_container_cluster" "primary" {
 
 resource "google_compute_firewall" "default" {
   name    = "game-server-firewall-firewall-${var.cluster["name"]}"
-  project = "${var.cluster["project"]}"
-  network = "${google_compute_network.default.name}"
+  project = var.cluster["project"]
+  network = google_compute_network.default.name
 
   allow {
     protocol = "udp"
-    ports    = ["${var.ports}"]
+    ports    = [var.ports]
   }
 
   source_tags = ["game-server"]
 }
 
 resource "google_compute_network" "default" {
-  project = "${var.cluster["project"]}"
+  project = var.cluster["project"]
   name    = "agones-network-${var.cluster["name"]}"
 }

--- a/install/terraform/modules/gke/outputs.tf
+++ b/install/terraform/modules/gke/outputs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 output "cluster_ca_certificate" {
-  value = "${base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)}"
+  value = base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
 }
 
 output "host" {
@@ -21,5 +21,5 @@ output "host" {
 }
 
 output "token" {
-  value = "${data.google_client_config.default.access_token}"
+  value = data.google_client_config.default.access_token
 }


### PR DESCRIPTION
Terraform 0.12.14 will start adding deprecation warnings for any strings that
only contain an interpolation as they can be replaced with straight references.

More at https://discuss.hashicorp.com/t/terraform-0-12-14-released/

This syntax has been available since Terraform 0.12 launched and it looks like 0.12 is the preferred version. Just in case I added a version constraint for 