### PR TITLE
Unity SDK - Initialize in Awake()

### DIFF
--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -59,10 +59,14 @@ namespace Agones
 
         #region Unity Methods
         // Use this for initialization.
-        private void Start()
+        private void Awake()
         {
             String port = Environment.GetEnvironmentVariable("AGONES_SDK_HTTP_PORT");
             sidecarAddress = "http://localhost:" + (port ?? "9358");
+        }
+
+        private void Start()
+        {
             HealthCheckAsync();
         }
 


### PR DESCRIPTION
We ran into an issue where `AgonesSdk` was used before it was initialized due to the fact that we keep the game object deactivated (checkbox unticked in editor) only to activate it when running as the game server. Activating the game object (thus activating the AgonesSdk MonoBehaviour) calls `Awake()` but `Start()` isn't called until "before the next `Update()`" which might be up to a frame later.

We ended up calling `WatchGameServer(...)` before `sidecarAddress` has been set (in `Start()`) so the watch request was sent to "http://localhost/watch/gameserver" instead (since the request was created with only the path component).

This PR moves the `sidecarAddress` init to `Awake()` so that when the MB has been "awoken" it is ready to be used. I left the health check kick-off in `Start()` as it felt more "internal start logic" than "init state", if that makes sense.

Feedback appreciated. 🙂 