### PR TITLE
Terraform: update GKE cluster version, use locals and `lookup` to set default values

### DIFF
--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -81,5 +81,9 @@ endif
 	GCP_CLUSTER_NAME=$(GCP_TF_CLUSTER_NAME) $(MAKE) gcloud-auth-cluster
 
 gcloud-terraform-destroy-cluster:
+ifndef GCP_PROJECT
+	$(eval GCP_PROJECT=$(shell sh -c "gcloud config get-value project 2> /dev/null"))
+endif
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && \
-	 terraform destroy -target module.helm_agones.helm_release.agones -auto-approve && sleep 60 && terraform destroy -auto-approve'
+	terraform destroy -var project=$(GCP_PROJECT) -target module.helm_agones.helm_release.agones -auto-approve && sleep 60 && \
+	terraform destroy -var project=$(GCP_PROJECT) -auto-approve'

--- a/build/terraform/gke/module.tf
+++ b/build/terraform/gke/module.tf
@@ -97,17 +97,21 @@ variable "feature_gates" {
   default = ""
 }
 
+variable "kubernetes_version" {
+  default = "1.15"
+}
 
 module "gke_cluster" {
   source = "../../../install/terraform/modules/gke"
 
   cluster = {
-    "name"             = var.name
-    "zone"             = var.zone
-    "machineType"      = var.machine_type
-    "initialNodeCount" = var.node_count
-    "project"          = var.project
-    "network"          = var.network
+    "name"              = var.name
+    "zone"              = var.zone
+    "machineType"       = var.machine_type
+    "initialNodeCount"  = var.node_count
+    "project"           = var.project
+    "network"           = var.network
+    "kubernetesVersion" = var.kubernetes_version
   }
 }
 

--- a/examples/terraform-submodules/gke/module.tf
+++ b/examples/terraform-submodules/gke/module.tf
@@ -46,7 +46,6 @@ variable "machine_type" {
 variable "node_count" {
   default = "4"
 }
-
 variable "zone" {
   default     = "us-west1-c"
   description = "The GCP zone to create the cluster in"
@@ -65,6 +64,10 @@ variable "feature_gates" {
   default = ""
 }
 
+variable "kubernetes_version" {
+  default = "1.15"
+}
+
 module "gke_cluster" {
   // ***************************************************************************************************
   // Update ?ref= to the agones release you are installing. For example, ?ref=release-1.3.0 corresponds
@@ -73,12 +76,13 @@ module "gke_cluster" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=master"
 
   cluster = {
-    "name"             = var.name
-    "zone"             = var.zone
-    "machineType"      = var.machine_type
-    "initialNodeCount" = var.node_count
-    "project"          = var.project
-    "network"          = var.network
+    "name"              = var.name
+    "zone"              = var.zone
+    "machineType"       = var.machine_type
+    "initialNodeCount"  = var.node_count
+    "project"           = var.project
+    "network"           = var.network
+    "kubernetesVersion" = var.kubernetes_version
   }
 }
 

--- a/examples/terraform-submodules/gke/module.tf
+++ b/examples/terraform-submodules/gke/module.tf
@@ -64,10 +64,6 @@ variable "feature_gates" {
   default = ""
 }
 
-variable "kubernetes_version" {
-  default = "1.15"
-}
-
 module "gke_cluster" {
   // ***************************************************************************************************
   // Update ?ref= to the agones release you are installing. For example, ?ref=release-1.3.0 corresponds
@@ -76,13 +72,12 @@ module "gke_cluster" {
   source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=master"
 
   cluster = {
-    "name"              = var.name
-    "zone"              = var.zone
-    "machineType"       = var.machine_type
-    "initialNodeCount"  = var.node_count
-    "project"           = var.project
-    "network"           = var.network
-    "kubernetesVersion" = var.kubernetes_version
+    "name"             = var.name
+    "zone"             = var.zone
+    "machineType"      = var.machine_type
+    "initialNodeCount" = var.node_count
+    "project"          = var.project
+    "network"          = var.network
   }
 }
 

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -31,12 +31,6 @@ locals {
   kubernetesVersion = lookup(var.cluster, "kubernetesVersion", "1.15")
 }
 
-data "google_container_engine_versions" "kubernetes" {
-  project        = local.project
-  location       = local.zone
-  version_prefix = local.kubernetesVersion
-}
-
 # echo command used for debugging purpose
 # Run `terraform taint null_resource.test-setting-variables` before second execution
 resource "null_resource" "test-setting-variables" {
@@ -56,9 +50,7 @@ resource "google_container_cluster" "primary" {
   project  = local.project
   network  = local.network
 
-  min_master_version = data.google_container_engine_versions.kubernetes.latest_master_version
-
-  node_version = data.google_container_engine_versions.kubernetes.latest_node_version
+  min_master_version = local.kubernetesVersion
 
   node_pool {
     name       = "default"

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -19,10 +19,22 @@ terraform {
 
 data "google_client_config" "default" {}
 
+# A list of all parameters used in interpolation var.cluster
+# Set values to default if not key was not set in original map
+locals {
+  project           = lookup(var.cluster, "project", "agones")
+  zone              = lookup(var.cluster, "zone", "us-west1-c")
+  name              = lookup(var.cluster, "name", "test-cluster")
+  machineType       = lookup(var.cluster, "machineType", "n1-standard-4")
+  initialNodeCount  = lookup(var.cluster, "initialNodeCount", "4")
+  network           = lookup(var.cluster, "network", "default")
+  kubernetesVersion = lookup(var.cluster, "kubernetesVersion", "1.15")
+}
+
 data "google_container_engine_versions" "kubernetes" {
-  project        = var.cluster["project"]
-  location       = var.cluster["zone"]
-  version_prefix = var.cluster["kubernetesVersion"]
+  project        = local.project
+  location       = local.zone
+  version_prefix = local.kubernetesVersion
 }
 
 # echo command used for debugging purpose
@@ -31,18 +43,18 @@ resource "null_resource" "test-setting-variables" {
   provisioner "local-exec" {
     command = <<EOT
     ${format("echo Current variables set as following - name: %s, project: %s, machineType: %s, initialNodeCount: %s, network: %s, zone: %s",
-    var.cluster["name"], var.cluster["project"],
-    var.cluster["machineType"], var.cluster["initialNodeCount"], var.cluster["network"],
-var.cluster["zone"])}
+    local.name, local.project,
+    local.machineType, local.initialNodeCount, local.network,
+local.zone)}
     EOT
 }
 }
 
 resource "google_container_cluster" "primary" {
-  name     = var.cluster["name"]
-  location = var.cluster["zone"]
-  project  = var.cluster["project"]
-  network  = var.cluster["network"]
+  name     = local.name
+  location = local.zone
+  project  = local.project
+  network  = local.network
 
   min_master_version = data.google_container_engine_versions.kubernetes.latest_master_version
 
@@ -50,14 +62,14 @@ resource "google_container_cluster" "primary" {
 
   node_pool {
     name       = "default"
-    node_count = var.cluster["initialNodeCount"]
+    node_count = local.initialNodeCount
 
     management {
       auto_upgrade = false
     }
 
     node_config {
-      machine_type = var.cluster["machineType"]
+      machine_type = local.machineType
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/devstorage.read_only",
@@ -140,9 +152,9 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_compute_firewall" "default" {
-  name    = "game-server-firewall-firewall-${var.cluster["name"]}"
-  project = var.cluster["project"]
-  network = var.cluster["network"]
+  name    = "game-server-firewall-firewall-${local.name}"
+  project = local.project
+  network = local.network
 
   allow {
     protocol = "udp"

--- a/install/terraform/modules/gke/variables.tf
+++ b/install/terraform/modules/gke/variables.tf
@@ -25,11 +25,12 @@ variable "cluster" {
   type        = map
 
   default = {
-    "zone"             = "us-west1-c"
-    "name"             = "test-cluster"
-    "machineType"      = "n1-standard-4"
-    "initialNodeCount" = "4"
-    "project"          = "agones"
-    "network"          = "default"
+    "zone"              = "us-west1-c"
+    "name"              = "test-cluster"
+    "machineType"       = "n1-standard-4"
+    "initialNodeCount"  = "4"
+    "project"           = "agones"
+    "network"           = "default"
+    "kubernetesVersion" = "1.15"
   }
 }

--- a/site/content/en/docs/Installation/Terraform/gke.md
+++ b/site/content/en/docs/Installation/Terraform/gke.md
@@ -92,7 +92,6 @@ Configurable parameters:
 - network - the name of the VPC network you want your cluster and firewall rules to be connected to (default is "default")
 - log_level - possible values: Fatal, Error, Warn, Info, Debug (default is "info")
 - feature_gates - a list of alpha and beta version features to enable. For example, "PlayerTracking=true&ContainerPortAllocation=true"
-- kubernetes_version - a Kubernetes version of the GKE cluster
 
 {{% alert title="Warning" color="warning"%}}
 On the lines that read `source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=master"`
@@ -140,7 +139,7 @@ You should have 6 nodes in `Ready` state.
 
 To delete all resources provisioned by Terraform:
 ```
-terraform destroy
+terraform destroy -var project="<YOUR_GCP_ProjectID>"
 ```
 
 ## Next Steps

--- a/site/content/en/docs/Installation/Terraform/gke.md
+++ b/site/content/en/docs/Installation/Terraform/gke.md
@@ -92,6 +92,7 @@ Configurable parameters:
 - network - the name of the VPC network you want your cluster and firewall rules to be connected to (default is "default")
 - log_level - possible values: Fatal, Error, Warn, Info, Debug (default is "info")
 - feature_gates - a list of alpha and beta version features to enable. For example, "PlayerTracking=true&ContainerPortAllocation=true"
+- kubernetes_version - a Kubernetes version of the GKE cluster
 
 {{% alert title="Warning" color="warning"%}}
 On the lines that read `source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=master"`


### PR DESCRIPTION
Add new variable to select Kubernetes major and minor version.
`google_container_engine_versions` data source added, which allows to select proper node and master versions which applicable for every zone in the region if it is used with a regional cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
 /kind feature

**What this PR does / Why we need it**:
For #1478 .

It would allow proper version selection by specifying Kubernetes version prefix and cluster location. I.e. for regional clusters, `us-west2` could be used, for zonal clusters `us-west2-c`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

**Special notes for your reviewer**:
Useful documents:
https://www.terraform.io/docs/providers/google/d/google_container_engine_versions.html#latest_master_version
https://www.terraform.io/docs/providers/google/r/container_cluster.html#min_master_version
https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_version


