### PR TITLE
Terraform docs about terraform destroy 

### DIFF
--- a/site/content/en/docs/Installation/Terraform/eks.md
+++ b/site/content/en/docs/Installation/Terraform/eks.md
@@ -64,9 +64,9 @@ kubectl get nodes
 
 ### Uninstall the Agones and delete EKS cluster
 
-Run the following commands to delete all Terraform provisioned resources if you choose helm:
+Run the following commands to delete all Terraform provisioned resources:
 ```
-helm delete --purge agones
+terraform destroy -target module.helm_agones.helm_release.agones -auto-approve && sleep 60
 terraform destroy
 ```
 


### PR DESCRIPTION
Split terraform destroy to give 60 seconds delay time to clean up the
resources created by `helm_release` Agones.

For #1403