### PR TITLE
e2e image needs 1.14.10 kubectl

### DIFF
--- a/build/e2e-image/Dockerfile
+++ b/build/e2e-image/Dockerfile
@@ -15,7 +15,7 @@ RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:/go/bin:$PATH
 
 # install kubectl without gcloud as we want the last version
-ENV KUBECTL_VER 1.13.12
+ENV KUBECTL_VER 1.14.10
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/linux/amd64/kubectl && \
     chmod go+rx ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
This fixes the break in CI we currently have. We missed changing the
kubectl version in the e2e image when we upgraded to Kubernetes 1.14

Now the 1.13.x version is no longer available on google cloud storage,
so things are breaking.

This should fix that!