### PR TITLE
Fixed flaky TestGameServerWithPortsMappedToMultipleContainers

### DIFF
--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -480,17 +481,19 @@ func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
 	t.Parallel()
 	firstContainerName := "udp-server"
 	secondContainerName := "second-udp-server"
+	firstPort := "gameport"
+	secondPort := "second-gameport"
 	gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{GenerateName: "udp-server", Namespace: defaultNs},
 		Spec: agonesv1.GameServerSpec{
 			Container: firstContainerName,
 			Ports: []agonesv1.GameServerPort{{
 				ContainerPort: 7654,
-				Name:          "gameport",
+				Name:          firstPort,
 				PortPolicy:    agonesv1.Dynamic,
 				Protocol:      corev1.ProtocolUDP,
 			}, {
 				ContainerPort: 5000,
-				Name:          "second-gameport",
+				Name:          secondPort,
 				PortPolicy:    agonesv1.Dynamic,
 				Protocol:      corev1.ProtocolUDP,
 				Container:     &secondContainerName,
@@ -522,17 +525,31 @@ func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
 	defer framework.AgonesClient.AgonesV1().GameServers(defaultNs).Delete(readyGs.ObjectMeta.Name, nil) // nolint: errcheck
 	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
 
-	firstContainerReply, err := e2eframework.SendGameServerUDPToPort(readyGs, "gameport", "Ping 1")
-	if err != nil {
-		t.Fatalf("Could not message GameServer: %v", err)
-	}
-	assert.Contains(t, firstContainerReply, "Ping 1")
+	interval := 2 * time.Second
+	timeOut := 60 * time.Second
 
-	secondContainerReply, err := e2eframework.SendGameServerUDPToPort(readyGs, "second-gameport", "Ping 2")
-	if err != nil {
-		t.Fatalf("Could not message GameServer: %v", err)
+	expectedMsg1 := "Ping 1"
+	errPoll := wait.PollImmediate(interval, timeOut, func() (done bool, err error) {
+		res, err := e2eframework.SendGameServerUDPToPort(readyGs, firstPort, expectedMsg1)
+		if err != nil {
+			t.Logf("Could not message GameServer on %s: %v. Will try again...", firstPort, err)
+		}
+		return err == nil && strings.Contains(res, expectedMsg1), nil
+	})
+	if errPoll != nil {
+		assert.FailNow(t, errPoll.Error(), "expected no errors after polling a port: %s", firstPort)
 	}
-	assert.Contains(t, secondContainerReply, "Ping 2")
+
+	expectedMsg2 := "Ping 2"
+	errPoll = wait.PollImmediate(interval, timeOut, func() (done bool, err error) {
+		res, err := e2eframework.SendGameServerUDPToPort(readyGs, secondPort, expectedMsg2)
+		if err != nil {
+			t.Logf("Could not message GameServer on %s: %v. Will try again...", secondPort, err)
+		}
+		return err == nil && strings.Contains(res, expectedMsg2), nil
+	})
+
+	assert.NoError(t, errPoll, "expected no errors after polling a port: %s", secondPort)
 }
 
 func TestGameServerReserve(t *testing.T) {


### PR DESCRIPTION
Closes #1450 
I've run this test more than 100 times and found that both pings can fail. 

Fix proof:
Game port №1:
![image](https://user-images.githubusercontent.com/16540942/78890322-137a6100-7a6e-11ea-8b40-e1404b0fafdb.png)

Game port №2:
![image](https://user-images.githubusercontent.com/16540942/78890291-06f60880-7a6e-11ea-913b-138c98678842.png)

Suggestion: Is there any opportunity to stop tests immediately by pressing ctr+c/ctr+z if we run them inside a container? It can take some time for some goroutines to finish their work.