### PR TITLE
Fix #1318 for the release-1.3.0 branch.

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Public/Agones.h
+++ b/sdks/unreal/Agones/Source/Agones/Public/Agones.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 #include "Engine/World.h"
 
 class FAgonesModule : public IModuleInterface


### PR DESCRIPTION
This is a fix for #1318 targeted at the release-1.3.0 branch in case a release-1.3.1 is made. This is useful for anyone on UE 4.24 since at the moment the release version of Agones UE4 plugin is not buildable with a default UE4 4.24 C++ project.