### PR TITLE
Fix for AKS recent provider change

### DIFF
--- a/examples/terraform-submodules/aks/module.tf
+++ b/examples/terraform-submodules/aks/module.tf
@@ -20,8 +20,17 @@
 variable "agones_version" {
   default = ""
 }
+
 variable "cluster_name" {
   default = "test-cluster"
+}
+
+variable "node_count" {
+  default = 4
+}
+
+variable "disk_size" {
+  default = 30
 }
 
 variable "client_id" {
@@ -37,29 +46,31 @@ variable "machine_type" { default = "Standard_D2_v2" }
 module "aks_cluster" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/aks/?ref=master"
 
-  machine_type  = "${var.machine_type}"
-  cluster_name  = "${var.cluster_name}"
-  client_id     = "${var.client_id}"
-  client_secret = "${var.client_secret}"
+  machine_type  = var.machine_type
+  cluster_name  = var.cluster_name
+  node_count    = var.node_count
+  disk_size     = var.disk_size
+  client_id     = var.client_id
+  client_secret = var.client_secret
 }
 
 module "helm_agones" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm/?ref=master"
 
-  agones_version         = "${var.agones_version}"
+  agones_version         = var.agones_version
   values_file            = ""
   chart                  = "agones"
-  host                   = "${module.aks_cluster.host}"
-  token                  = "${module.aks_cluster.token}"
-  cluster_ca_certificate = "${module.aks_cluster.cluster_ca_certificate}"
+  host                   = module.aks_cluster.host
+  token                  = module.aks_cluster.token
+  cluster_ca_certificate = module.aks_cluster.cluster_ca_certificate
 }
 
 output "host" {
-  value = "${module.aks_cluster.host}"
+  value = module.aks_cluster.host
 }
 output "token" {
-  value = "${module.aks_cluster.token}"
+  value = module.aks_cluster.token
 }
 output "cluster_ca_certificate" {
-  value = "${module.aks_cluster.cluster_ca_certificate}"
+  value = module.aks_cluster.cluster_ca_certificate
 }

--- a/examples/terraform-submodules/eks/module.tf
+++ b/examples/terraform-submodules/eks/module.tf
@@ -43,28 +43,28 @@ variable "machine_type" { default = "t2.large" }
 module "eks_cluster" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/eks/?ref=master"
 
-  machine_type = "${var.machine_type}"
-  cluster_name = "${var.cluster_name}"
-  node_count   = "${var.node_count}"
-  region       = "${var.region}"
+  machine_type = var.machine_type
+  cluster_name = var.cluster_name
+  node_count   = var.node_count
+  region       = var.region
 }
 
 data "aws_eks_cluster_auth" "example" {
-  name = "${var.cluster_name}"
+  name = var.cluster_name
 }
 
 // Next Helm module cause "terraform destroy" timeout, unless helm release would be deleted first.
 // Therefore "helm delete --purge agones" should be executed from the CLI before executing "terraform destroy".
 module "helm_agones" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm/?ref=master"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm/?ref=master"   
 
   udp_expose             = "false"
-  agones_version         = "${var.agones_version}"
+  agones_version         = var.agones_version
   values_file            = ""
   chart                  = "agones"
-  host                   = "${module.eks_cluster.host}"
-  token                  = "${data.aws_eks_cluster_auth.example.token}"
-  cluster_ca_certificate = "${module.eks_cluster.cluster_ca_certificate}"
+  host                   = module.eks_cluster.host
+  token                  = data.aws_eks_cluster_auth.example.token
+  cluster_ca_certificate = module.eks_cluster.cluster_ca_certificate
 }
 
 output "host" {

--- a/install/terraform/modules/aks/outputs.tf
+++ b/install/terraform/modules/aks/outputs.tf
@@ -13,21 +13,27 @@
 # limitations under the License.
 
 output "cluster_ca_certificate" {
-  value = "${base64decode(azurerm_kubernetes_cluster.test.kube_config.0.cluster_ca_certificate)}"
+  value = "${base64decode(azurerm_kubernetes_cluster.agones.kube_config.0.cluster_ca_certificate)}"
+  depends_on = [
+    # Helm would be invoked only after all node pools would be created
+    # This way taints and tolerations for Agones controller would work properly
+    azurerm_kubernetes_cluster_node_pool.system,
+    azurerm_kubernetes_cluster_node_pool.metrics
+  ]
 }
 
 output "client_certificate" {
-  value = "${azurerm_kubernetes_cluster.test.kube_config.0.client_certificate}"
+  value = "${azurerm_kubernetes_cluster.agones.kube_config.0.client_certificate}"
 }
 
 output "kube_config" {
-  value = "${azurerm_kubernetes_cluster.test.kube_config_raw}"
+  value = "${azurerm_kubernetes_cluster.agones.kube_config_raw}"
 }
 
 output "host" {
-  value = "${azurerm_kubernetes_cluster.test.kube_config.0.host}"
+  value = "${azurerm_kubernetes_cluster.agones.kube_config.0.host}"
 }
 
 output "token" {
-  value = "${azurerm_kubernetes_cluster.test.kube_config.0.password}"
+  value = "${azurerm_kubernetes_cluster.agones.kube_config.0.password}"
 }

--- a/install/terraform/modules/aks/variables.tf
+++ b/install/terraform/modules/aks/variables.tf
@@ -16,6 +16,14 @@ variable "machine_type" {
   default = "Standard_D2_v2"
 }
 
+variable "node_count" {
+  default = 4
+}
+
+variable "disk_size" {
+  default = 30
+}
+
 variable "cluster_name" {
   default = "test-cluster"
 }

--- a/install/terraform/modules/eks/eks.tf
+++ b/install/terraform/modules/eks/eks.tf
@@ -78,7 +78,7 @@ module "vpc" {
 
 module "eks" {
   source          = "git::github.com/terraform-aws-modules/terraform-aws-eks.git?ref=v7.0.1"
-  cluster_name    = "${var.cluster_name}"
+  cluster_name    = var.cluster_name
   subnets         = module.vpc.public_subnets
   vpc_id          = module.vpc.vpc_id
   cluster_version = "1.13"
@@ -86,24 +86,24 @@ module "eks" {
   worker_groups_launch_template = [
     {
       name                          = "default"
-      instance_type                 = "${var.machine_type}"
-      asg_desired_capacity          = "${var.node_count}"
-      asg_min_size                  = "${var.node_count}"
-      asg_max_size                  = "${var.node_count}"
+      instance_type                 = var.machine_type
+      asg_desired_capacity          = var.node_count
+      asg_min_size                  = var.node_count
+      asg_max_size                  = var.node_count
       additional_security_group_ids = [aws_security_group.worker_group_mgmt_one.id]
       public_ip                     = true
     },
     // Node Pools with taints for metrics and system
     {
       name                 = "agones-system"
-      instance_type        = "${var.machine_type}"
+      instance_type        = var.machine_type
       asg_desired_capacity = 1
       kubelet_extra_args   = "--node-labels=agones.dev/agones-system=true --register-with-taints=agones.dev/agones-system=true:NoExecute"
       public_ip            = true
     },
     {
       name                 = "agones-metrics"
-      instance_type        = "${var.machine_type}"
+      instance_type        = var.machine_type
       asg_desired_capacity = 1
       kubelet_extra_args   = "--node-labels=agones.dev/agones-metrics=true --register-with-taints=agones.dev/agones-metrics=true:NoExecute"
       public_ip            = true

--- a/install/terraform/modules/eks/outputs.tf
+++ b/install/terraform/modules/eks/outputs.tf
@@ -43,6 +43,6 @@ output "cluster_ca_certificate" {
 }
 
 output "host" {
-  depends_on = ["module.eks"]
+  depends_on = [module.eks]
   value      = "${module.eks.cluster_endpoint}"
 }


### PR DESCRIPTION
Remove deprecation warnings for AKS and EKS syntax : "${}"

About 6 days ago there was an update of AzureRM terraform provider, which broke AKS terraform config:
https://stackoverflow.com/questions/60384689/terraform-azurerm-2-x-error-features-required-field-is-not-set
