### PR TITLE
Helm: add ping HTTP and UDP annotations into chart

### DIFF
--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -95,6 +95,10 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.agones.ping.http.annotations }}
+  annotations:
+{{ toYaml .Values.agones.ping.http.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     agones.dev/role: ping
@@ -119,6 +123,10 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.agones.ping.udp.annotations }}
+  annotations:
+{{ toYaml .Values.agones.ping.udp.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     agones.dev/role: ping

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -25,6 +25,10 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.agones.allocator.http.annotations }}
+  annotations:
+{{ toYaml .Values.agones.allocator.http.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     multicluster.agones.dev/role: allocator

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -124,6 +124,7 @@ agones:
     http:
       port: 443
       serviceType: LoadBalancer
+      annotations: {}
     generateTLS: true
   image:
     registry: gcr.io/agones-images

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -88,11 +88,13 @@ agones:
       response: ok
       port: 80
       serviceType: LoadBalancer
+      annotations: {}
     udp:
       expose: true
       rateLimit: 20
       port: 50000
       serviceType: LoadBalancer
+      annotations: {}
     healthCheck:
       initialDelaySeconds: 3
       periodSeconds: 3


### PR DESCRIPTION
Add ability to change Ping service annotations.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Add an ability to set annotations for UDP and HTTP Ping services.
helm upgrade --install agones ./install/helm/agones/ --set agones.ping.http.annotations."external-dns\.alpha\.kubernetes\.io/hostname"="agones-http-ping\.example\.com"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1491

**Special notes for your reviewer**:


