### PR TITLE
Stackdriver - fix getMonitoredResource

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -95,10 +95,6 @@ func SetReportingPeriod(forPrometheus, forStackdriver bool) {
 }
 
 func getMonitoredResource(projectID string) (*monitoredres.MonitoredResource, error) {
-	instanceID, err := metadata.InstanceID()
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting instance ID")
-	}
 	zone, err := metadata.Zone()
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting zone")
@@ -112,13 +108,12 @@ func getMonitoredResource(projectID string) (*monitoredres.MonitoredResource, er
 		Type: "k8s_container",
 		Labels: map[string]string{
 			"project_id":   projectID,
-			"instance_id":  instanceID,
-			"zone":         zone,
+			"location":     zone,
 			"cluster_name": clusterName,
 
 			// See: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-			"namespace_id":   os.Getenv("POD_NAMESPACE"),
-			"pod_id":         os.Getenv("POD_NAME"),
+			"namespace_name": os.Getenv("POD_NAMESPACE"),
+			"pod_name":       os.Getenv("POD_NAME"),
 			"container_name": os.Getenv("CONTAINER_NAME"),
 		},
 	}, nil

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -205,14 +205,14 @@ Note that Stackdriver monitoring is enabled by default on GKE clusters, however 
 
 Default metrics exporter is Prometheus. If you are using the [Helm installation]({{< ref "/docs/Installation/Install Agones/helm.md" >}}), you can install or upgrade Agones to use Stackdriver, using the following chart parameters:
 ```
-helm upgrade --install --wait --set agones.metrics.stackdriverEnabled=true --set agones.metrics.prometheusEnabled=false --set agones.metrics.prometheusServiceDiscovery=false my-release-name agones/agones
+helm upgrade --install --wait --set agones.metrics.stackdriverEnabled=true --set agones.metrics.prometheusEnabled=false --set agones.metrics.prometheusServiceDiscovery=false my-release-name agones/agones --namespace=agones-system
 ```
 
 With this configuration only Stackdriver exporter would be used instead of Prometheus exporter.
 
 Create a Fleet or a Gameserver in order to check that connection with stackdriver API is configured properly and so that you will be able to see the metrics data.
 
-Visit [Stackdriver monitoring](https://app.google.stackdriver.com) website, select your project, or choose `Create a new Workspace` and select GCP project where your cluster resides. In [Stackdriver metrics explorer](https://cloud.google.com/monitoring/charts/metrics-explorer) you should be able to find new metrics with prefix `agones/` (resource type is `Global`) after a couple of minutes. Choose the metrics you are interested in and add to a single or separate graphs. You can create multiple graphs, save them into your dashboard and use various aggregation parameters and reducers for each graph.
+Visit [Stackdriver monitoring](https://app.google.stackdriver.com) website, select your project, or choose `Create a new Workspace` and select GCP project where your cluster resides. In [Stackdriver metrics explorer](https://cloud.google.com/monitoring/charts/metrics-explorer) you should be able to find new metrics with prefix `agones/` after a couple of minutes. Choose the metrics you are interested in and add to a single or separate graphs. Select `Kubernetes Container` resource type for each of them. You can create multiple graphs, save them into your dashboard and use various aggregation parameters and reducers for each graph.
 
 Example of the dashboard appearance is provided below:
 


### PR DESCRIPTION
Labels were changed for k8s_container monitored resource. Fix error message, update docs.
Tested on Stackdriver dashboard. Old dashboard's charts are not available and should be readded with `Kubernetes Container` resource instead of `Global`

Part of #1330.