### PR TITLE
Add PlayerTracking IDs to SDK Convert function

### DIFF
--- a/pkg/sdkserver/sdk.go
+++ b/pkg/sdkserver/sdk.go
@@ -72,6 +72,7 @@ func convert(gs *agonesv1.GameServer) *sdk.GameServer {
 			result.Status.Players = &sdk.GameServer_Status_PlayerStatus{
 				Count:    gs.Status.Players.Count,
 				Capacity: gs.Status.Players.Capacity,
+				IDs:      gs.Status.Players.IDs,
 			}
 		}
 	}

--- a/pkg/sdkserver/sdk_test.go
+++ b/pkg/sdkserver/sdk_test.go
@@ -94,13 +94,14 @@ func TestConvert(t *testing.T) {
 		assert.NoError(t, runtime.ParseFeatures(string(runtime.FeaturePlayerTracking)+"=true"))
 
 		gs := fixture.DeepCopy()
-		gs.Status.Players = &agonesv1.PlayerStatus{Capacity: 10, Count: 5}
+		gs.Status.Players = &agonesv1.PlayerStatus{Capacity: 10, Count: 5, IDs: []string{"one", "two"}}
 
 		sdkGs := convert(gs)
 		eq(t, fixture, sdkGs)
 		assert.Zero(t, sdkGs.ObjectMeta.DeletionTimestamp)
 		assert.Equal(t, gs.Status.Players.Capacity, sdkGs.Status.Players.Capacity)
 		assert.Equal(t, gs.Status.Players.Count, sdkGs.Status.Players.Count)
+		assert.Equal(t, gs.Status.Players.IDs, sdkGs.Status.Players.IDs)
 	})
 
 	t.Run("DeletionTimestamp", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

When converting from CRD->gRPC model for SDK.GetGameServer(), add the Player Tracking IDs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #1033

**Special notes for your reviewer**:

None