### PR TITLE
Fix broken Fuzz Roundtrip tests in 1.15

### DIFF
--- a/pkg/apis/agones/v1/fuzz_test/roundtrip_test.go
+++ b/pkg/apis/agones/v1/fuzz_test/roundtrip_test.go
@@ -14,6 +14,7 @@ import (
 	genericfuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestRoundTripTypes(t *testing.T) {
@@ -28,7 +29,22 @@ func TestRoundTripTypes(t *testing.T) {
 	}
 	seed := rand.Int63()
 	localFuzzer := fuzzer.FuzzerFor(genericfuzzer.Funcs, rand.NewSource(seed), codecs)
-
 	assert.NoError(t, localSchemeBuilder.AddToScheme(scheme))
-	roundtrip.RoundTripExternalTypes(t, scheme, codecs, localFuzzer, nil)
+
+	var globalNonRoundTrippableTypes = sets.NewString(
+		"ExportOptions",
+		"GetOptions",
+		"WatchEvent",
+		"ListOptions",
+		"DeleteOptions",
+	)
+	kinds := scheme.AllKnownTypes()
+	for gvk := range kinds {
+		if gvk.Version == runtime.APIVersionInternal || globalNonRoundTrippableTypes.Has(gvk.Kind) {
+			continue
+		}
+		t.Run(gvk.Group+"."+gvk.Version+"."+gvk.Kind, func(t *testing.T) {
+			roundtrip.RoundTripSpecificKindWithoutProtobuf(t, gvk, scheme, codecs, localFuzzer, nil)
+		})
+	}
 }


### PR DESCRIPTION
Fix for errors like:
GameServerSet does not implement the protobuf marshalling interface.
There exist a function RoundTripExternalTypesWithoutProtobuf() which do
the same but it not available in 1.15.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

/kind hotfix

**What this PR does / Why we need it**:
Kubernetes version 1.15 enabled Protobuf codecs in Roundtrip tests. More details here.
This PR would return disable Protobuf checks as it was in 1.14. 
https://github.com/googleforgames/agones/issues/1478#issuecomment-625807835

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
For #1478

**Special notes for your reviewer**:
There could be some other ways to fix this. With this fix at lest we would not loose the tests which was prior to the update to 1.15.


