### PR TITLE
Retry logic in htmltest

### DIFF
--- a/build/includes/website.mk
+++ b/build/includes/website.mk
@@ -61,8 +61,10 @@ site-deploy-preview: site-static-preview
 
 hugo-test:
 	$(MAKE) site-static-preview
-	docker run --rm -t -e "TERM=xterm-256color" $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
-		"mkdir -p /tmp/website && cp -r $(mount_path)/site/public /tmp/website/site && htmltest -c $(mount_path)/site/htmltest.yaml /tmp/website"
+	for i in {1..5}; \
+		do docker run --rm -t -e "TERM=xterm-256color" $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
+			"mkdir -p /tmp/website && cp -r $(mount_path)/site/public /tmp/website/site && htmltest -c $(mount_path)/site/htmltest.yaml /tmp/website" && \
+	break || (echo "retrying..." && sleep 60); done
 
 site-test:
 	# generate actual html and run test against - provides a more accurate tests


### PR DESCRIPTION
Looks like the rate of html requests to Github has been lowered which is causing errors with our CI process.

This will retry the test, to resolve rate issues or intermittent external link issues.