### PR TITLE
Feature Gates: EnableAllFeatures

### DIFF
--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -115,6 +115,23 @@ func ParseFeatures(queryString string) error {
 	return nil
 }
 
+// EnableAllFeatures turns on all feature flags.
+// This is useful for libraries/processes/tests that want to
+// enable all Alpha/Beta features without having to track all
+// the current feature flags.
+func EnableAllFeatures() {
+	featureMutex.Lock()
+	defer featureMutex.Unlock()
+
+	features := map[Feature]bool{}
+	// copy the defaults into this map
+	for k := range featureDefaults {
+		features[k] = true
+	}
+
+	featureGates = features
+}
+
 // FeatureEnabled returns if a Feature is enabled or not
 func FeatureEnabled(feature Feature) bool {
 	featureMutex.RLock()

--- a/pkg/util/runtime/features_test.go
+++ b/pkg/util/runtime/features_test.go
@@ -29,6 +29,7 @@ func TestFeatures(t *testing.T) {
 	FeatureTestMutex.Lock()
 	defer FeatureTestMutex.Unlock()
 
+	orig := featureDefaults
 	// stable feature flag state
 	featureDefaults = map[Feature]bool{
 		FeatureExample:  true,
@@ -76,4 +77,33 @@ func TestFeatures(t *testing.T) {
 		assert.True(t, FeatureEnabled(Feature("Test")))
 		assert.True(t, FeatureEnabled(FeatureExample))
 	})
+
+	// reset things back the way they were
+	featureDefaults = orig
+}
+
+func TestEnableAllFeatures(t *testing.T) {
+	t.Parallel()
+	FeatureTestMutex.Lock()
+	defer FeatureTestMutex.Unlock()
+
+	orig := featureDefaults
+	// stable feature flag state
+	featureDefaults = map[Feature]bool{
+		FeatureExample:  true,
+		Feature("Test"): false,
+	}
+
+	err := ParseFeatures("Example=0&Test=0")
+	assert.NoError(t, err)
+	assert.False(t, FeatureEnabled("Example"))
+	assert.False(t, FeatureEnabled("Test"))
+
+	EnableAllFeatures()
+
+	assert.True(t, FeatureEnabled("Example"))
+	assert.True(t, FeatureEnabled("Test"))
+
+	// reset things back the way they were
+	featureDefaults = orig
 }


### PR DESCRIPTION
It's can be useful for libraries that use Agones' code as a library to interact with Agones, to enable all Alpha/Beta features with one command, rather than having to track all Features that currently exists.

This provides that functionality.