### PR TITLE
Enhance Logs readability of  SDK Conformance Tests

### DIFF
--- a/build/build-sdk-images/node/build-sdk-test.sh
+++ b/build/build-sdk-images/node/build-sdk-test.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 cd /go/src/agones.dev/agones/test/sdk/nodejs
-npm install
-npm rebuild
+npm install --quiet
+npm rebuild --quiet
 
 # If first 'npm install' attempt fails, which could occur for a variety of reasons,
 # do one more attempt
@@ -27,6 +27,6 @@ then
     rm -rf /go/src/agones.dev/agones/test/sdk/nodejs/node_modules
     rm /go/src/agones.dev/agones/test/sdk/nodejs/package-lock.json
     npm cache clean
-    npm rebuild
-    npm install
+    npm rebuild --quiet
+    npm install --quiet
 fi

--- a/build/build-sdk-images/restapi/Dockerfile
+++ b/build/build-sdk-images/restapi/Dockerfile
@@ -26,10 +26,12 @@ ENV GOPATH /go
 RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir -p ${GOPATH}
 
+RUN echo '§' && apt-get -qy update 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -qq -y nodejs
 
-RUN apt-get install -y openjdk-8-jre
+#RUN apt-get install -qq -y openjdk-8-jre
+RUN apt-get install -qq -y openjdk-8-jre > /dev/null
 
 ENV PATH /usr/local/go/bin:/go/bin:$PATH
 

--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -143,7 +143,7 @@ run-sdk-conformance-no-build: FEATURE_GATES ?=
 run-sdk-conformance-no-build: ensure-agones-sdk-image
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	DOCKER_RUN_ARGS="--net host -e AGONES_SDK_GRPC_PORT=$(GRPC_PORT) -e AGONES_SDK_HTTP_PORT=$(HTTP_PORT) -e FEATURE_GATES=$(FEATURE_GATES) $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \
-	docker run -p $(GRPC_PORT):$(GRPC_PORT) -p $(HTTP_PORT):$(HTTP_PORT) -e "FEATURE_GATES=$(FEATURE_GATES)" -e "ADDRESS=" -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" -e "DELAY=$(DELAY)" \
+	docker run -p $(GRPC_PORT):$(GRPC_PORT) -p $(HTTP_PORT):$(HTTP_PORT) -e "FEATURE_GATES=$(FEATURE_GATES)" -e "ADDRESS=" -e "TEST=$(TESTS)" -e "SDK_NAME=$(SDK_FOLDER)" -e "TIMEOUT=$(TIMEOUT)" -e "DELAY=$(DELAY)" \
 	--net=host $(sidecar_tag) --grpc-port $(GRPC_PORT) --http-port $(HTTP_PORT)
 
 # Run SDK conformance test for a specific SDK_FOLDER

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -51,14 +51,15 @@ const (
 	podNamespaceEnv   = "POD_NAMESPACE"
 
 	// Flags (that can also be env vars)
-	localFlag    = "local"
-	fileFlag     = "file"
-	testFlag     = "test"
-	addressFlag  = "address"
-	delayFlag    = "delay"
-	timeoutFlag  = "timeout"
-	grpcPortFlag = "grpc-port"
-	httpPortFlag = "http-port"
+	localFlag       = "local"
+	fileFlag        = "file"
+	testFlag        = "test"
+	testSdkNameFlag = "sdk-name"
+	addressFlag     = "address"
+	delayFlag       = "delay"
+	timeoutFlag     = "timeout"
+	grpcPortFlag    = "grpc-port"
+	httpPortFlag    = "http-port"
 )
 
 var (
@@ -208,6 +209,7 @@ func registerTestSdkServer(grpcServer *grpc.Server, ctlConf config) (func(), err
 	s.GenerateUID()
 	expectedFuncs := strings.Split(ctlConf.Test, ",")
 	s.SetExpectedSequence(expectedFuncs)
+	s.SetSdkName(ctlConf.TestSdkName)
 
 	sdk.RegisterSDKServer(grpcServer, s)
 	sdkalpha.RegisterSDKServer(grpcServer, s)
@@ -258,6 +260,7 @@ func parseEnvFlags() config {
 	viper.SetDefault(localFlag, false)
 	viper.SetDefault(fileFlag, "")
 	viper.SetDefault(testFlag, "")
+	viper.SetDefault(testSdkNameFlag, "")
 	viper.SetDefault(addressFlag, "localhost")
 	viper.SetDefault(delayFlag, 0)
 	viper.SetDefault(timeoutFlag, 0)
@@ -272,6 +275,7 @@ func parseEnvFlags() config {
 	pflag.Int(delayFlag, viper.GetInt(delayFlag), "Time to delay (in seconds) before starting to execute main. Useful for tests")
 	pflag.Int(timeoutFlag, viper.GetInt(timeoutFlag), "Time of execution (in seconds) before close. Useful for tests")
 	pflag.String(testFlag, viper.GetString(testFlag), "List functions which should be called during the SDK Conformance test run.")
+	pflag.String(testSdkNameFlag, viper.GetString(testSdkNameFlag), "SDK name which is tested by this SDK Conformance test.")
 	runtime.FeaturesBindFlags()
 	pflag.Parse()
 
@@ -279,6 +283,7 @@ func parseEnvFlags() config {
 	runtime.Must(viper.BindEnv(localFlag))
 	runtime.Must(viper.BindEnv(addressFlag))
 	runtime.Must(viper.BindEnv(testFlag))
+	runtime.Must(viper.BindEnv(testSdkNameFlag))
 	runtime.Must(viper.BindEnv(gameServerNameEnv))
 	runtime.Must(viper.BindEnv(podNamespaceEnv))
 	runtime.Must(viper.BindEnv(delayFlag))
@@ -291,25 +296,27 @@ func parseEnvFlags() config {
 	runtime.Must(runtime.ParseFeaturesFromEnv())
 
 	return config{
-		IsLocal:   viper.GetBool(localFlag),
-		Address:   viper.GetString(addressFlag),
-		LocalFile: viper.GetString(fileFlag),
-		Delay:     viper.GetInt(delayFlag),
-		Timeout:   viper.GetInt(timeoutFlag),
-		Test:      viper.GetString(testFlag),
-		GRPCPort:  viper.GetInt(grpcPortFlag),
-		HTTPPort:  viper.GetInt(httpPortFlag),
+		IsLocal:     viper.GetBool(localFlag),
+		Address:     viper.GetString(addressFlag),
+		LocalFile:   viper.GetString(fileFlag),
+		Delay:       viper.GetInt(delayFlag),
+		Timeout:     viper.GetInt(timeoutFlag),
+		Test:        viper.GetString(testFlag),
+		TestSdkName: viper.GetString(testSdkNameFlag),
+		GRPCPort:    viper.GetInt(grpcPortFlag),
+		HTTPPort:    viper.GetInt(httpPortFlag),
 	}
 }
 
 // config is all the configuration for this program
 type config struct {
-	Address   string
-	IsLocal   bool
-	LocalFile string
-	Delay     int
-	Timeout   int
-	Test      string
-	GRPCPort  int
-	HTTPPort  int
+	Address     string
+	IsLocal     bool
+	LocalFile   string
+	Delay       int
+	Timeout     int
+	Test        string
+	TestSdkName string
+	GRPCPort    int
+	HTTPPort    int
 }

--- a/cmd/sdk-server/main_test.go
+++ b/cmd/sdk-server/main_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// TestRegisterTestSdkServer - test to verify
+func TestRegisterTestSdkServer(t *testing.T) {
+	t.Parallel()
+	ctlConf := parseEnvFlags()
+	grpcServer := grpc.NewServer()
+	_, err := registerTestSdkServer(grpcServer, ctlConf)
+	assert.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx.Done()
+	ctlConf.LocalFile = "@@"
+	_, err = registerLocal(grpcServer, ctlConf)
+	assert.Error(t, err, "Wrong file name should produce an error")
+}

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -416,6 +416,6 @@ func TestSDKConformanceFunctionality(t *testing.T) {
 	wg.Wait()
 
 	l.SetExpectedSequence(expected)
-	b := EqualSets(l.expectedSequence, l.requestSequence)
+	b := l.EqualSets(l.expectedSequence, l.requestSequence)
 	assert.True(t, b, "we should receive strings from all go routines %v %v", l.expectedSequence, l.requestSequence)
 }

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -67,19 +67,21 @@ func TestLocal(t *testing.T) {
 }
 
 func TestLocalSDKWithTestMode(t *testing.T) {
+	l, err := NewLocalSDKServer("")
+	assert.NoError(t, err, "Should be able to create local SDK server")
 	a := []string{"ready", "allocate", "setlabel", "setannotation", "gameserver", "health", "shutdown", "watch"}
 	b := []string{"ready", "health", "ready", "watch", "allocate", "gameserver", "setlabel", "setannotation", "health", "health", "shutdown"}
-	assert.True(t, EqualSets(a, a))
-	assert.True(t, EqualSets(a, b))
-	assert.True(t, EqualSets(b, a))
-	assert.True(t, EqualSets(b, b))
+	assert.True(t, l.EqualSets(a, a))
+	assert.True(t, l.EqualSets(a, b))
+	assert.True(t, l.EqualSets(b, a))
+	assert.True(t, l.EqualSets(b, b))
 	a[0] = "rady"
-	assert.False(t, EqualSets(a, b))
-	assert.False(t, EqualSets(b, a))
+	assert.False(t, l.EqualSets(a, b))
+	assert.False(t, l.EqualSets(b, a))
 	a[0] = "ready"
 	b[1] = "halth"
-	assert.False(t, EqualSets(a, b))
-	assert.False(t, EqualSets(b, a))
+	assert.False(t, l.EqualSets(a, b))
+	assert.False(t, l.EqualSets(b, a))
 }
 
 func TestLocalSDKWithGameServer(t *testing.T) {


### PR DESCRIPTION
Add more detaied logging for local SDK server. Make `npm` and `apt-get` less noisy. `apt-get install openjdk-8-jre` spares about 25% of output.

For #1452 .