### PR TITLE
Fix Local SDK nil Players with test

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -126,9 +126,10 @@ ensure-build-sdk-image:
 # SDK client test against it. Useful for test development
 run-sdk-conformance-local: TIMEOUT ?= 30
 run-sdk-conformance-local: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
+run-sdk-conformance-local: FEATURE_GATES ?=
 run-sdk-conformance-local: ensure-agones-sdk-image
 	docker run -e "ADDRESS=" -p 9357:9357 -p 9358:9358 \
-	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" $(sidecar_tag)
+	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" -e "FEATURE_GATES=$(FEATURE_GATES)" $(sidecar_tag)
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
 # Sleeps the start of the sidecar to test that the SDK blocks on connection correctly

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -134,6 +134,9 @@ func NewLocalSDKServer(filePath string) (*LocalSDKServer, error) {
 			l.logger.WithError(err).WithField("filePath", filePath).Error("error adding watcher")
 		}
 	}
+	if runtime.FeatureEnabled(runtime.FeaturePlayerTracking) && l.gs.Status.Players == nil {
+		l.gs.Status.Players = &sdk.GameServer_Status_PlayerStatus{}
+	}
 
 	go func() {
 		for value := range l.update {
@@ -197,8 +200,14 @@ func (l *LocalSDKServer) recordRequestWithValue(request string, value string, ob
 		case "UID":
 			fieldVal = l.gs.ObjectMeta.Uid
 		case "PlayerCapacity":
+			if !runtime.FeatureEnabled(runtime.FeaturePlayerTracking) {
+				return
+			}
 			fieldVal = strconv.FormatInt(l.gs.Status.Players.Capacity, 10)
 		case "PlayerIDs":
+			if !runtime.FeatureEnabled(runtime.FeaturePlayerTracking) {
+				return
+			}
 			fieldVal = strings.Join(l.gs.Status.Players.Ids, ",")
 		default:
 			l.logger.Error("unexpected Field to compare")

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -91,10 +91,9 @@ type LocalSDKServer struct {
 
 // NewLocalSDKServer returns the default LocalSDKServer
 func NewLocalSDKServer(filePath string) (*LocalSDKServer, error) {
-	gs := defaultGs()
 	l := &LocalSDKServer{
 		gsMutex:         sync.RWMutex{},
-		gs:              gs,
+		gs:              defaultGs(),
 		update:          make(chan struct{}),
 		updateObservers: sync.Map{},
 		testMutex:       sync.Mutex{},

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -40,8 +40,10 @@ var (
 	_ sdk.SDKServer   = &LocalSDKServer{}
 	_ alpha.SDKServer = &LocalSDKServer{}
 	_ beta.SDKServer  = &LocalSDKServer{}
+)
 
-	defaultGs = &sdk.GameServer{
+func defaultGs() *sdk.GameServer {
+	return &sdk.GameServer{
 		ObjectMeta: &sdk.GameServer_ObjectMeta{
 			Name:              "local",
 			Namespace:         "default",
@@ -66,7 +68,7 @@ var (
 			Ports:   []*sdk.GameServer_Status_Port{{Name: "default", Port: 7777}},
 		},
 	}
-)
+}
 
 // LocalSDKServer type is the SDKServer implementation for when the sidecar
 // is being run for local development, and doesn't connect to the
@@ -89,9 +91,10 @@ type LocalSDKServer struct {
 
 // NewLocalSDKServer returns the default LocalSDKServer
 func NewLocalSDKServer(filePath string) (*LocalSDKServer, error) {
+	gs := defaultGs()
 	l := &LocalSDKServer{
 		gsMutex:         sync.RWMutex{},
-		gs:              defaultGs,
+		gs:              gs,
 		update:          make(chan struct{}),
 		updateObservers: sync.Map{},
 		testMutex:       sync.Mutex{},

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -333,13 +333,14 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 	defer runtime.FeatureTestMutex.Unlock()
 	assert.NoError(t, runtime.ParseFeatures(string(runtime.FeaturePlayerTracking)+"=true"))
 
-	fixture := &agonesv1.GameServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "stuff"},
-		Status: agonesv1.GameServerStatus{
-			Players: &agonesv1.PlayerStatus{
-				Capacity: 1,
-			},
-		},
+	gs := func() *agonesv1.GameServer {
+		return &agonesv1.GameServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "stuff"},
+			Status: agonesv1.GameServerStatus{
+				Players: &agonesv1.PlayerStatus{
+					Capacity: 1,
+				},
+			}}
 	}
 
 	e := &alpha.Empty{}
@@ -352,12 +353,12 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 	}{
 		"test mode on, gs with Status.Players": {
 			testMode: true,
-			gs:       fixture.DeepCopy(),
+			gs:       gs(),
 			useFile:  true,
 		},
 		"test mode off, gs with Status.Players": {
 			testMode: false,
-			gs:       fixture.DeepCopy(),
+			gs:       gs(),
 			useFile:  true,
 		},
 		"test mode on, gs without Status.Players": {

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -395,13 +395,6 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 			assert.Nil(t, err)
 			l.SetTestMode(v.testMode)
 
-			if !v.useFile || v.gs == nil {
-				_, err := l.SetPlayerCapacity(context.Background(), &alpha.Count{
-					Count: 1,
-				})
-				assert.NoError(t, err)
-			}
-
 			stream := newGameServerMockStream()
 			go func() {
 				err := l.WatchGameServer(&sdk.Empty{}, stream)
@@ -418,6 +411,19 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 				return found, nil
 			})
 			assert.NoError(t, err)
+
+			if !v.useFile || v.gs == nil {
+				_, err := l.SetPlayerCapacity(context.Background(), &alpha.Count{
+					Count: 1,
+				})
+				assert.NoError(t, err)
+				expected := &sdk.GameServer_Status_PlayerStatus{
+					Capacity: 1,
+				}
+				assertWatchUpdate(t, stream, expected, func(gs *sdk.GameServer) interface{} {
+					return gs.Status.Players
+				})
+			}
 
 			id := &alpha.PlayerID{PlayerID: "one"}
 			ok, err := l.IsPlayerConnected(context.Background(), id)

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -373,9 +373,9 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 			testMode: true,
 			useFile:  false,
 		},
-		"test mode off, use filePath": {
+		"test mode off, no filePath": {
 			testMode: false,
-			useFile:  true,
+			useFile:  false,
 		},
 	}
 
@@ -395,7 +395,7 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 			assert.Nil(t, err)
 			l.SetTestMode(v.testMode)
 
-			if !v.useFile {
+			if !v.useFile || v.gs == nil {
 				_, err := l.SetPlayerCapacity(context.Background(), &alpha.Count{
 					Count: 1,
 				})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature

/kind hotfix

**What this PR does / Why we need it**:
There was a situation when additional call in testMode leads to
SegFault, a call when gs.Status.Players is nil. Added tests for different situations with and without files.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

**Special notes for your reviewer**:


