### PR TITLE
Update docs to explicitly allow specifying ca.crt in client secret instead of serverCa field for multi-cluster allocation

### DIFF
--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -386,7 +386,7 @@ func (c *Allocator) createRemoteClusterDialOption(namespace string, connectionIn
 		if len(connectionInfo.ServerCA) != 0 && !tlsConfig.RootCAs.AppendCertsFromPEM(connectionInfo.ServerCA) {
 			return nil, errors.New("only PEM format is accepted for server CA")
 		}
-		// Add client CA cert, added for backward compatibility
+		// Add client CA cert, which can be used instead of / as well as the specified ServerCA cert
 		if len(caCert) != 0 {
 			_ = tlsConfig.RootCAs.AppendCertsFromPEM(caCert)
 		}

--- a/site/content/en/docs/Advanced/multi-cluster-allocation.md
+++ b/site/content/en/docs/Advanced/multi-cluster-allocation.md
@@ -42,7 +42,7 @@ EOF
 
 To define the local cluster priority, similarly, an allocation rule should be defined, while leaving allocationEndpoints unset. If the local cluster priority is not defined, the allocation from the local cluster happens only if allocation from other clusters with the existing allocation rules is unsuccessful.
 
-`serverCa` is the server TLS CA public certificate, set only if the remote server certificate is not signed by a public CA (e.g. self-signed).
+`serverCa` is the server TLS CA public certificate, set only if the remote server certificate is not signed by a public CA (e.g. self-signed). If this field is not specified, the certificate can also be specified in the `ca.crt` field of the client secret (i.e. the secret referred to in the `secretName` field).
 
 ## Establish trust
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:
With multi-cluster allocation, we have a use-case for using the `ca.crt` field in the client secret for the server TLS CA public certificate, rather than the `serverCA` field in the custom resource (see https://github.com/googleforgames/agones/issues/1614 for details). Doing this is currently supported, but there was plan to deprecate this in future. After discussion in https://github.com/googleforgames/agones/issues/1614, it seems best to update the documentation to allow this explicitly and to not look to deprecate this flow in future.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1614

**Special notes for your reviewer**:
n/a

