### PR TITLE
Faq links point to wrong place

### DIFF
--- a/site/content/en/docs/FAQ/_index.md
+++ b/site/content/en/docs/FAQ/_index.md
@@ -84,8 +84,8 @@ server binary at Allocation time, through Agones functionality.
 The Agones game server SDK allows you to set custom 
 [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) 
 and [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) through 
-the [SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-label-key-value" >}}) 
-and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-annotation-key-value" >}}) functionality
+the [SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabel-key-value" >}}) 
+and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/_index.md#setannotation-key-value" >}}) functionality
 respectively.
 
 This information is then queryable via the [Kubernetes API]({{< ref "/docs/Guides/access-api.md" >}}), 
@@ -94,8 +94,8 @@ and can be used for game specific, custom integrations.
 ### If my game server requires more states than what Agones provides (e.g. Ready, Allocated, Shutdown, etc), can I add my own? 
 
 If you want to track custom game server states, then you can utilise the game server client SDK
-[SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-label" >}}) 
-and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/rest.md#set-annotation" >}}) functionality to
+[SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabel-key-value" >}}) 
+and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/_index.md#setannotation-key-value" >}}) functionality to
 expose these custom states to outside systems via your own labels and annotations.
 
 This information is then queryable via the [Kubernetes API]({{< ref "/docs/Guides/access-api.md" >}}), and 
@@ -156,7 +156,7 @@ We routinely see users running container images that are multiple GB in size.
 The only downside to larger images, is that they can take longer to first load on a Kubernetes node, but that can be
 managed by your 
 [Fleet]({{< ref "/docs/Reference/fleet.md" >}}) and 
-[Fleet Autoscaling]({{< ref "/docs/Reference/fleetautoscaler.md" >}})
+[Fleet Autoscaling]({{< ref "/docs/Reference/fleetautoscaler.md" >}}
 configuration to ensure this load time is taken into account on a new Node's container initial load.
 
 ### How quickly can Agones spin up new GameServer instances?


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Not sure how this passed in the first place, but the FAQ links should
points to the SDK, not REST API.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None