### PR TITLE
Fix small typo in comments

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -340,22 +340,22 @@ build-controller-image: $(ensure-build-image) build-controller-binary build-lice
 push-controller-image: $(ensure-build-image)
 	docker push $(controller_tag)
 
-# build the static binary for the gamesever sidecar
+# build the static binary for the gameserver sidecar
 build-agones-sdk-binary: $(ensure-build-image) build-agones-sdk-binary-linux build-agones-sdk-binary-windows build-agones-sdk-binary-darwin
 	$(ZIP_SDK) \
 		agonessdk-server-$(VERSION).zip sdk-server.darwin.amd64 sdk-server.linux.amd64 sdk-server.windows.amd64.exe
 
-# build the static binary for the gamesever sidecar for Linux
+# build the static binary for the gameserver sidecar for Linux
 build-agones-sdk-binary-linux: $(ensure-build-image)
 	$(GO_BUILD_LINUX_AMD64) \
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.linux.amd64 $(go_rebuild_flags) $(go_version_flags) -installsuffix cgo $(agones_package)/cmd/sdk-server
 
-# build the static binary for the gamesever sidecar for Darwin (macOS)
+# build the static binary for the gameserver sidecar for Darwin (macOS)
 build-agones-sdk-binary-darwin: $(ensure-build-image)
 	$(GO_BUILD_DARWIN_AMD64) \
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.darwin.amd64 $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server
 
-# build the windows binary for the gamesever sidecar for Windows
+# build the windows binary for the gameserver sidecar for Windows
 build-agones-sdk-binary-windows: $(ensure-build-image)
 	$(GO_BUILD_WINDOWS_AMD64) \
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server

--- a/pkg/apis/agones/v1/gameserverset.go
+++ b/pkg/apis/agones/v1/gameserverset.go
@@ -116,7 +116,7 @@ func (gsSet *GameServerSet) GetGameServerSpec() *GameServerSpec {
 }
 
 // GameServer returns a single GameServer derived
-// from the GameSever template
+// from the GameServer template
 func (gsSet *GameServerSet) GameServer() *GameServer {
 	gs := &GameServer{
 		ObjectMeta: *gsSet.Spec.Template.ObjectMeta.DeepCopy(),

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -441,7 +441,7 @@ func (c *Allocator) ListenAndAllocate(updateWorkerCount int, stop <-chan struct{
 	// Once we have 1 or more requests in c.pendingRequests (which is buffered to 100), we can start the batch process.
 
 	// Assuming this is the first run (either entirely, or for a while), list will be nil, and therefore the first
-	// thing that will be done is retrieving the Ready GameSerers and sorting them for this batch via
+	// thing that will be done is retrieving the Ready GameServers and sorting them for this batch via
 	// c.listSortedReadyGameServers(). This list is maintained as we flow through the batch.
 
 	// We then use findGameServerForAllocation to loop around the sorted list of Ready GameServers to look for matches

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -234,7 +234,7 @@ func (c *Controller) creationMutationHandler(review admv1beta1.AdmissionReview) 
 
 	newGS, err := json.Marshal(gs)
 	if err != nil {
-		return review, errors.Wrapf(err, "error marshalling default applied GameSever %s to json", gs.ObjectMeta.Name)
+		return review, errors.Wrapf(err, "error marshalling default applied GameServer %s to json", gs.ObjectMeta.Name)
 	}
 
 	patch, err := jsonpatch.CreatePatch(obj.Raw, newGS)

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -162,7 +162,7 @@ func (hc *HealthController) loggerForGameServer(gs *agonesv1.GameServer) *logrus
 	return hc.loggerForGameServerKey(gsName).WithField("gs", gs)
 }
 
-// syncGameServer sets the GameSerer to Unhealthy, if its state is Ready
+// syncGameServer sets the GameServer to Unhealthy, if its state is Ready
 func (hc *HealthController) syncGameServer(key string) error {
 	hc.loggerForGameServerKey(key).Debug("Synchronising")
 

--- a/site/content/en/docs/FAQ/_index.md
+++ b/site/content/en/docs/FAQ/_index.md
@@ -84,8 +84,8 @@ server binary at Allocation time, through Agones functionality.
 The Agones game server SDK allows you to set custom 
 [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) 
 and [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) through 
-the [SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/rest.md#setlabel-key-value" >}}) 
-and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/rest.md#setannotation-key-value" >}}) functionality
+the [SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-label-key-value" >}}) 
+and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-annotation-key-value" >}}) functionality
 respectively.
 
 This information is then queryable via the [Kubernetes API]({{< ref "/docs/Guides/access-api.md" >}}), 
@@ -94,8 +94,8 @@ and can be used for game specific, custom integrations.
 ### If my game server requires more states than what Agones provides (e.g. Ready, Allocated, Shutdown, etc), can I add my own? 
 
 If you want to track custom game server states, then you can utilise the game server client SDK
-[SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/rest.md#setlabel-key-value" >}}) 
-and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/rest.md#setannotation-key-value" >}}) functionality to
+[SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-label" >}}) 
+and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-annotation" >}}) functionality to
 expose these custom states to outside systems via your own labels and annotations.
 
 This information is then queryable via the [Kubernetes API]({{< ref "/docs/Guides/access-api.md" >}}), and 

--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -53,7 +53,7 @@ $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:${AG
 ```
 
 ### Health
-Send a Empty every d Duration to declare that this GameSever is healthy
+Send a Empty every d Duration to declare that this GameServer is healthy
 
 - Path: `/health`
 - Method: `POST`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->
There was a typos in GameServer term.

One more could be found in proto. This would go into another PR. https://github.com/googleforgames/agones/blob/3bb4e1fe40e587a4ec104e16b8d80e3b902b2885/proto/sdk/sdk.proto#L47-L48

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

 /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


