### PR TITLE
Add sidecar memory resources setting

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -84,6 +84,12 @@ spec:
           value: {{ .Values.agones.image.sdk.alwaysPull | quote }}
         - name: SIDECAR_CPU_REQUEST
           value: {{ .Values.agones.image.sdk.cpuRequest | quote }}
+        - name: SIDECAR_CPU_LIMIT
+          value: {{ .Values.agones.image.sdk.cpuLimit | quote }}
+        - name: SIDECAR_MEMORY_REQUEST
+          value: {{ .Values.agones.image.sdk.memoryRequest | quote }}
+        - name: SIDECAR_MEMORY_LIMIT
+          value: {{ .Values.agones.image.sdk.memoryLimit | quote }}
         - name: SDK_SERVICE_ACCOUNT
           value: {{ .Values.agones.serviceaccount.sdk | quote }}
         - name: PROMETHEUS_EXPORTER
@@ -94,8 +100,6 @@ spec:
           value: {{ .Values.agones.metrics.stackdriverLabels | quote }}
         - name: GCP_PROJECT_ID
           value: {{ .Values.agones.metrics.stackdriverProjectID | quote }}
-        - name: SIDECAR_CPU_LIMIT
-          value: {{ .Values.agones.image.sdk.cpuLimit | quote }}
         - name: NUM_WORKERS
           value: {{ .Values.agones.controller.numWorkers | quote }}
         - name: API_SERVER_QPS

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -133,6 +133,8 @@ agones:
       name: agones-sdk
       cpuRequest: 30m
       cpuLimit: 0
+      memoryRequest: 0
+      memoryLimit: 0
       alwaysPull: false
     ping:
       name: agones-ping

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1453,6 +1453,12 @@ spec:
           value: "false"
         - name: SIDECAR_CPU_REQUEST
           value: "30m"
+        - name: SIDECAR_CPU_LIMIT
+          value: "0"
+        - name: SIDECAR_MEMORY_REQUEST
+          value: "0"
+        - name: SIDECAR_MEMORY_LIMIT
+          value: "0"
         - name: SDK_SERVICE_ACCOUNT
           value: "agones-sdk"
         - name: PROMETHEUS_EXPORTER
@@ -1463,8 +1469,6 @@ spec:
           value: ""
         - name: GCP_PROJECT_ID
           value: ""
-        - name: SIDECAR_CPU_LIMIT
-          value: "0"
         - name: NUM_WORKERS
           value: "100"
         - name: API_SERVER_QPS

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -67,6 +67,8 @@ type Controller struct {
 	alwaysPullSidecarImage bool
 	sidecarCPURequest      resource.Quantity
 	sidecarCPULimit        resource.Quantity
+	sidecarMemoryRequest   resource.Quantity
+	sidecarMemoryLimit     resource.Quantity
 	sdkServiceAccount      string
 	crdGetter              v1beta1.CustomResourceDefinitionInterface
 	podGetter              typedcorev1.PodsGetter
@@ -97,6 +99,8 @@ func NewController(
 	alwaysPullSidecarImage bool,
 	sidecarCPURequest resource.Quantity,
 	sidecarCPULimit resource.Quantity,
+	sidecarMemoryRequest resource.Quantity,
+	sidecarMemoryLimit resource.Quantity,
 	sdkServiceAccount string,
 	kubeClient kubernetes.Interface,
 	kubeInformerFactory informers.SharedInformerFactory,
@@ -112,6 +116,8 @@ func NewController(
 		sidecarImage:           sidecarImage,
 		sidecarCPULimit:        sidecarCPULimit,
 		sidecarCPURequest:      sidecarCPURequest,
+		sidecarMemoryLimit:     sidecarMemoryLimit,
+		sidecarMemoryRequest:   sidecarMemoryRequest,
 		alwaysPullSidecarImage: alwaysPullSidecarImage,
 		sdkServiceAccount:      sdkServiceAccount,
 		crdGetter:              extClient.ApiextensionsV1beta1().CustomResourceDefinitions(),
@@ -623,13 +629,23 @@ func (c *Controller) sidecar(gs *agonesv1.GameServer) corev1.Container {
 		sidecar.Args = append(sidecar.Args, fmt.Sprintf("--http-port=%d", gs.Spec.SdkServer.HTTPPort))
 	}
 
+	requests := corev1.ResourceList{}
 	if !c.sidecarCPURequest.IsZero() {
-		sidecar.Resources.Requests = corev1.ResourceList{corev1.ResourceCPU: c.sidecarCPURequest}
+		requests[corev1.ResourceCPU] = c.sidecarCPURequest
 	}
+	if !c.sidecarMemoryRequest.IsZero() {
+		requests[corev1.ResourceMemory] = c.sidecarMemoryRequest
+	}
+	sidecar.Resources.Requests = requests
 
+	limits := corev1.ResourceList{}
 	if !c.sidecarCPULimit.IsZero() {
-		sidecar.Resources.Limits = corev1.ResourceList{corev1.ResourceCPU: c.sidecarCPULimit}
+		limits[corev1.ResourceCPU] = c.sidecarCPULimit
 	}
+	if !c.sidecarCPULimit.IsZero() {
+		limits[corev1.ResourceMemory] = c.sidecarMemoryLimit
+	}
+	sidecar.Resources.Limits = limits
 
 	if c.alwaysPullSidecarImage {
 		sidecar.ImagePullPolicy = corev1.PullAlways

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -827,6 +827,8 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			assert.Equal(t, pod.Spec.Containers[1].Image, c.sidecarImage)
 			assert.Equal(t, pod.Spec.Containers[1].Resources.Limits.Cpu(), &c.sidecarCPULimit)
 			assert.Equal(t, pod.Spec.Containers[1].Resources.Requests.Cpu(), &c.sidecarCPURequest)
+			assert.Equal(t, pod.Spec.Containers[1].Resources.Limits.Memory(), &c.sidecarMemoryLimit)
+			assert.Equal(t, pod.Spec.Containers[1].Resources.Requests.Memory(), &c.sidecarMemoryRequest)
 			assert.Len(t, pod.Spec.Containers[1].Env, 3, "3 env vars")
 			assert.Equal(t, "GAMESERVER_NAME", pod.Spec.Containers[1].Env[0].Name)
 			assert.Equal(t, fixture.ObjectMeta.Name, pod.Spec.Containers[1].Env[0].Value)
@@ -1439,7 +1441,8 @@ func newFakeController() (*Controller, agtesting.Mocks) {
 	wh := webhooks.NewWebHook(http.NewServeMux())
 	c := NewController(wh, healthcheck.NewHandler(),
 		10, 20, "sidecar:dev", false,
-		resource.MustParse("0.05"), resource.MustParse("0.1"), "sdk-service-account",
+		resource.MustParse("0.05"), resource.MustParse("0.1"),
+		resource.MustParse("50Mi"), resource.MustParse("100Mi"), "sdk-service-account",
 		m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m

--- a/sdks/nodejs/package-lock.json
+++ b/sdks/nodejs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/agones-sdk",
-  "version": "1.5.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sdks/nodejs/package-lock.json
+++ b/sdks/nodejs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/agones-sdk",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -121,8 +121,6 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.image.sdk.name`                             | Image name for the sdk                                                                          | `agones-sdk`           |
 | `agones.image.sdk.cpuRequest`                       | The [cpu request][cpu-constraints] for sdk server container                                     | `30m`                  |
 | `agones.image.sdk.cpuLimit`                         | The [cpu limit][cpu-constraints] for the sdk server container                                   | `0` (none)             |
-| `agones.image.sdk.memoryRequest`                    | The [memory request][memory-constraints] for sdk server container                               | `0` (none)             |
-| `agones.image.sdk.memoryLimit`                      | The [memory limit][memory-constraints] for the sdk server container                             | `0` (none)             |
 | `agones.image.sdk.alwaysPull`                       | Tells if the sdk image should always be pulled                                                  | `false`                |
 | `agones.image.ping.name`                            | Image name for the ping service                                                                 | `agones-ping`          |
 | `agones.image.ping.pullPolicy`                      | Image pull policy for the ping service                                                          | `IfNotPresent`         |
@@ -174,7 +172,8 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
-|                                                     |                                                                                                 |                        |
+| `agones.image.sdk.memoryRequest`                    | The [memory request][memory-constraints] for sdk server container                               | `0` (none)             |
+| `agones.image.sdk.memoryLimit`                      | The [memory limit][memory-constraints] for the sdk server container                             | `0` (none)             |
 
 {{% /feature %}}
 

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -119,8 +119,10 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.image.controller.pullPolicy`                | Image pull policy for the controller                                                            | `IfNotPresent`         |
 | `agones.image.controller.pullSecret`                | Image pull secret for the controller, allocator, sdk and ping image. Should be created both in `agones-system` and `default` namespaces | ``                     |
 | `agones.image.sdk.name`                             | Image name for the sdk                                                                          | `agones-sdk`           |
-| `agones.image.sdk.cpuRequest`                       | The [cpu request][constraints] for sdk server container                                         | `30m`                  |
-| `agones.image.sdk.cpuLimit`                         | The [cpu limit][constraints] for the sdk server container                                       | `0` (none)             |
+| `agones.image.sdk.cpuRequest`                       | The [cpu request][cpu-constraints] for sdk server container                                                  | `30m`                  |
+| `agones.image.sdk.cpuLimit`                         | The [cpu limit][cpu-constraints] for the sdk server container                                                  | `0` (none)             |
+| `agones.image.sdk.memoryRequest`                    | The [memory request][memory-constraints] for sdk server container                                                  | `0` (none)             |
+| `agones.image.sdk.memoryLimit`                      | The [memory limit][memory-constraints] for the sdk server container                                                  | `0` (none)             |
 | `agones.image.sdk.alwaysPull`                       | Tells if the sdk image should always be pulled                                                  | `false`                |
 | `agones.image.ping.name`                            | Image name for the ping service                                                                 | `agones-ping`          |
 | `agones.image.ping.pullPolicy`                      | Image pull policy for the ping service                                                          | `IfNotPresent`         |
@@ -179,7 +181,8 @@ The following tables lists the configurable parameters of the Agones chart and t
 [toleration]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 [nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-[constraints]: https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/
+[cpu-constraints]: https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/
+[memory-constraints]: https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/
 [ping]: {{< ref "/docs/Guides/ping-service.md" >}}
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [allocator]: {{< ref "/docs/advanced/allocator-service.md" >}}

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -119,10 +119,10 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.image.controller.pullPolicy`                | Image pull policy for the controller                                                            | `IfNotPresent`         |
 | `agones.image.controller.pullSecret`                | Image pull secret for the controller, allocator, sdk and ping image. Should be created both in `agones-system` and `default` namespaces | ``                     |
 | `agones.image.sdk.name`                             | Image name for the sdk                                                                          | `agones-sdk`           |
-| `agones.image.sdk.cpuRequest`                       | The [cpu request][cpu-constraints] for sdk server container                                                  | `30m`                  |
-| `agones.image.sdk.cpuLimit`                         | The [cpu limit][cpu-constraints] for the sdk server container                                                  | `0` (none)             |
-| `agones.image.sdk.memoryRequest`                    | The [memory request][memory-constraints] for sdk server container                                                  | `0` (none)             |
-| `agones.image.sdk.memoryLimit`                      | The [memory limit][memory-constraints] for the sdk server container                                                  | `0` (none)             |
+| `agones.image.sdk.cpuRequest`                       | The [cpu request][cpu-constraints] for sdk server container                                     | `30m`                  |
+| `agones.image.sdk.cpuLimit`                         | The [cpu limit][cpu-constraints] for the sdk server container                                   | `0` (none)             |
+| `agones.image.sdk.memoryRequest`                    | The [memory request][memory-constraints] for sdk server container                               | `0` (none)             |
+| `agones.image.sdk.memoryLimit`                      | The [memory limit][memory-constraints] for the sdk server container                             | `0` (none)             |
 | `agones.image.sdk.alwaysPull`                       | Tells if the sdk image should always be pulled                                                  | `false`                |
 | `agones.image.ping.name`                            | Image name for the ping service                                                                 | `agones-ping`          |
 | `agones.image.ping.pullPolicy`                      | Image pull policy for the ping service                                                          | `IfNotPresent`         |


### PR DESCRIPTION
Add memory Requests/Limits for Gameserver resource estimation and Pod QoS class configuration.

### About QoS
Details of Pod QoS is as below.
https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/

By setting the QoS to "guaranteed", if the node does not have enough resources, it is kill from pods other than "guaranteed".

Also, This is followed to be "Guaranteed" in the sample-udp example.
https://github.com/googleforgames/agones/pull/487#issuecomment-455164341

But, QoS is not assigned to "Guaranteed" unless CPU and Memory are the same in Limit and Request for each container.

When not set sidecar Requests/Limits.
```
$ kubectl describe po simple-udp-5xdrf
:
Containers:
  simple-udp:
    Image:          gcr.io/agones-images/udp-server:0.18
:
    Limits:
      cpu:     20m
      memory:  32Mi
    Requests:
      cpu:     20m
      memory:  32Mi
:
  agones-gameserver-sidecar:
    Image:         gcr.io/agones-images/agones-sdk:1.5.0-dcb266e
:
    Requests:
      cpu:     30m
:
QoS Class:       Burstable
```

When sidecar setting is "Guaranteed".
```
$ kubectl describe po simple-udp-k9lsh
:
Containers:
  simple-udp:
    Image:          gcr.io/agones-images/udp-server:0.18
:
    Limits:
      cpu:     20m
      memory:  32Mi
    Requests:
      cpu:     20m
      memory:  32Mi
:
  agones-gameserver-sidecar:
    Image:         gcr.io/agones-images/agones-sdk:1.5.0-dcb266e
:
    Limits:
      cpu:     100m
      memory:  100Mi
    Requests:
      cpu:     100m
      memory:  100Mi
:
QoS Class:       Guaranteed
```