### PR TITLE
Fix SDK conformance GRPC gateway test

### DIFF
--- a/build/build-sdk-images/restapi/Dockerfile
+++ b/build/build-sdk-images/restapi/Dockerfile
@@ -26,10 +26,10 @@ ENV GOPATH /go
 RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir -p ${GOPATH}
 
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
-RUN  apt-get install -y openjdk-8-jre
+RUN apt-get install -y openjdk-8-jre
 
 ENV PATH /usr/local/go/bin:/go/bin:$PATH
 

--- a/build/build-sdk-images/restapi/clean.sh
+++ b/build/build-sdk-images/restapi/clean.sh
@@ -16,4 +16,4 @@
 
 set -ex
 rm -rf /go/src/agones.dev/agones/test/sdk/restapi/swagger
-rm /go/src/agones.dev/agones/test/sdk/restapi/http-api-test.go
+rm /go/src/agones.dev/agones/test/sdk/restapi/http-api-test.go || true

--- a/test/sdk/restapi/http-api-test.go.nolint
+++ b/test/sdk/restapi/http-api-test.go.nolint
@@ -32,8 +32,8 @@ func main() {
 
 	ctx := context.Background()
 
-	// Wait for SDK server to start the test (30 seconds)
-	for c := 0; c < 5; c++ {
+	// Wait for SDK server to start the test (15 seconds)
+	for c := 0; c < 15; c++ {
 		_, _, err := cli.SDKApi.Ready(ctx, swagger.SdkEmpty{})
 		if err == nil {
 			break


### PR DESCRIPTION
Add more time to wait before start, update nodejs version to even
number.