### PR TITLE
Remove the provider blocks from the gke submodules

### DIFF
--- a/examples/terraform-submodules/gke-local/main.tf
+++ b/examples/terraform-submodules/gke-local/main.tf
@@ -16,6 +16,14 @@
 // Run:
 //  terraform apply [-var agones_version="1.1.0"]
 
+provider "google" {
+  version = "~> 2.10"
+}
+
+provider "google-beta" {
+  version = "~> 2.10"
+}
+
 // Install latest version of agones
 variable "agones_version" {
   default = ""
@@ -30,7 +38,7 @@ module "gke_cluster" {
   source = "../../../install/terraform/modules/gke"
 
   cluster = {
-    "project"          = "${var.project}"
+    "project"          = var.project
     "zone"             = "us-west1-c"
     "name"             = "test-cluster3"
     "machineType"      = "n1-standard-4"
@@ -42,20 +50,20 @@ module "helm_agones" {
 
   source = "../../../install/terraform/modules/helm"
 
-  agones_version         = "${var.agones_version}"
+  agones_version         = var.agones_version
   values_file            = ""
   chart                  = "agones"
-  host                   = "${module.gke_cluster.host}"
-  token                  = "${module.gke_cluster.token}"
-  cluster_ca_certificate = "${module.gke_cluster.cluster_ca_certificate}"
+  host                   = module.gke_cluster.host
+  token                  = module.gke_cluster.token
+  cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
 }
 
 output "host" {
-  value = "${module.gke_cluster.host}"
+  value = module.gke_cluster.host
 }
 output "token" {
-  value = "${module.gke_cluster.token}"
+  value = module.gke_cluster.token
 }
 output "cluster_ca_certificate" {
-  value = "${module.gke_cluster.cluster_ca_certificate}"
+  value = module.gke_cluster.cluster_ca_certificate
 }

--- a/examples/terraform-submodules/gke/module.tf
+++ b/examples/terraform-submodules/gke/module.tf
@@ -16,6 +16,14 @@
 // Run:
 //  terraform apply -var project="<YOUR_GCP_ProjectID>" [-var agones_version="1.1.0"]
 
+provider "google" {
+  version = "~> 2.10"
+}
+
+provider "google-beta" {
+  version = "~> 2.10"
+}
+
 variable "project" {
   default = ""
 }
@@ -26,7 +34,7 @@ variable "name" {
 
 // Install latest version of agones
 variable "agones_version" {
-  default=""
+  default = ""
 }
 
 variable "machine_type" {
@@ -41,15 +49,15 @@ variable "node_count" {
 
 module "agones" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/?ref=master"
-  
+
   cluster = {
-      "zone"             = "us-west1-c"
-      "name"             = "${var.name}"
-      "machineType"      = "${var.machine_type}"
-      "initialNodeCount" = "${var.node_count}"
-      "project"          = "${var.project}"
+    "zone"             = "us-west1-c"
+    "name"             = var.name
+    "machineType"      = var.machine_type
+    "initialNodeCount" = var.node_count
+    "project"          = var.project
   }
-  agones_version = "${var.agones_version}"
-  values_file=""
-  chart="agones"
+  agones_version = var.agones_version
+  values_file    = ""
+  chart          = "agones"
 }

--- a/install/terraform/cluster.tf
+++ b/install/terraform/cluster.tf
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "google-beta" {
-  version = "~> 2.10"
-  zone    = "${var.cluster["zone"]}"
-}
-
-provider "google" {
-  version = "~> 2.10"
-}
-
 
 # Ports can be overriden using tfvars file
 variable "ports" {

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -17,15 +17,6 @@ terraform {
   required_version = ">= 0.12.6"
 }
 
-provider "google-beta" {
-  version = "~> 2.10"
-  zone    = "${var.cluster["zone"]}"
-}
-
-provider "google" {
-  version = "~> 2.10"
-}
-
 data "google_client_config" "default" {}
 
 # echo command used for debugging purpose


### PR DESCRIPTION
Defining the provider blocks in the sub modules will not allow users to
define their provider at a global level and be implicitly inherited into the
submodules.
This also allows for provider aliasing in the module.

Updated the example docs for GKE to use best practices

refs:
https://www.terraform.io/docs/configuration/modules.html#providers-within-modules
https://www.terraform.io/docs/configuration/providers.html#selecting-alternate-providers