### PR TITLE
Local SDK wasn't loading referenced file

### DIFF
--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -174,7 +174,8 @@ func main() {
 func registerLocal(grpcServer *grpc.Server, ctlConf config) (func(), error) {
 	filePath := ""
 	if ctlConf.LocalFile != "" {
-		filePath, err := filepath.Abs(ctlConf.LocalFile)
+		var err error
+		filePath, err = filepath.Abs(ctlConf.LocalFile)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Subtle bug in variable assignment caused the sdk server to not load a
GameServer yaml when passed in.

**Which issue(s) this PR fixes**:

Closes #1508

**Special notes for your reviewer**:

None