### PR TITLE
Unity SDK: Fix SpecHealth parsing

### DIFF
--- a/sdks/unity/model/SpecHealth.cs
+++ b/sdks/unity/model/SpecHealth.cs
@@ -29,10 +29,13 @@ namespace Agones.Model
         /// </summary>
         public SpecHealth(IReadOnlyDictionary<string, object> data)
         {
-            this.Disabled = data.TryGetValue("disabled", out var disabled) && (bool)disabled;
-            this.PeriodSeconds = (Int64) data["period_seconds"];
-            this.FailureThreshold = (Int64) data["failure_threshold"];
-            this.InitialDelaySeconds = (Int64) data["initial_delay_seconds"];
+            this.Disabled = data.TryGetValue("disabled", out var disabled) && bool.Parse((string)disabled);
+            if (!this.Disabled)
+            {
+                this.PeriodSeconds = (Int64)data["period_seconds"];
+                this.FailureThreshold = (Int64)data["failure_threshold"];
+                this.InitialDelaySeconds = (Int64)data["initial_delay_seconds"];
+            }
         }
 
         public bool Disabled { get; }

--- a/sdks/unity/model/SpecHealth.cs
+++ b/sdks/unity/model/SpecHealth.cs
@@ -29,7 +29,7 @@ namespace Agones.Model
         /// </summary>
         public SpecHealth(IReadOnlyDictionary<string, object> data)
         {
-            this.Disabled = data.TryGetValue("disabled", out var disabled) && bool.Parse((string)disabled);
+            this.Disabled = data.TryGetValue("disabled", out var disabled) && (bool)disabled;
             if (!this.Disabled)
             {
                 this.PeriodSeconds = (Int64)data["period_seconds"];

--- a/sdks/unity/model/SpecHealth.cs
+++ b/sdks/unity/model/SpecHealth.cs
@@ -29,7 +29,7 @@ namespace Agones.Model
         /// </summary>
         public SpecHealth(IReadOnlyDictionary<string, object> data)
         {
-            this.Disabled = data.TryGetValue("disabled", out var disabled) && bool.Parse((string) disabled);
+            this.Disabled = data.TryGetValue("disabled", out var disabled) && (bool)disabled;
             this.PeriodSeconds = (Int64) data["period_seconds"];
             this.FailureThreshold = (Int64) data["failure_threshold"];
             this.InitialDelaySeconds = (Int64) data["initial_delay_seconds"];


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
>
> /kind breaking

/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Fix type cast error in Unity SDK when parsing SpecHealth

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
None

**Special notes for your reviewer**:

The issue occurs only when health check is disabled.
`disabled` value is already type of `bool` (boxed), thus casting it to `string` causes `InvalidCastException`