### PR TITLE
SdkServer: updateState does not do a DeepClone()

### DIFF
--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -432,6 +432,11 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 		gs.ApplyDefaults()
 		return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{gs}}, nil
 	})
+	m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua := action.(k8stesting.UpdateAction)
+		gs := ua.GetObject().(*agonesv1.GameServer)
+		return true, gs, nil
+	})
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -525,7 +525,7 @@ func TestGameServerReserve(t *testing.T) {
 		logger.WithField("first-time", e.FirstTimestamp).WithField("count", e.Count).
 			WithField("last-time", e.LastTimestamp).
 			WithField("name", e.Name).
-			WithField("reason", e.Reason).WithField("message", e.Message).Info("gs event details")
+			WithField("reason", e.Reason).WithField("message", e.Message).Info("gs pod details")
 	}
 }
 


### PR DESCRIPTION
This might be the reason for TestGameServerReserve's flakiness.

Either way, this is worth fixing, to ensure that the backing Kubernetes client cache for the sdk server is not corrupted and cause indeterminate behaviour.