### PR TITLE
Fixed permission of sidecar serviceaccount

### DIFF
--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -39,7 +39,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 - apiGroups: ["agones.dev"]
   resources: ["gameservers"]
   verbs: ["list", "update", "watch"]

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -157,7 +157,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 - apiGroups: ["agones.dev"]
   resources: ["gameservers"]
   verbs: ["list", "update", "watch"]


### PR DESCRIPTION
Add "patch" authority to resource "events" to serviceaccount "agones-sdk".

GameServer's sidecar creates a patch for an existing event.
The current serviceaccount did not allow "patch", which resulted in an error.

Fixes #1304 