### PR TITLE
Fix Kubernetes terraform provider version

### DIFF
--- a/examples/terraform-submodules/aks/module.tf
+++ b/examples/terraform-submodules/aks/module.tf
@@ -18,38 +18,48 @@
 
 // Install latest version of agones
 variable "agones_version" {
-  default=""
+  default = ""
 }
 variable "cluster_name" {
-  default="test-cluster"
+  default = "test-cluster"
 }
 
-variable "machine_type" {default = "Standard_D2_v2"}
+variable "client_id" {
+  default = ""
+}
+
+variable "client_secret" {
+  default = ""
+}
+
+variable "machine_type" { default = "Standard_D2_v2" }
 
 module "aks_cluster" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/aks/?ref=master"
-  
-  machine_type = "${var.machine_type}"
-  cluster_name = "${var.cluster_name}"
+
+  machine_type  = "${var.machine_type}"
+  cluster_name  = "${var.cluster_name}"
+  client_id     = "${var.client_id}"
+  client_secret = "${var.client_secret}"
 }
 
 module "helm_agones" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm/?ref=master"
-  
-  agones_version = "${var.agones_version}"
-  values_file=""
-  chart="agones"
-  host="${module.aks_cluster.host}"
-  token="${module.aks_cluster.token}"
-  cluster_ca_certificate="${module.aks_cluster.cluster_ca_certificate}"
+
+  agones_version         = "${var.agones_version}"
+  values_file            = ""
+  chart                  = "agones"
+  host                   = "${module.aks_cluster.host}"
+  token                  = "${module.aks_cluster.token}"
+  cluster_ca_certificate = "${module.aks_cluster.cluster_ca_certificate}"
 }
 
 output "host" {
-    value = "${module.aks_cluster.host}"
+  value = "${module.aks_cluster.host}"
 }
 output "token" {
-    value = "${module.aks_cluster.token}"
+  value = "${module.aks_cluster.token}"
 }
 output "cluster_ca_certificate" {
-    value = "${module.aks_cluster.cluster_ca_certificate}"
+  value = "${module.aks_cluster.cluster_ca_certificate}"
 }

--- a/install/terraform/helm.tf
+++ b/install/terraform/helm.tf
@@ -88,7 +88,7 @@ variable "values_file" {
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
-  version                = "~> 1.5"
+  version                = "~> 1.5, <=1.10"
   load_config_file       = false
   host                   = "https://${google_container_cluster.primary.endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/install/terraform/modules/aks/aks.tf
+++ b/install/terraform/modules/aks/aks.tf
@@ -19,8 +19,8 @@ provider "azuread" {
 # Create Service Principal password
 resource "azuread_service_principal_password" "aks" {
   end_date             = "2299-12-30T23:00:00Z" # Forever
-  service_principal_id = "${azuread_service_principal.aks.id}"
-  value                = "${random_string.password.result}"
+  service_principal_id = azuread_service_principal.aks.id
+  value                = random_string.password.result
 }
 
 # Create Azure AD Application for Service Principal
@@ -30,7 +30,7 @@ resource "azuread_application" "aks" {
 
 # Create Service Principal
 resource "azuread_service_principal" "aks" {
-  application_id = "${azuread_application.aks.application_id}"
+  application_id = azuread_application.aks.application_id
 }
 
 # Generate random string to be used for Service Principal Password
@@ -50,18 +50,18 @@ resource "azurerm_kubernetes_cluster" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   dns_prefix          = "agones"
 
-  kubernetes_version = "1.14.10"
+  kubernetes_version = "1.14.8"
 
-  agent_pool_profile {
-    name            = "default"
-    count           = 2
-    vm_size         = "${var.machine_type}"
-    os_type         = "Linux"
-    os_disk_size_gb = 30
+  default_node_pool {
+    name                = "default"
+    node_count          = 2
+    vm_size             = "${var.machine_type}"
+    os_disk_size_gb     = 30
+    enable_auto_scaling = false
   }
   service_principal {
-    client_id     = "${azuread_application.aks.application_id}"
-    client_secret = "${azuread_service_principal_password.aks.value}"
+    client_id     = "${var.client_id}"
+    client_secret = "${var.client_secret}"
   }
   tags = {
     Environment = "Production"

--- a/install/terraform/modules/aks/variables.tf
+++ b/install/terraform/modules/aks/variables.tf
@@ -19,3 +19,9 @@ variable "machine_type" {
 variable "cluster_name" {
   default = "test-cluster"
 }
+
+variable "client_id" {
+}
+
+variable "client_secret" {
+}

--- a/install/terraform/modules/helm/helm.tf
+++ b/install/terraform/modules/helm/helm.tf
@@ -40,11 +40,11 @@ resource "kubernetes_cluster_role_binding" "tiller" {
     namespace = "kube-system"
   }
 
-  depends_on = ["kubernetes_service_account.tiller"]
+  depends_on = [kubernetes_service_account.tiller]
 }
 
 provider "kubernetes" {
-  version                = "~> 1.5"
+  version                = "~> 1.5, <=1.10"
   load_config_file       = false
   host                   = "${var.host}"
   token                  = "${var.token}"
@@ -72,7 +72,7 @@ data "helm_repository" "agones" {
   name = "agones"
   url  = "https://agones.dev/chart/stable"
 
-  depends_on = ["kubernetes_cluster_role_binding.tiller"]
+  depends_on = [kubernetes_cluster_role_binding.tiller]
 }
 
 locals {
@@ -80,6 +80,7 @@ locals {
   # for installing latest image it would use chart value
   tag_name = "${var.agones_version != "" ? "agones.image.tag" : "skip"}"
 }
+
 
 resource "helm_release" "agones" {
   name         = "agones"
@@ -129,8 +130,8 @@ resource "helm_release" "agones" {
   }
 
   set {
-    name = "agones.ping.udp.expose"
-    value ="${var.udp_expose}"
+    name  = "agones.ping.udp.expose"
+    value = "${var.udp_expose}"
   }
 
   set {


### PR DESCRIPTION
Use older version, fix variables for AKS
Removed deprecated field `agent_pool_profile` in favor of new `default_node_pool` which would be required in next version.

There is a know bug in the most recent 1.11.0 version https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759, so in order to retiliate this issue we should avoid the most recent version.

Error was the following;
```
Error: Failed to initialize config: invalid configuration: no configuration has been provided

  on .terraform/modules/agones/install/terraform/helm.tf line 90, in provider "kubernetes":
  90: provider "kubernetes" {
```