### PR TITLE
Add support for internal game server ports

### DIFF
--- a/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
@@ -64,17 +64,20 @@ properties:
             portPolicy:
               title: the port policy that will be applied to the game server
               description: |
-                  portPolicy has three options:
+                  portPolicy has four options:
                   - "Dynamic" (default) the system allocates a random free hostPort for the gameserver, for game clients to connect to
                   - "Static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
                   port is available. When static is the policy specified, `hostPort` is required to be populated
                   - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
                   This will mean that users will need to lookup what port has been opened through the server side SDK.
+                  - "Internal" means that the system won't allocate a hostPort for this port. The onus is on the user to find a way
+                  to connect players to that port, whether it be through a custom proxy or otherwise.
               type: string
               enum:
               - Dynamic
               - Static
               - Passthrough
+              - Internal
             protocol:
               title: Protocol being used. Defaults to UDP. TCP is the only other option
               type: string

--- a/pkg/apis/agones/v1/common.go
+++ b/pkg/apis/agones/v1/common.go
@@ -28,7 +28,7 @@ import (
 // Block of const Error messages
 const (
 	ErrContainerRequired        = "Container is required when using multiple containers in the pod template"
-	ErrHostPort                 = "HostPort cannot be specified with a Dynamic or Passthrough PortPolicy"
+	ErrHostPort                 = "HostPort cannot be specified with a Dynamic, Internal or Passthrough PortPolicy"
 	ErrPortPolicyStatic         = "PortPolicy must be Static"
 	ErrContainerPortRequired    = "ContainerPort must be defined for Dynamic and Static PortPolicies"
 	ErrContainerPortPassthrough = "ContainerPort cannot be specified with Passthrough PortPolicy"

--- a/pkg/gameservers/portallocator.go
+++ b/pkg/gameservers/portallocator.go
@@ -121,6 +121,9 @@ func (pa *PortAllocator) Allocate(gs *agonesv1.GameServer) *agonesv1.GameServer 
 	// Also the return gives an escape from the double loop
 	findOpenPorts := func(amount int) []pn {
 		var ports []pn
+		if amount == 0 {
+			return ports
+		}
 		for _, n := range pa.portAllocations {
 			for p, taken := range n {
 				if !taken {

--- a/pkg/gameservers/portallocator_test.go
+++ b/pkg/gameservers/portallocator_test.go
@@ -106,6 +106,15 @@ func TestPortAllocatorAllocate(t *testing.T) {
 		assert.Equal(t, gsCopy.Spec.Ports[0].HostPort, gsCopy.Spec.Ports[0].ContainerPort)
 		assert.Nil(t, err)
 		assert.Equal(t, 11, countTotalAllocatedPorts(pa))
+
+		// single port, internal
+		gsCopy = fixture.DeepCopy()
+		gsCopy.Spec.Ports[0] = agonesv1.GameServerPort{Name: "internal", PortPolicy: agonesv1.Internal}
+		assert.Len(t, gsCopy.Spec.Ports, 1)
+		pa.Allocate(gsCopy)
+		assert.Empty(t, gsCopy.Spec.Ports[0].HostPort)
+		assert.Nil(t, err)
+		assert.Equal(t, 11, countTotalAllocatedPorts(pa))
 	})
 
 	t.Run("ports are all allocated", func(t *testing.T) {

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -98,12 +98,14 @@ spec:
   ports:
     # name is a descriptive name for the port
   - name: default
-    # portPolicy has three options:
+    # portPolicy has four options:
     # - "Dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
     # - "Static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
     # port is available. When static is the policy specified, `hostPort` is required to be populated
     # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
     #      This will mean that users will need to lookup what port has been opened through the server side SDK.
+    # - "Internal" means that the system won't allocate a hostPort for this port. The onus is on the user to find a way
+    # to connect players to that port, whether it be through a custom proxy or otherwise.
     portPolicy: Static
     # (Alpha) the name of the container to open the port on. Defaults to the game server container if omitted or empty.
     container: simple-udp
@@ -201,6 +203,7 @@ The `spec` field is the actual GameServer specification and it is composed as fo
         - `Dynamic` (default) the system allocates a random free hostPort for the gameserver, for game clients to connect to.
         - `Static`, user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the port is available. When static is the policy specified, `hostPort` is required to be populated.
         - `Passthrough` dynamically sets the `containerPort`  to the same value as the dynamically selected hostPort. This will mean that users will need to lookup what port to open through the server side SDK before starting communications.
+        - `Internal` means that the system wont allocate a hostPort for this port. The onus is on the user to find a way to connect players to that port, whether it be through a custom proxy or otherwise.
   - `container` (Alpha) the name of the container to open the port on. Defaults to the game server container if omitted or empty.
   - `containerPort` the port that is being opened on the game server process, this is a required field for `Dynamic` and `Static` port policies, and should not be included in <code>Passthrough</code> configuration.
   - `protocol` the protocol being used. Defaults to UDP. TCP is the only other option.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:
This PR adds support for specifying internal only ports, which don't get assigned a hostPort by the controller. This is useful for games that really on a custom proxy solution that sits in front of the game servers (minecraft servers are a big case for this kind of setup) and having the container port expose could open a security hole (eg: in network scenarios, minecraft authentication is happen on the proxy level, not the individual game server).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #749 

**Special notes for your reviewer**:
As stated in my last pr, I'm new to go in general so if I need to change anything to fit better with go semantics, let me know :)

