### PR TITLE
Update documentation describing when we will change the version of Kubernetes  that we support.

### DIFF
--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -23,7 +23,8 @@ description: >
 
 {{< alert title="Warning" color="warning">}}
 Later versions of Kubernetes may work, but this project is tested against 1.14, and is therefore the supported version.
-Agones will update its support to n-1 version of what is available across all major cloud providers - GKE, EKS and AKS
+Agones will update its support to n-1 version of what is available across the majority of major cloud providers - GKE, EKS and
+AKS, while also ensuring that all Cloud providers can support that version.
 {{< /alert >}}
 
 {{< alert title="Note" color="info">}}


### PR DESCRIPTION
I purposely didn't put this change behind a version guard so that it will go live immediately (close to the 1.5 release) and so that we can apply the new language now for the 1.6 release. 