### PR TITLE
Terraform make targets: Switch from the plane structure to module terraform config

### DIFF
--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -70,4 +70,4 @@ endif
 
 gcloud-terraform-destroy-cluster:
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && \
-	 terraform destroy -auto-approve'
+	 terraform destroy -target module.helm_agones.helm_release.agones -auto-approve && sleep 60 && terraform destroy -auto-approve'

--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -16,11 +16,11 @@
 terraform-init:
 terraform-init: $(ensure-build-image)
 	docker run --rm -it $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c '\
-	cd $(mount_path)/examples/terraform-submodules/gke-local && terraform init && gcloud auth application-default login'
+	cd $(mount_path)/build/terraform/gke && terraform init && gcloud auth application-default login'
 
 terraform-clean:
-	rm -r ../examples/terraform-submodules/gke-local/.terraform
-	rm ../examples/terraform-submodules/gke-local/.tfstate*
+	rm -r ../build/terraform/gke/.terraform || true
+	rm ../build/terraform/gke/terraform.tfstate* || true
 
 # Creates a cluster and install release version of Agones controller
 # Version could be specified by AGONES_VERSION
@@ -33,35 +33,41 @@ gcloud-terraform-cluster:
 ifndef GCP_PROJECT
 	$(eval GCP_PROJECT=$(shell sh -c "gcloud config get-value project 2> /dev/null"))
 endif
-	$(DOCKER_RUN) bash -c 'export TF_VAR_agones_version=$(AGONES_VERSION) && \
-		cd $(mount_path)/examples/terraform-submodules/gke-local && terraform apply -auto-approve -var project="$(GCP_PROJECT)" -var name="$(GCP_CLUSTER_NAME)"'
-	$(MAKE) gcloud-auth-cluster
+	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && \
+		 terraform apply -auto-approve  -var agones_version="$(AGONES_VERSION)" \
+		-var name=$(GCP_CLUSTER_NAME) -var machine_type="$(GCP_CLUSTER_NODEPOOL_MACHINETYPE)" \
+		-var values_file="" \
+		-var zone="$(GCP_CLUSTER_ZONE)" -var project="$(GCP_PROJECT)" \
+		-var node_count=$(GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT)'
+	GCP_CLUSTER_NAME=$(GCP_CLUSTER_NAME) $(MAKE) gcloud-auth-cluster
 
 # Creates a cluster and install current version of Agones controller
 # Set all necessary variables as `make install` does
+# Unifies previous `make gcloud-test-cluster` and `make install` targets
 gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT ?= 4
 gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= n1-standard-4
 gcloud-terraform-install: ALWAYS_PULL_SIDECAR := true
 gcloud-terraform-install: IMAGE_PULL_POLICY := "Always"
 gcloud-terraform-install: PING_SERVICE_TYPE := "LoadBalancer"
 gcloud-terraform-install: CRD_CLEANUP := true
+gcloud-terraform-install: GCP_CLUSTER_NAME ?= test-cluster
 gcloud-terraform-install:
 ifndef GCP_PROJECT
 	$(eval GCP_PROJECT=$(shell sh -c "gcloud config get-value project 2> /dev/null"))
 endif
 	$(DOCKER_RUN) bash -c ' \
-	cd $(mount_path)/examples/terraform-submodules/gke-local && terraform apply -auto-approve -var agones_version="$(VERSION)" -var image_registry="$(REGISTRY)" \
+	cd $(mount_path)/build/terraform/gke && terraform apply -auto-approve -var agones_version="$(VERSION)" -var image_registry="$(REGISTRY)" \
 		-var pull_policy="$(IMAGE_PULL_POLICY)" \
 		-var always_pull_sidecar="$(ALWAYS_PULL_SIDECAR)" \
 		-var image_pull_secret="$(IMAGE_PULL_SECRET)" \
 		-var ping_service_type="$(PING_SERVICE_TYPE)" \
 		-var crd_cleanup="$(CRD_CLEANUP)" \
-		-var "cluster={name=\"$(GCP_CLUSTER_NAME)\", machineType=\"$(GCP_CLUSTER_NODEPOOL_MACHINETYPE)\", \
-		-var values_file="../../../helm/agones/values.yaml" \
-		 zone=\"$(GCP_CLUSTER_ZONE)\", project=\"$(GCP_PROJECT)\", \
-		 initialNodeCount=\"$(GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT)\"}"'
-	$(MAKE) gcloud-auth-cluster
+		-var chart="../../../install/helm/agones/" \
+		-var name=$(GCP_CLUSTER_NAME) -var machine_type="$(GCP_CLUSTER_NODEPOOL_MACHINETYPE)" \
+		-var zone=$(GCP_CLUSTER_ZONE) -var project=$(GCP_PROJECT) \
+		-var node_count=$(GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT)'
+	GCP_CLUSTER_NAME=$(GCP_CLUSTER_NAME) $(MAKE) gcloud-auth-cluster
 
 gcloud-terraform-destroy-cluster:
-	$(DOCKER_RUN) bash -c 'cd $(mount_path)/install/terraform && \
+	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && \
 	 terraform destroy -auto-approve'

--- a/build/terraform/gke/module.tf
+++ b/build/terraform/gke/module.tf
@@ -28,10 +28,6 @@ variable "project" {
   default = ""
 }
 
-variable "name" {
-  default = "agones-terraform-example"
-}
-
 // Install latest version of agones
 variable "agones_version" {
   default = ""
@@ -40,19 +36,13 @@ variable "agones_version" {
 variable "machine_type" {
   default = "n1-standard-4"
 }
-<<<<<<< HEAD:examples/terraform-submodules/gke-local/module.tf
-=======
 
 variable "name" {
-  default = "agones-terraform-example"
-}
-
-variable "machine_type" {
-  default = "n1-standard-4"
+  default = "agones-tf-cluster"
 }
 
 variable "values_file" {
-  default = ""
+  default = "../../../install/helm/agones/values.yaml"
 }
 
 // Note: This is the number of gameserver nodes. The Agones module will automatically create an additional
@@ -60,14 +50,16 @@ variable "values_file" {
 variable "node_count" {
   default = "4"
 }
+variable "chart" {
+  default = "agones"
+}
 
-module "gke_cluster" {
->>>>>>> Switch from the normal to module terraform config:examples/terraform-submodules/gke-local/main.tf
+variable "crd_cleanup" {
+  default = "true"
+}
 
-// Note: This is the number of gameserver nodes. The Agones module will automatically create an additional
-// two node pools with 1 node each for "agones-system" and "agones-metrics".
-variable "node_count" {
-  default = "4"
+variable "ping_service_type" {
+  default = "LoadBalancer"
 }
 
 variable "zone" {
@@ -79,6 +71,23 @@ variable "network" {
   default     = "default"
   description = "The name of the VPC network to attach the cluster and firewall rule to"
 }
+
+variable "pull_policy" {
+  default = "Always"
+}
+
+variable "image_registry" {
+  default = "gcr.io/agones-images"
+}
+
+variable "always_pull_sidecar" {
+  default = "true"
+}
+
+variable "image_pull_secret" {
+  default = ""
+}
+
 
 module "gke_cluster" {
   source = "../../../install/terraform/modules/gke"
@@ -98,10 +107,14 @@ module "helm_agones" {
 
   agones_version         = var.agones_version
   values_file            = var.values_file
-  chart                  = "agones"
+  chart                  = var.chart
   host                   = module.gke_cluster.host
   token                  = module.gke_cluster.token
   cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
+  image_registry         = var.image_registry
+  image_pull_secret      = var.image_pull_secret
+  crd_cleanup            = var.crd_cleanup
+  ping_service_type      = var.ping_service_type
 }
 
 output "host" {

--- a/examples/terraform-submodules/gke-local/module.tf
+++ b/examples/terraform-submodules/gke-local/module.tf
@@ -40,6 +40,29 @@ variable "agones_version" {
 variable "machine_type" {
   default = "n1-standard-4"
 }
+<<<<<<< HEAD:examples/terraform-submodules/gke-local/module.tf
+=======
+
+variable "name" {
+  default = "agones-terraform-example"
+}
+
+variable "machine_type" {
+  default = "n1-standard-4"
+}
+
+variable "values_file" {
+  default = ""
+}
+
+// Note: This is the number of gameserver nodes. The Agones module will automatically create an additional
+// two node pools with 1 node each for "agones-system" and "agones-metrics".
+variable "node_count" {
+  default = "4"
+}
+
+module "gke_cluster" {
+>>>>>>> Switch from the normal to module terraform config:examples/terraform-submodules/gke-local/main.tf
 
 // Note: This is the number of gameserver nodes. The Agones module will automatically create an additional
 // two node pools with 1 node each for "agones-system" and "agones-metrics".
@@ -74,7 +97,7 @@ module "helm_agones" {
   source = "../../../install/terraform/modules/helm"
 
   agones_version         = var.agones_version
-  values_file            = ""
+  values_file            = var.values_file
   chart                  = "agones"
   host                   = module.gke_cluster.host
   token                  = module.gke_cluster.token

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -31,6 +31,7 @@ resource "null_resource" "test-setting-variables" {
     EOT
   }
 }
+
 resource "google_container_cluster" "primary" {
   name     = var.cluster["name"]
   location = var.cluster["zone"]
@@ -139,6 +140,5 @@ resource "google_compute_firewall" "default" {
     protocol = "udp"
     ports    = [var.ports]
   }
-
   target_tags = ["game-server"]
 }

--- a/install/terraform/modules/helm/variables.tf
+++ b/install/terraform/modules/helm/variables.tf
@@ -62,5 +62,5 @@ variable "ping_service_type" {
 }
 
 variable "values_file" {
-  default = "../../../helm/agones/values.yaml"
+  default = ""
 }


### PR DESCRIPTION
make targets for development

The main difference between `make gcloud-test-cluster` and `make gcloud-terraform-cluster` is that one use helm repo later one use local chart.

 There is an option to limit the number of resources created by using `terraform apply -target=resource` 
https://www.terraform.io/docs/commands/apply.html#target-resource

In the case when we want similar functionality to `make gcloud-test-cluster` and `make install` we should use `-target=module.gke_cluster` and `-target=module.helm_agones`

Note that `values_file` and `chart` variables are there to have one `Helm.tf` module performing two functions:

1. we can install local version, local values_file is used.
1. we can install release which is achieved by
```
tag_name = "${var.agones_version != "" ? "agones.image.tag" : "skip"}"
```
For #657 and #1373 