### PR TITLE
Save UE4 Plugin settings to per-project config file

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Public/AgonesSettings.h
+++ b/sdks/unreal/Agones/Source/Agones/Public/AgonesSettings.h
@@ -22,7 +22,7 @@
 /**
  * Implements the settings for Agones.
  */
-UCLASS(config = Game)
+UCLASS(config = Game, defaultconfig)
 class AGONES_API UAgonesSettings : public UObject
 {
 	GENERATED_BODY()


### PR DESCRIPTION
Use the *defaultconfig* UCLASS specifier so that UE4 Agones Settings are saved to the per-project configuration file, rather than the per-user configuration file.

Fixes #1351.