### PR TITLE
Flaky: TestGameServerReserve

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -148,7 +148,7 @@ func (f *Framework) WaitForGameServerStateWithLogger(logger *logrus.Entry, gs *a
 		checkGs, err = f.AgonesClient.AgonesV1().GameServers(gs.Namespace).Get(gs.Name, metav1.GetOptions{})
 
 		if err != nil {
-			logrus.WithError(err).Warn("error retrieving gameserver")
+			logger.WithError(err).Warn("error retrieving gameserver")
 			return false, nil
 		}
 


### PR DESCRIPTION
The idea behind this solution is that as you get down into the WaitFor() commands, there is a goroutine that is run to implement polling.

Normally, if there is a delay due to goroutine scheduling, this is fine, as we are waiting for something to happen, and if the test comes in after the thing happened - then that is fine.

In this instance, we definitely need to check right away, so I implemented a special case of using a for loop instead, so that the test can't be non-determinately delayed.