### PR TITLE
Added version to stress tests files

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -265,7 +265,8 @@ stress-test-e2e: $(ensure-build-image)
 		--gameserver-image=$(GS_TEST_IMAGE) \
 		--pullsecret=$(IMAGE_PULL_SECRET) \
 		--stress $(STRESS_TEST_LEVEL) \
-		--perf-output $(PERF_OUTPUT_DIR)
+		--perf-output $(PERF_OUTPUT_DIR) \
+		--version $(VERSION)
 
 # Run test on install yaml - make sure there is no change
 # mostly this is for CI

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -843,8 +843,8 @@ func TestScaleUpAndDownInParallelStressTest(t *testing.T) {
 
 	var fleets []*agonesv1.Fleet
 
-	scaleUpStats := framework.NewStatsCollector(fmt.Sprintf("fleet_%v_scale_up", fleetSize))
-	scaleDownStats := framework.NewStatsCollector(fmt.Sprintf("fleet_%v_scale_down", fleetSize))
+	scaleUpStats := framework.NewStatsCollector(fmt.Sprintf("fleet_%v_scale_up", fleetSize), framework.Version)
+	scaleDownStats := framework.NewStatsCollector(fmt.Sprintf("fleet_%v_scale_down", fleetSize), framework.Version)
 
 	defer scaleUpStats.Report()
 	defer scaleDownStats.Report()

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -62,6 +62,7 @@ type Framework struct {
 	PullSecret      string
 	StressTestLevel int
 	PerfOutputDir   string
+	Version         string
 }
 
 // New setups a testing framework using a kubeconfig path and the game server image to use for testing.
@@ -115,6 +116,7 @@ func NewFromFlags() (*Framework, error) {
 		"optional secret to be used for pulling the gameserver and/or Agones SDK sidecar images")
 	stressTestLevel := flag.Int("stress", 0, "enable stress test at given level 0-100")
 	perfOutputDir := flag.String("perf-output", "", "write performance statistics to the specified directory")
+	version := flag.String("version", "", "agones controller version that was tested in the release version plus the short hash of the latest commit")
 
 	flag.Parse()
 
@@ -127,6 +129,7 @@ func NewFromFlags() (*Framework, error) {
 	framework.PullSecret = *pullSecret
 	framework.StressTestLevel = *stressTestLevel
 	framework.PerfOutputDir = *perfOutputDir
+	framework.Version = *version
 
 	return framework, nil
 }
@@ -304,11 +307,11 @@ func (f *Framework) WaitForFleetGameServerListCondition(flt *agonesv1.Fleet,
 
 // NewStatsCollector returns new instance of statistics collector,
 // which can be used to emit performance statistics for load tests and stress tests.
-func (f *Framework) NewStatsCollector(name string) *StatsCollector {
+func (f *Framework) NewStatsCollector(name, version string) *StatsCollector {
 	if f.StressTestLevel > 0 {
 		name = fmt.Sprintf("stress_%v_%v", f.StressTestLevel, name)
 	}
-	return &StatsCollector{name: name, outputDir: f.PerfOutputDir}
+	return &StatsCollector{name: name, outputDir: f.PerfOutputDir, version: version}
 }
 
 // CleanUp Delete all Agones resources in a given namespace.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -116,7 +116,7 @@ func NewFromFlags() (*Framework, error) {
 		"optional secret to be used for pulling the gameserver and/or Agones SDK sidecar images")
 	stressTestLevel := flag.Int("stress", 0, "enable stress test at given level 0-100")
 	perfOutputDir := flag.String("perf-output", "", "write performance statistics to the specified directory")
-	version := flag.String("version", "", "agones controller version that was tested in the release version plus the short hash of the latest commit")
+	version := flag.String("version", "", "agones controller version to be tested, consists of release version plus a short hash of the latest commit")
 
 	flag.Parse()
 


### PR DESCRIPTION
Part of #573 

Added version number to stress tests file names and to _Labels_ field.

Tests output file looks like this:
_stress_1_fleet_10_scale_down_1.5.0-0607041_2020-03-26_1424.json_

Labels field:
_"Labels": "Agones stress_1_fleet_10_scale_up_1.5.0-0607041"_
