### PR TITLE
Add port flag to example allocator-client

### DIFF
--- a/examples/allocator-client/main.go
+++ b/examples/allocator-client/main.go
@@ -33,12 +33,13 @@ func main() {
 	certFile := flag.String("cert", "missing cert", "the public key file for the client certificate in PEM format")
 	cacertFile := flag.String("cacert", "missing cacert", "the CA cert file for server signing certificate in PEM format")
 	externalIP := flag.String("ip", "missing external IP", "the external IP for allocator server")
+	port := flag.String("port", "443", "the port for allocator server")
 	namespace := flag.String("namespace", "default", "the game server kubernetes namespace")
 	multicluster := flag.Bool("multicluster", false, "set to true to enable the multi-cluster allocation")
 
 	flag.Parse()
 
-	endpoint := *externalIP + ":443"
+	endpoint := *externalIP + ":" + *port
 	cert, err := ioutil.ReadFile(*certFile)
 	if err != nil {
 		panic(err)

--- a/site/content/en/docs/Advanced/allocator-service.md
+++ b/site/content/en/docs/Advanced/allocator-service.md
@@ -123,6 +123,7 @@ CERT_FILE=client.crt
 TLS_CA_FILE=ca.crt
 
 go run examples/allocator-client/main.go --ip ${EXTERNAL_IP} \
+    --port 443 \
     --namespace ${NAMESPACE} \
     --key ${KEY_FILE} \
     --cert ${CERT_FILE} \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind feature

**What this PR does / Why we need it**:
It adds the ability to specify `--port <port>` when using the allocator-client in examples/allocator-client. Without this, you can only use this allocator-client to hit allocators exposed on port 443. We expose our allocator through istio on a non-443 port, so this change is required to use the client to test our allocator.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
n/a - haven't raised a corresponding issue (but I'm happy to if required).

**Special notes for your reviewer**:
I've tested this by running `go run examples/allocator-client/main.go --ip <allocator-ip> --namespace game-scavengers --key tls.key --cert tls.crt --cacert ca.crt --port <port>` against a v1.6 allocator running in GKE, exposed on a non-443 port, and it succeeded. Let me know if you feel this needs any more testing.

