### PR TITLE
Super Tux Kart -> SuperTuxKart, and additional wording fixes

### DIFF
--- a/examples/supertuxkart/Makefile
+++ b/examples/supertuxkart/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #
-# Makefile for building the Super Tux Kart server
+# Makefile for building the SuperTuxKart server
 #
 
 #  __     __         _       _     _

--- a/examples/supertuxkart/README.md
+++ b/examples/supertuxkart/README.md
@@ -1,11 +1,11 @@
-# Super Tux Kart Example
+# SuperTuxKart Game Server Example
 
-Example using a [Super Tux Kart](https://supertuxkart.net/) dedicated game server.
+Example using a [SuperTuxKart](https://supertuxkart.net/) dedicated game server.
 
-This example wraps the Super Tux Kart server with a [Go](https://golang.org) binary, and introspects
+This example wraps the SuperTuxKart server with a [Go](https://golang.org) binary, and introspects
 the log file to provide the event hooks for the SDK integration.
 
-It is not a direct integration, but is an approach for to integrate with existing
+It is not a direct integration, but is an approach to integrate with existing
 dedicated game servers.
 
-You will need to download the Super Tux Kart client separately to play.
+You will need to download the SuperTuxKart client separately to play.

--- a/examples/supertuxkart/main.go
+++ b/examples/supertuxkart/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC All Rights Reserved.
+// Copyright 2020 Google LLC, All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ import (
 	sdk "agones.dev/agones/sdks/go"
 )
 
-// logLocation is the path to the location of the Super Tux Kart log file
+// logLocation is the path to the location of the SuperTuxKart log file
 const logLocation = "/.config/supertuxkart/config-0.10/server_config.log"
 
-// main intercepts the log file of the Super Tux Kart gameserver and uses it
+// main intercepts the log file of the SuperTuxKart gameserver and uses it
 // to determine if the game server is ready or not.
 func main() {
 	input := flag.String("i", "", "the command and arguments to execute the server binary")
@@ -40,14 +40,14 @@ func main() {
 	fmt.Println(">>> Connecting to Agones with the SDK")
 	s, err := sdk.NewSDK()
 	if err != nil {
-		log.Fatalf(">>> Could not connect to sdk: %v", err)
+		log.Fatalf(">>> Could not connect to SDK: %v", err)
 	}
 
 	fmt.Println(">>> Starting health checking")
 	go doHealth(s)
 
-	fmt.Println(">>> Starting wrapper for Super Tux Kart!")
-	fmt.Printf(">>> Command run for Super Tux Kart server: %s \n", *input)
+	fmt.Println(">>> Starting wrapper for SuperTuxKart")
+	fmt.Printf(">>> Command being run for SuperTuxKart server: %s \n", *input)
 
 	cmdString := strings.Split(*input, " ")
 	command, args := cmdString[0], cmdString[1:]
@@ -57,10 +57,10 @@ func main() {
 	cmd.Stdout = os.Stdout
 
 	if err := cmd.Start(); err != nil {
-		log.Fatalf(">>> Error Starting Cmd: %v", err)
+		log.Fatalf(">>> Error starting cmd: %v", err)
 	}
 
-	// Super Tux Kart refuses to output to foreground, so we're going to
+	// SuperTuxKart refuses to output to foreground, so we're going to
 	// poll the server log.
 	ready := false
 	home, err := os.UserHomeDir()
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	err = cmd.Wait()
-	log.Fatalf(">>> Super Tux Kart shutdown unexpectedly: %v", err)
+	log.Fatalf(">>> SuperTuxKart shutdown unexpectedly: %v", err)
 }
 
 // doHealth sends the regular Health Pings


### PR DESCRIPTION
SuperTuxKart is officially spelled with no spaces; also a few other minor word tweaks thrown in.  :)