### PR TITLE
Flakiness: TestGameServerAllocationDeletionOnUnAllocate

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -239,11 +239,16 @@ test-go:
 # Runs end-to-end tests on the current configured cluster
 # For minikube user the minikube-test-e2e targets
 test-e2e: $(ensure-build-image)
-	echo "Starting e2e test runner!"
-	$(GO_TEST) $(agones_package)/test/e2e $(ARGS) $(GO_E2E_TEST_ARGS) \
+	echo "Starting e2e integration test!"
+	$(GO_TEST) $(ARGS) $(agones_package)/test/e2e $(GO_E2E_TEST_ARGS) \
 		--gameserver-image=$(GS_TEST_IMAGE) \
 		--pullsecret=$(IMAGE_PULL_SECRET)
-	echo "Finishing e2e test runner!"
+	echo "Finishing e2e integration test!"
+	echo "starting e2e controller failure test"
+	$(GO_TEST) -parallel=1 $(agones_package)/test/e2e/controller $(GO_E2E_TEST_ARGS) \
+    		--gameserver-image=$(GS_TEST_IMAGE) \
+    		--pullsecret=$(IMAGE_PULL_SECRET)
+	echo "Finishing e2e controller failure test!"
 
 # Runs end-to-end stress tests on the current configured cluster
 # For minikube user the minikube-stress-test-e2e targets

--- a/test/e2e/controller/doc.go
+++ b/test/e2e/controller/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package controller is for testing controller failures.
+// *** Under no circumstance should these tests be made t.Parallel()! ***
+package controller

--- a/test/e2e/controller/main_test.go
+++ b/test/e2e/controller/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC All Rights Reserved.
+// Copyright 2020 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package controller
 
 import (
 	"log"
@@ -58,5 +58,4 @@ func TestMain(m *testing.M) {
 		os.Exit(exitCode)
 	}()
 	exitCode = m.Run()
-
 }

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -462,7 +462,7 @@ func TestUpdateGameServerConfigurationInFleet(t *testing.T) {
 
 	client := framework.AgonesClient.AgonesV1()
 
-	gsSpec := defaultGameServer(defaultNs).Spec
+	gsSpec := framework.DefaultGameServer(defaultNs).Spec
 	oldPort := int32(7111)
 	gsSpec.Ports = []agonesv1.GameServerPort{{
 		ContainerPort: oldPort,
@@ -1234,7 +1234,7 @@ func scaleFleetSubresource(t *testing.T, f *agonesv1.Fleet, scale int32) *agones
 
 // defaultFleet returns a default fleet configuration
 func defaultFleet(namespace string) *agonesv1.Fleet {
-	gs := defaultGameServer(namespace)
+	gs := framework.DefaultGameServer(namespace)
 	return fleetWithGameServerSpec(&gs.Spec, namespace)
 }
 

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -37,7 +37,7 @@ const (
 
 func TestCreateConnect(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 
 	if err != nil {
@@ -61,7 +61,7 @@ func TestCreateConnect(t *testing.T) {
 // nolint:dupl
 func TestSDKSetLabel(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -91,7 +91,7 @@ func TestSDKSetLabel(t *testing.T) {
 
 func TestHealthCheckDisable(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	gs.Spec.Health = agonesv1.Health{
 		Disabled:            true,
 		FailureThreshold:    1,
@@ -123,7 +123,7 @@ func TestHealthCheckDisable(t *testing.T) {
 // nolint:dupl
 func TestSDKSetAnnotation(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	annotation := "agones.dev/sdk-timestamp"
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 
 func TestUnhealthyGameServerAfterHealthCheckFail(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	gs.Spec.Health.FailureThreshold = 1
 
 	gs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
@@ -184,7 +184,7 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 	// gate
 	assert.True(t, len(nodes.Items) > 0)
 
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	gs.Spec.Ports[0].HostPort = 7515
 	gs.Spec.Ports[0].PortPolicy = agonesv1.Static
 
@@ -204,7 +204,7 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 
 func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -233,7 +233,7 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	t.Parallel()
 	logger := logrus.WithField("test", t.Name())
 
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	// give some buffer with gameservers crashing and coming back
 	gs.Spec.Health.PeriodSeconds = 60 * 60
 	gs.Spec.Template.Spec.Containers[0].Env = append(gs.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "READY", Value: "FALSE"})
@@ -339,7 +339,7 @@ func TestGameServerUnhealthyAfterReadyCrash(t *testing.T) {
 
 	l := logrus.WithField("test", "TestGameServerUnhealthyAfterReadyCrash")
 
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -425,7 +425,7 @@ func TestDevelopmentGameServerLifecycle(t *testing.T) {
 
 func TestGameServerSelfAllocate(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -447,7 +447,7 @@ func TestGameServerSelfAllocate(t *testing.T) {
 
 func TestGameServerReadyAllocateReady(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -476,7 +476,7 @@ func TestGameServerReadyAllocateReady(t *testing.T) {
 
 func TestGameServerReserve(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -502,7 +502,7 @@ func TestGameServerReserve(t *testing.T) {
 
 func TestGameServerShutdown(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -533,7 +533,7 @@ func TestGameServerShutdown(t *testing.T) {
 // Ephemeral Storage limit set to 0Mi
 func TestGameServerEvicted(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	gs.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse("0Mi")
 	newGs, err := framework.AgonesClient.AgonesV1().GameServers(defaultNs).Create(gs)
 
@@ -549,7 +549,7 @@ func TestGameServerEvicted(t *testing.T) {
 
 func TestGameServerPassthroughPort(t *testing.T) {
 	t.Parallel()
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	gs.Spec.Ports[0] = agonesv1.GameServerPort{PortPolicy: agonesv1.Passthrough}
 	gs.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "PASSTHROUGH", Value: "TRUE"}}
 	// gate
@@ -572,44 +572,4 @@ func TestGameServerPassthroughPort(t *testing.T) {
 	}
 
 	assert.Equal(t, "ACK: Hello World !\n", reply)
-}
-
-func defaultGameServer(namespace string) *agonesv1.GameServer {
-	gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{GenerateName: "udp-server", Namespace: namespace},
-		Spec: agonesv1.GameServerSpec{
-			Container: "udp-server",
-			Ports: []agonesv1.GameServerPort{{
-				ContainerPort: 7654,
-				Name:          "gameport",
-				PortPolicy:    agonesv1.Dynamic,
-				Protocol:      corev1.ProtocolUDP,
-			}},
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:            "udp-server",
-						Image:           framework.GameServerImage,
-						ImagePullPolicy: corev1.PullIfNotPresent,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("30m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("30m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-						},
-					}},
-				},
-			},
-		},
-	}
-
-	if framework.PullSecret != "" {
-		gs.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{
-			Name: framework.PullSecret}}
-	}
-
-	return gs
 }

--- a/test/e2e/gameserverallocation_test.go
+++ b/test/e2e/gameserverallocation_test.go
@@ -245,7 +245,7 @@ func TestCreateFullFleetAndCantGameServerAllocate(t *testing.T) {
 func TestGameServerAllocationMetaDataPatch(t *testing.T) {
 	t.Parallel()
 
-	gs := defaultGameServer(defaultNs)
+	gs := framework.DefaultGameServer(defaultNs)
 	gs.ObjectMeta.Labels = map[string]string{"test": t.Name()}
 
 	gs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)


### PR DESCRIPTION
Realised that Go test will compile and run tests in parallel per file,
which means we could shutdown the controller while an allocation is in
process - which means, it will fail completely, as the Kubernetes API
cannot reach the controller's http endpoint for allocation.

Split the controller tests into a separate package which could be run
with -parallel=1 so that there can be no race condition.

Also did some grouping of e2e test functionality to reduce code
repetition.

Closes #1326