### PR TITLE
Docs: add Grafana version explicitly

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -457,6 +457,9 @@ setup-grafana:
 		--set persistence.enabled=$(PVC),server.persistentVolume.size=$(PV_SIZE) \
 		--set adminPassword=$(PASSWORD) -f $(mount_path)/build/grafana.yaml
 
+helm-repo-update:
+	$(DOCKER_RUN) helm repo update
+
 setup-test-cluster: DOCKER_RUN_ARGS+=--network=host
 setup-test-cluster: $(ensure-build-image)
 	$(DOCKER_RUN) kubectl apply -f $(mount_path)/build/helm.yaml

--- a/build/Makefile
+++ b/build/Makefile
@@ -453,7 +453,7 @@ setup-grafana: PASSWORD ?= admin
 setup-grafana:
 	$(DOCKER_RUN) kubectl apply -f $(mount_path)/build/grafana/
 	$(DOCKER_RUN) \
-		helm upgrade --install --wait grafana stable/grafana --version=5.0.11  --namespace metrics \
+		helm upgrade --install --wait grafana stable/grafana --version=5.0.13  --namespace metrics \
 		--set persistence.enabled=$(PVC),server.persistentVolume.size=$(PV_SIZE) \
 		--set adminPassword=$(PASSWORD) -f $(mount_path)/build/grafana.yaml
 

--- a/build/README.md
+++ b/build/README.md
@@ -502,6 +502,10 @@ You can use this to collect Agones [Metrics](../site/content/en/docs/Guides/metr
 
 See [`make minikube-setup-prometheus`](#make-minikube-setup-prometheus) and [`make kind-setup-prometheus`](#make-kind-setup-prometheus) to run the installation on Minikube or Kind.
 
+#### make helm-repo-update
+
+Run helm repo update to get the mose recent charts.
+
 #### `make setup-grafana`
 
 Install Gafrana server using [stable/grafana](https://github.com/helm/charts/tree/master/stable/grafana) chart into the current cluster and setup [Agones dashboards with Prometheus datasource](./grafana/).

--- a/build/grafana.yaml
+++ b/build/grafana.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 service:
   port: 3000
 tolerations:

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -179,7 +179,7 @@ Now let's install some Grafana dashboards.
 
 ### Grafana installation
 
-Grafana is a open source time series analytics platform which supports Prometheus data source. We can also install easily import pre-built dashboards.
+Grafana is a open source time series analytics platform which supports Prometheus data source. We can also easily import pre-built dashboards.
 
 First we will install [Agones dashboard](#grafana-dashboards) as [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) in our cluster.
 
@@ -190,8 +190,8 @@ kubectl apply -f ./build/grafana/
 Now we can install [grafana chart](https://github.com/helm/charts/tree/master/stable/grafana) from stable repository. (Replace `<your-admin-password>` with the admin password of your choice)
 
 ```bash
-helm install --wait --name grafana stable/grafana --namespace metrics \
-  --set adminPassword=<your-admin-password> -f ../build/grafana.yaml
+helm install --wait --name grafana stable/grafana --version=5.0.11 --namespace metrics \
+  --set adminPassword=<your-admin-password> -f ./build/grafana.yaml
 ```
 
 This will install Grafana with our prepopulated dashboards and prometheus datasource [previously installed](#prometheus-installation)

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -190,7 +190,7 @@ kubectl apply -f ./build/grafana/
 Now we can install [grafana chart](https://github.com/helm/charts/tree/master/stable/grafana) from stable repository. (Replace `<your-admin-password>` with the admin password of your choice)
 
 ```bash
-helm install --wait --name grafana stable/grafana --version=5.0.11 --namespace metrics \
+helm install --wait --name grafana stable/grafana --version=5.0.13 --namespace metrics \
   --set adminPassword=<your-admin-password> -f ./build/grafana.yaml
 ```
 


### PR DESCRIPTION
Set Grafana version to the docs.
Add new make target `helm-repo-update`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:
User can install previous version of the Grafana 6.2 which does not support new `GameServers` dashboard. This could lead to an error, which is hard to debug (but this error caused by missing `bargauge`):
```
undefined is not iterable (cannot read property Symbol(Symbol.iterator)) in grafana
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Leftover of #1465.
Met in #1479.

**Special notes for your reviewer**:

<img width="1344" alt="BarGauge" src="https://user-images.githubusercontent.com/5626814/80093079-8aceeb00-856c-11ea-9407-ebcf90f42fe9.png">

