### PR TITLE
Unreal SDK add Allocate + Reserve and changes to the plugin settings

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Agones.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Agones.cpp
@@ -86,7 +86,6 @@ void FAgonesModule::OnWorldInitialized(UWorld* World, const UWorld::Initializati
 	if (World != nullptr && World->GetNetMode() == ENetMode::NM_DedicatedServer)
 	{
 		HookPtr = MakeShareable(new FAgonesHook());
-		HookPtr->Ready();
 	}
 }
 

--- a/sdks/unreal/Agones/Source/Agones/AgonesHook.cpp
+++ b/sdks/unreal/Agones/Source/Agones/AgonesHook.cpp
@@ -123,28 +123,26 @@ void FAgonesHook::SetLabel(const FString& Key, const FString& Value)
 {
 	FKeyValuePair Label = { Key, Value };
 	FString Json;
-	if (FJsonObjectConverter::UStructToJsonObjectString(Label, Json))
+	if (!FJsonObjectConverter::UStructToJsonObjectString(Label, Json))
 	{
-		SendRequest(SidecarAddress + SetLabelSuffix, Json, FHttpVerb::PUT, true);
+		UE_LOG(LogAgonesHook, Error, TEXT("Failed to set label, error serializing key-value pair (%s: %s)"), *Key, *Value);
+		return;
 	}
-	else
-	{
-		UE_LOG(LogAgonesHook, Error, TEXT("Failed to send request, error serializing key-value pair (%s: %s)"), *Key, *Value);
-	}
+
+	SendRequest(SidecarAddress + SetLabelSuffix, Json, FHttpVerb::PUT, true);
 }
 
 void FAgonesHook::SetAnnotation(const FString& Key, const FString& Value)
 {
 	FKeyValuePair Annotation = { Key, Value };
 	FString Json;
-	if (FJsonObjectConverter::UStructToJsonObjectString(Annotation, Json))
+	if (!FJsonObjectConverter::UStructToJsonObjectString(Annotation, Json))
 	{
-		SendRequest(SidecarAddress + SetAnnotationSuffix, Json, FHttpVerb::PUT, true);
+		UE_LOG(LogAgonesHook, Error, TEXT("Failed to set annotation, error serializing key-value pair (%s: %s)"), *Key, *Value);
+		return;
 	}
-	else
-	{
-		UE_LOG(LogAgonesHook, Error, TEXT("Failed to send request, error serializing key-value pair (%s: %s)"), *Key, *Value);
-	}
+
+	SendRequest(SidecarAddress + SetAnnotationSuffix, Json, FHttpVerb::PUT, true);
 }
 
 void FAgonesHook::GetGameServer(const FGameServerRequestCompleteDelegate& Delegate)
@@ -184,14 +182,13 @@ void FAgonesHook::Reserve(const int64 Seconds)
 {
 	FDuration Duration = { Seconds };
 	FString Json;
-	if (FJsonObjectConverter::UStructToJsonObjectString(Duration, Json))
-	{
-		SendRequest(SidecarAddress + ReserveSuffix, Json, FHttpVerb::POST, true);
-	}
-	else
+	if (!FJsonObjectConverter::UStructToJsonObjectString(Duration, Json))
 	{
 		UE_LOG(LogAgonesHook, Error, TEXT("Failed to send reserve request, error serializing duration (%d)"), Seconds);
+		return;
 	}
+
+	SendRequest(SidecarAddress + ReserveSuffix, Json, FHttpVerb::POST, true);
 }
 
 TSharedRef<IHttpRequest> FAgonesHook::MakeRequest(const FString& URL, const FString& JsonContent, const FHttpVerb Verb, const bool bRetryOnFailure)

--- a/sdks/unreal/Agones/Source/Agones/AgonesHook.cpp
+++ b/sdks/unreal/Agones/Source/Agones/AgonesHook.cpp
@@ -19,6 +19,7 @@
 #include "JsonObjectConverter.h"
 #include "Serialization/JsonReader.h"
 #include "GenericPlatform/GenericPlatformMisc.h"
+#include "Model/Duration.h"
 #include "Model/KeyValuePair.h"
 #include "Runtime/Online/HTTP/Public/Http.h"
 #include "Serialization/JsonSerializer.h"
@@ -43,6 +44,8 @@ FAgonesHook::FAgonesHook()
 	, SetLabelSuffix(FString(TEXT("/metadata/label")))
 	, SetAnnotationSuffix(FString(TEXT("/metadata/annotation")))
 	, GetGameServerSuffix(FString(TEXT("/gameserver")))
+	, AllocateSuffix(FString(TEXT("/allocate")))
+	, ReserveSuffix(FString(TEXT("/reserve")))
 {
 	Settings = GetDefault<UAgonesSettings>();
 	check(Settings != nullptr);
@@ -52,12 +55,17 @@ FAgonesHook::FAgonesHook()
 		FHttpRetrySystem::FRetryLimitCountSetting(RetryLimitCount),
 		FHttpRetrySystem::FRetryTimeoutRelativeSecondsSetting());
 
-	UE_LOG(LogAgonesHook, Log, TEXT("Initialized Agones Hook, Sidecar address: %s, Health Enabled: %s, Health Ping: %f, Debug: %s, Request Retry Limit: %d")
+	UE_LOG(LogAgonesHook, Log, TEXT("Initialized Agones Hook, Sidecar address: %s, Health Enabled: %s, Health Ping: %f, Request Retry Limit: %d, Send Ready at Startup: %s")
 		, *SidecarAddress
 		, (Settings->bHealthPingEnabled ? TEXT("True") : TEXT("False"))
 		, Settings->HealthPingSeconds
-		, (Settings->bDebugLogEnabled ? TEXT("True") : TEXT("False"))
-		, Settings->RequestRetryLimit);
+		, Settings->RequestRetryLimit
+		, (Settings->bSendReadyAtStartup ? TEXT("True") : TEXT("False")));
+
+	if (Settings->bSendReadyAtStartup)
+	{
+		Ready();
+	}
 }
 
 FAgonesHook::~FAgonesHook()
@@ -167,6 +175,25 @@ void FAgonesHook::GetGameServer(const FGameServerRequestCompleteDelegate& Delega
 	});
 }
 
+void FAgonesHook::Allocate()
+{
+	SendRequest(SidecarAddress + AllocateSuffix, TEXT("{}"), FHttpVerb::POST, true);
+}
+
+void FAgonesHook::Reserve(const int64 Seconds)
+{
+	FDuration Duration = { Seconds };
+	FString Json;
+	if (FJsonObjectConverter::UStructToJsonObjectString(Duration, Json))
+	{
+		SendRequest(SidecarAddress + ReserveSuffix, Json, FHttpVerb::POST, true);
+	}
+	else
+	{
+		UE_LOG(LogAgonesHook, Error, TEXT("Failed to send reserve request, error serializing duration (%d)"), Seconds);
+	}
+}
+
 TSharedRef<IHttpRequest> FAgonesHook::MakeRequest(const FString& URL, const FString& JsonContent, const FHttpVerb Verb, const bool bRetryOnFailure)
 {
 	TSharedRef<IHttpRequest> Req = bRetryOnFailure
@@ -184,16 +211,13 @@ TSharedRef<IHttpRequest> FAgonesHook::SendRequest(const FString& URL, const FStr
 {
 	TSharedRef<IHttpRequest> Req = MakeRequest(URL, JsonContent, Verb, bRetryOnFailure);
 	bool bSuccess = Req->ProcessRequest();
-	if (Settings->bDebugLogEnabled)
+	if (bSuccess)
 	{
-		if (bSuccess)
-		{
-			UE_LOG(LogAgonesHook, Log, TEXT("Send: %s"), *URL);
-		}
-		else
-		{
-			UE_LOG(LogAgonesHook, Error, TEXT("Failed sending: %s"), *URL);
-		}
+		UE_LOG(LogAgonesHook, Verbose, TEXT("Send: %s"), *URL);
+	}
+	else
+	{
+		UE_LOG(LogAgonesHook, Error, TEXT("Failed sending: %s"), *URL);
 	}
 
 	return Req;

--- a/sdks/unreal/Agones/Source/Agones/AgonesHook.h
+++ b/sdks/unreal/Agones/Source/Agones/AgonesHook.h
@@ -94,6 +94,10 @@ public:
 	void SetAnnotation(const FString& Key, const FString& Value);
 	/** Retrieve the GameServer details from the sidecar */
 	void GetGameServer(const FGameServerRequestCompleteDelegate& Delegate);
+	/** Sends a request to allocate the GameServer **/
+	void Allocate();
+	/** Sends a request to mark the GameServer as reserved for the specified duration */
+	void Reserve(const int64 Seconds);
 
 private:
 
@@ -117,4 +121,6 @@ private:
 	const FString SetLabelSuffix;
 	const FString SetAnnotationSuffix;
 	const FString GetGameServerSuffix;
+	const FString AllocateSuffix;
+	const FString ReserveSuffix;
 };

--- a/sdks/unreal/Agones/Source/Agones/Model/Duration.h
+++ b/sdks/unreal/Agones/Source/Agones/Model/Duration.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC All Rights Reserved.
+// Copyright 2020 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "AgonesSettings.h"
+#pragma once
 
-UAgonesSettings::UAgonesSettings()
-	: Super()
-	, bHealthPingEnabled(true)
-	, HealthPingSeconds(5.0f)
-	, RequestRetryLimit(30)
-	, bSendReadyAtStartup(true)
+#include "CoreMinimal.h"
+#include "Duration.generated.h"
+
+USTRUCT()
+struct FDuration
 {
-}
+	GENERATED_BODY()
 
- 
+	UPROPERTY()
+	int64 Seconds;
+};

--- a/sdks/unreal/Agones/Source/Agones/Public/AgonesSettings.h
+++ b/sdks/unreal/Agones/Source/Agones/Public/AgonesSettings.h
@@ -38,9 +38,9 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Agones", meta = (DisplayName = "Health Ping Seconds"))
 	float HealthPingSeconds;
 
-	UPROPERTY(EditAnywhere, config, Category = "Agones", meta = (DisplayName = "Debug Logging Enabled"))
-	bool bDebugLogEnabled;
-
 	UPROPERTY(EditAnywhere, config, Category = "Agones", meta = (DisplayName = "Request Retry Limit"))
 	uint32 RequestRetryLimit;
+
+	UPROPERTY(EditAnywhere, config, Category = "Agones", meta = (DisplayName = "Send Ready at Startup"))
+	bool bSendReadyAtStartup;
 };

--- a/site/content/en/docs/Guides/Client SDKs/unreal.md
+++ b/site/content/en/docs/Guides/Client SDKs/unreal.md
@@ -39,6 +39,6 @@ Available settings:
 
 - Health Ping Enabled. Whether the server sends a health ping to the Agones sidecar. (default: `true`)
 - Health Ping Seconds. Interval of the server sending a health ping to the Agones sidecar. (default: `5`)
-- Debug Logging Enabled. Debug logging for development of this Plugin. (default: `false`)
 - Request Retry Limit. Maximum number of times a failed request to the Agones sidecar is retried. Health requests are not retried. (default: `30`)
+- Send Ready at Startup. Automatically send a Ready request when the server starts. Disable this to manually control when the game server should be marked as ready. (default: `true`)
 

--- a/site/content/en/docs/Guides/Client SDKs/unreal.md
+++ b/site/content/en/docs/Guides/Client SDKs/unreal.md
@@ -31,6 +31,40 @@ At this moment we do not provide binaries for the plugin. This requires you to c
 2. Copy {{< ghlink href="sdks/unreal" >}}the Agones plugin directory{{< /ghlink >}} into the Plugins directory.
 3. Build the project.
 
+### Agones Hook
+
+To manually call the Agones SDK methods add the plugin as a dependency inside the `<project>.Build.cs` file:
+
+```
+PublicDependencyModuleNames.AddRange(
+    new string[]
+    {
+        ...
+        "Agones"
+    });
+```
+
+Then use `FAgonesModule::GetHook()` to get a reference to the Agones hook and call the SDK methods using the hook:
+
+```
+#include "Agones.h"
+
+...
+
+// Get a reference to the Agones hook.
+FAgonesHook& Hook = FAgonesModule::GetHook();
+
+Hook.Ready();
+Hook.SetLabel(TEXT("key"), TEXT("value"));
+
+// GetGameServerDelegate here is a class member of type FGameServerRequestCompleteDelegate.
+Hook.GetGameServer(GetGameServerDelegate);
+GetGameServerDelegate.BindLambda([](TSharedPtr<FGameServer> GameServer, bool bSuccess)
+{
+    // ...
+});
+```
+
 ## Settings
 
 The settings for the Agones Plugin can be found in the Unreal Engine editor `Edit > Project Settings > Plugins >  Agones`


### PR DESCRIPTION
Adds the `Allocate` and `Reserve` methods to the Unreal plugin, and an option to configure whether `Ready` should be sent automatically at startup.

Also removed the debug logging option in the settings following up from https://github.com/googleforgames/agones/pull/1303#discussion_r372858159 to be more consistent with UnrealEngine logging behaviour (and changed the default verbosity to Verbose)