### PR TITLE
Switch godoc.org links to pkg.go.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ manually before the PR is approved, using the latest released version of UE4.
 When submitting pull requests, make sure to do the following:
 
 - Format all Go code with [gofmt](https://golang.org/cmd/gofmt/). Many people
-  use [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) which
+  use [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) which
   fixes import statements and formats code in the same style of `gofmt`.
 - C++ code should follow the [Google C++ Style
   Guide](https://google.github.io/styleguide/cppguide.html), which can be

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img src="./docs/agones.png" alt="Agones logo" width="250px" height="250px" />
 
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/agones.dev/agones)
 [![GoDoc](https://godoc.org/agones.dev/agones?status.svg)](https://godoc.org/agones.dev/agones)
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleforgames/agones)](https://goreportcard.com/report/github.com/googleforgames/agones)
 [![GitHub release](https://img.shields.io/github/release/googleforgames/agones.svg)](https://github.com/googleforgames/agones/releases)

--- a/examples/allocator-service/README.md
+++ b/examples/allocator-service/README.md
@@ -1,6 +1,6 @@
 # Simple Allocator Service
 
-This service provides an example of using the [Agones API](https://godoc.org/agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1) to allocate a GameServer from a Fleet, and is used in the [Create an Allocator Service (Go)](https://agones.dev/site/docs/tutorials/allocator-service-go/) tutorial.
+This service provides an example of using the [Agones API](https://pkg.go.dev/agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1) to allocate a GameServer from a Fleet, and is used in the [Create an Allocator Service (Go)](https://agones.dev/site/docs/tutorials/allocator-service-go/) tutorial.
 
 ## Allocator Service
 The service exposes an endpoint which allows client calls to AllocationInterface.Create() over a secure connection.  It also provides examples of how to create a service account with the least necessary privileges, how to create an Ingress, and how services can use secrets specific to their respective accounts.

--- a/site/content/en/docs/Examples/_index.md
+++ b/site/content/en/docs/Examples/_index.md
@@ -38,6 +38,6 @@ These are all examples of simple game server implementations, that integrate the
 ## Building on top of Agones
 
 - {{< ghlink href="examples/allocator-service" >}}Allocator Service{{< /ghlink >}} (Go) - 
-  This service provides an example of using the [Agones API](https://godoc.org/agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1)
+  This service provides an example of using the [Agones API](https://pkg.go.dev/agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1)
   to allocate a GameServer from a Fleet,
   and is used in the [Create an Allocator Service (Go)]({{< ref "/docs/Tutorials/allocator-service-go.md" >}}) tutorial.

--- a/site/content/en/docs/Guides/Client SDKs/go.md
+++ b/site/content/en/docs/Guides/Client SDKs/go.md
@@ -14,4 +14,4 @@ Check the [Client SDK Documentation]({{< relref "_index.md" >}}) for more detail
 
 ## Usage
 
-Review the [GoDoc](https://godoc.org/agones.dev/agones/sdks/go) for usage instructions
+Review the [GoDoc](https://pkg.go.dev/agones.dev/agones/sdks/go) for usage instructions

--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -30,8 +30,8 @@ but other methods may also work as well.
 Kubernetes Go Client tooling generates a Client for Agones that we can use to interact with the Agones
 installation on our Kubernetes cluster.
 
-- [Godoc for the Agones Client](https://godoc.org/agones.dev/agones/pkg/client/clientset/versioned)
-- [Godoc for the standard Kubernetes Client](https://godoc.org/k8s.io/client-go)
+- [Godoc for the Agones Client](https://pkg.go.dev/agones.dev/agones/pkg/client/clientset/versioned)
+- [Godoc for the standard Kubernetes Client](https://pkg.go.dev/k8s.io/client-go)
 
 ### Authentication
 

--- a/site/content/en/docs/Tutorials/allocator-service-go.md
+++ b/site/content/en/docs/Tutorials/allocator-service-go.md
@@ -4,7 +4,7 @@ linkTitle: "Create an Allocator Service (Go)"
 date: 2019-01-03T03:15:34Z
 description: >
   This tutorial describes how to interact programmatically with the 
-  [Agones API](https://godoc.org/agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1).
+  [Agones API](https://pkg.go.dev/agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1).
 ---
 
 To do this, we will implement a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) which allocates a


### PR DESCRIPTION
pkg.go.dev is nicer - you can choose specific versions of Go APIs to browse, and the latest tag is the default - not master (you can't even see master!)