### PR TITLE
Allocator client tutorial: add steps for MacOS

### DIFF
--- a/site/content/en/docs/Advanced/allocator-service.md
+++ b/site/content/en/docs/Advanced/allocator-service.md
@@ -75,6 +75,9 @@ TLS_CA_FILE=ca.crt
 TLS_CA_VALUE=`kubectl get secret allocator-tls -n agones-system -ojsonpath='{.data.ca\.crt}'`
 echo ${TLS_CA_VALUE} | base64 -d > ${TLS_CA_FILE}
 
+# In case of MacOS
+# echo ${TLS_CA_VALUE} | base64 -D > ${TLS_CA_FILE}
+
 # Add ca.crt to the allocator-tls-ca Secret
 kubectl get secret allocator-tls-ca -o json -n agones-system | jq '.data["tls-ca.crt"]="'${TLS_CA_VALUE}'"' | kubectl apply -f -
 ```
@@ -118,6 +121,10 @@ Now the service is ready to accept requests from the client with the generated c
 #!/bin/bash
 
 NAMESPACE=default # replace with any namespace
+EXTERNAL_IP=`kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+KEY_FILE=client.key
+CERT_FILE=client.crt
+TLS_CA_FILE=ca.crt
 
 go run examples/allocator-client/main.go --ip ${EXTERNAL_IP} \
     --namespace ${NAMESPACE} \


### PR DESCRIPTION
Minor fix of argument and summarize all environment vars together to be
used by shell script.
Tested that all steps could be performed on MacOS.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**

/kind documentation

**What this PR does / Why we need it**:
Fixes [Tutorial](https://agones.dev/site/docs/advanced/allocator-service/) for MacOS.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
Results of running the [bash script](https://agones.dev/site/docs/advanced/allocator-service/#send-allocation-request):
```
 ./test.sh
response: state:Allocated gameServerName:"simple-udp-phptn-6kd8m" ports:<name:"default" port:7947 > address:"35.197.45.57" nodeName:"gke-test-cluster-default-ac24bb9b-hhsl"
```

