### PR TITLE
Fix allocator service tls auth for C# client and add a C# sample

### DIFF
--- a/examples/allocator-client-csharp/Program.cs
+++ b/examples/allocator-client-csharp/Program.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using Grpc.Core;
+using V1Alpha1;
+using System.Net.Http;
+
+namespace AllocatorClient
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            if (args.Length < 6) {
+                throw new Exception("Arguments are missing. Expecting: <private key> <public key> <server CA> <external IP> <namepace> <enable multi-cluster>");
+            }
+
+            string clientKey    = File.ReadAllText(args[0]);
+            string clientCert   = File.ReadAllText(args[1]);
+            string serverCa     = File.ReadAllText(args[2]);
+            string externalIp   = args[3];
+            string namespaceArg = args[4];
+            bool   multicluster = bool.Parse(args[5]);
+
+            var creds = new SslCredentials(serverCa, new KeyCertificatePair(clientCert, clientKey));
+            var channel = new Channel(externalIp + ":443", creds);
+            var client = new AllocationService.AllocationServiceClient(channel);
+
+           try {
+                var response = await client.AllocateAsync(new AllocationRequest { 
+                    Namespace = namespaceArg,
+                    MultiClusterSetting = new V1Alpha1.MultiClusterSetting {
+                        Enabled = multicluster,
+                    }
+                });
+                Console.WriteLine(response);
+            } 
+            catch(RpcException e)
+            {
+                Console.WriteLine($"gRPC error: {e}");
+            }
+        }
+    }
+}

--- a/examples/allocator-client-csharp/README.md
+++ b/examples/allocator-client-csharp/README.md
@@ -1,0 +1,19 @@
+# A sample Allocator service C# client
+
+This sample serves as a gRPC C# client sample code for agones-allocator gRPC service.
+
+Follow instructions in [Allocator Service](https://agones.dev/site/docs/advanced/allocator-service) to set up client and server certificate.
+
+Run the following to allocate a game server:
+```
+#!/bin/bash
+
+NAMESPACE=default # replace with any namespace
+EXTERNAL_IP=`kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+KEY_FILE=client.key
+CERT_FILE=client.crt
+TLS_CA_FILE=ca.crt
+MULTICLUSTER_ENABLED=false
+
+dotnet run $KEY_FILE $CERT_FILE $TLS_CA_FILE $EXTERNAL_IP $NAMESPACE $MULTICLUSTER_ENABLED
+```

--- a/examples/allocator-client-csharp/allocator-client-csharp.csproj
+++ b/examples/allocator-client-csharp/allocator-client-csharp.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>AllocatorClient</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Api.CommonProtos" Version="1.7.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
+    <PackageReference Include="Grpc" Version="2.26.0" />
+    <PackageReference Include="Grpc.Core" Version="2.26.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.26.0" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="allocation.proto" ProtoRoot="../../proto/allocation/v1alpha1;../../proto/googleapis" GrpcServices="Client"/>
+  </ItemGroup>
+</Project>

--- a/examples/allocator-client/main.go
+++ b/examples/allocator-client/main.go
@@ -34,7 +34,7 @@ func main() {
 	cacertFile := flag.String("cacert", "missing cacert", "the CA cert file for server signing certificate in PEM format")
 	externalIP := flag.String("ip", "missing external IP", "the external IP for allocator server")
 	namespace := flag.String("namespace", "default", "the game server kubernetes namespace")
-	multicluster := flag.Bool("multicluster", false, "enabling")
+	multicluster := flag.Bool("multicluster", false, "set to true to enable the multi-cluster allocation")
 
 	flag.Parse()
 

--- a/site/content/en/docs/Advanced/allocator-service.md
+++ b/site/content/en/docs/Advanced/allocator-service.md
@@ -115,7 +115,14 @@ kubectl get pods -n agones-system -o=name | grep agones-allocator | xargs kubect
 
 ## Send allocation request
 
+{{% feature expiryVersion="1.6.0" %}}
 Now the service is ready to accept requests from the client with the generated certificates. Create a [fleet](https://agones.dev/site/docs/getting-started/create-fleet/#1-create-a-fleet) and send a gRPC request to agones-allocator by providing the namespace to which the fleet is deployed. You can find the gRPC sample for sending allocation request at {{< ghlink href="examples/allocator-client/main.go" >}}allocator-client sample{{< /ghlink >}}.
+{{% /feature %}}
+
+{{% feature publishVersion="1.6.0" %}}
+Now the service is ready to accept requests from the client with the generated certificates. Create a [fleet](https://agones.dev/site/docs/getting-started/create-fleet/#1-create-a-fleet) and send a gRPC request to agones-allocator. To start, take a look at the allocation gRPC client examples in {{< ghlink href="examples/allocator-client/main.go" >}}golang{{< /ghlink >}} and {{< ghlink href="examples/allocator-client-csharp/Program.cs" >}}C#{{< /ghlink >}} languages. In the following, the {{< ghlink href="examples/allocator-client/main.go" >}}golang gRPC client example{{< /ghlink >}} is used to allocate a Game Server in the default namespace.
+{{% /feature %}}
+
 
 ```bash
 #!/bin/bash


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
C# client cannot talk to agone-allocator service due to language incompatibility for handling mTLS. Changed the mTLS handling to custom verify client certificate.

Also, added C# client sample code that is compatible with the golang gRPC server.

**Which issue(s) this PR fixes**:
Closes https://github.com/googleforgames/agones/issues/1421


