### PR TITLE
Fix 404 in CRD generated documentation.

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -89,7 +89,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
 
 # install API reference docs generator
 RUN mkdir -p /go/src/github.com/ahmetb && \
-    cd /go/src/github.com/ahmetb && git clone -b v0.1.1 https://github.com/ahmetb/gen-crd-api-reference-docs && \
+    cd /go/src/github.com/ahmetb && git clone -b v0.2.0 https://github.com/ahmetb/gen-crd-api-reference-docs && \
     cd ./gen-crd-api-reference-docs && go build
 
 # html checker

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -4,3 +4,4 @@ resources/
 node_modules/
 tech-doc-hugo
 *.json
+!/assets/templates/crd-doc-config.json

--- a/site/assets/templates/crd-doc-config.json
+++ b/site/assets/templates/crd-doc-config.json
@@ -1,0 +1,28 @@
+{
+    "hideMemberFields": [
+        "TypeMeta"
+    ],
+    "hideTypePatterns": [
+        "ParseError$",
+        "List$"
+    ],
+    "externalPackages": [
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
+            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "docsURLTemplate": "https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",
+            "docsURLTemplate": "https://godoc.org/github.com/knative/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        }
+    ],
+    "typeDisplayNamePrefixOverrides": {
+        "k8s.io/api/": "Kubernetes ",
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+    },
+    "markdownDisabled": false
+}

--- a/site/assets/templates/pkg.tpl
+++ b/site/assets/templates/pkg.tpl
@@ -5,21 +5,23 @@
 <ul>
     {{ range . }}
     <li>
-        <a href="#{{- packageDisplayName . -}}">{{ packageDisplayName . }}</a>
+        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
     </li>
     {{ end }}
 </ul>
 {{ end}}
 
 {{ range .packages }}
-    <h2 id="{{- packageDisplayName . -}}">
+    <h2 id="{{- packageAnchorID . -}}">
         {{- packageDisplayName . -}}
     </h2>
 
-    {{ with .DocComments }}
-    <p>
-        {{ safe (renderComments .) }}
-    </p>
+    {{ with (index .GoPackages 0 )}}
+        {{ with .DocComments }}
+        <p>
+            {{ safe (renderComments .) }}
+        </p>
+        {{ end }}
     {{ end }}
 
     Resource Types:
@@ -27,7 +29,7 @@
     {{- range (visibleTypes (sortedTypes .Types)) -}}
         {{ if isExportedType . -}}
         <li>
-            <a href="#{{ typeIdentifier . }}">{{ typeIdentifier . }}</a>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
         </li>
         {{- end }}
     {{- end -}}

--- a/site/content/en/docs/Advanced/limiting-resources.md
+++ b/site/content/en/docs/Advanced/limiting-resources.md
@@ -19,7 +19,7 @@ Kubernetes documentation for more details on "requests" and "limits" to both CPU
 
 ## GameServers
 
-Since the `GameServer` specification provides a full [`PodSpecTemplate`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podtemplatespec-v1-core),
+Since the `GameServer` specification provides a full [`PodSpecTemplate`](https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core),
 we can take advantage of both resource limits and requests in our `GameServer` configurations. 
 
 For example, to set a CPU limit on our `GameServer` configuration of `250m/0.25` of a CPU,

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -277,7 +277,7 @@ If `GameServer.Status.Players.IDs` is set manually through the Kubernetes API, u
 or SDK.WatchGameServer() instead to list the connected players.
 {{< /alert >}}
 
-[playerstatus]: {{< ref "/docs/Reference/agones_crd_api_reference.html#PlayerStatus" >}}
+[playerstatus]: {{< ref "/docs/Reference/agones_crd_api_reference.html#agones.dev/v1.PlayerStatus" >}}
 
 ## Writing your own SDK
 

--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -310,4 +310,4 @@ Response:
 {"list":["uzh7i","3zh7i"]}
 ```
 
-[playerstatus]: {{< ref "/docs/Reference/agones_crd_api_reference.html#PlayerStatus" >}}
+[playerstatus]: {{< ref "/docs/Reference/agones_crd_api_reference.html#agones.dev/v1.PlayerStatus" >}}

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -65,7 +65,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -103,7 +103,7 @@ int32
 <td>
 <code>strategy</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#deploymentstrategy-v1-apps">
 Kubernetes apps/v1.DeploymentStrategy
 </a>
 </em>
@@ -191,7 +191,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -280,7 +280,7 @@ SdkServer
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -356,7 +356,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -503,7 +503,7 @@ int32
 <td>
 <code>strategy</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#deploymentstrategy-v1-apps">
 Kubernetes apps/v1.DeploymentStrategy
 </a>
 </em>
@@ -704,7 +704,7 @@ int32
 <td>
 <code>protocol</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#protocol-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#protocol-v1-core">
 Kubernetes core/v1.Protocol
 </a>
 </em>
@@ -943,7 +943,7 @@ SdkServer
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -1043,7 +1043,7 @@ string
 <td>
 <code>reservedUntil</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -1131,7 +1131,7 @@ int32
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -1220,7 +1220,7 @@ SdkServer
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -1505,7 +1505,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -1546,7 +1546,7 @@ Otherwise, allocation will happen locally.</p>
 <td>
 <code>required</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -1559,7 +1559,7 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <code>preferred</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 []Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -1647,7 +1647,7 @@ Otherwise, allocation will happen locally.</p>
 <td>
 <code>required</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -1660,7 +1660,7 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <code>preferred</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 []Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -1851,7 +1851,7 @@ bool
 <td>
 <code>policySelector</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -1904,7 +1904,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2349,7 +2349,7 @@ of the fleet managed by this autoscaler, as last calculated by the autoscaler</p
 <td>
 <code>lastScaleTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -2438,7 +2438,7 @@ allowed, either.</p>
 <td>
 <code>service</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicereference-v1beta1-admissionregistration">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#servicereference-v1beta1-admissionregistration">
 Kubernetes admissionregistration/v1beta1.ServiceReference
 </a>
 </em>
@@ -2512,7 +2512,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2769,31 +2769,31 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#agones.dev">agones.dev</a>
+<a href="#agones.dev%2fv1">agones.dev/v1</a>
 </li>
 <li>
-<a href="#allocation.agones.dev">allocation.agones.dev</a>
+<a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
 </li>
 <li>
-<a href="#autoscaling.agones.dev">autoscaling.agones.dev</a>
+<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
 </li>
 <li>
-<a href="#multicluster.agones.dev">multicluster.agones.dev</a>
+<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
 </li>
 </ul>
-<h2 id="agones.dev">agones.dev</h2>
+<h2 id="agones.dev/v1">agones.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#Fleet">Fleet</a>
+<a href="#agones.dev/v1.Fleet">Fleet</a>
 </li><li>
-<a href="#GameServer">GameServer</a>
+<a href="#agones.dev/v1.GameServer">GameServer</a>
 </li><li>
-<a href="#GameServerSet">GameServerSet</a>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>
 </li></ul>
-<h3 id="Fleet">Fleet
+<h3 id="agones.dev/v1.Fleet">Fleet
 </h3>
 <p>
 <p>Fleet is the data structure for a Fleet resource</p>
@@ -2827,7 +2827,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2841,7 +2841,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#FleetSpec">
+<a href="#agones.dev/v1.FleetSpec">
 FleetSpec
 </a>
 </em>
@@ -2865,7 +2865,7 @@ int32
 <td>
 <code>strategy</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#deploymentstrategy-v1-apps">
 Kubernetes apps/v1.DeploymentStrategy
 </a>
 </em>
@@ -2889,7 +2889,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>template</code></br>
 <em>
-<a href="#GameServerTemplateSpec">
+<a href="#agones.dev/v1.GameServerTemplateSpec">
 GameServerTemplateSpec
 </a>
 </em>
@@ -2905,7 +2905,7 @@ GameServerTemplateSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#FleetStatus">
+<a href="#agones.dev/v1.FleetStatus">
 FleetStatus
 </a>
 </em>
@@ -2915,7 +2915,7 @@ FleetStatus
 </tr>
 </tbody>
 </table>
-<h3 id="GameServer">GameServer
+<h3 id="agones.dev/v1.GameServer">GameServer
 </h3>
 <p>
 <p>GameServer is the data structure for a GameServer resource.
@@ -2953,7 +2953,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2967,7 +2967,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#GameServerSpec">
+<a href="#agones.dev/v1.GameServerSpec">
 GameServerSpec
 </a>
 </em>
@@ -2992,7 +2992,7 @@ container defined</p>
 <td>
 <code>ports</code></br>
 <em>
-<a href="#GameServerPort">
+<a href="#agones.dev/v1.GameServerPort">
 []GameServerPort
 </a>
 </em>
@@ -3005,7 +3005,7 @@ container defined</p>
 <td>
 <code>health</code></br>
 <em>
-<a href="#Health">
+<a href="#agones.dev/v1.Health">
 Health
 </a>
 </em>
@@ -3029,7 +3029,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>sdkServer</code></br>
 <em>
-<a href="#SdkServer">
+<a href="#agones.dev/v1.SdkServer">
 SdkServer
 </a>
 </em>
@@ -3042,7 +3042,7 @@ SdkServer
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -3055,7 +3055,7 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>players</code></br>
 <em>
-<a href="#PlayersSpec">
+<a href="#agones.dev/v1.PlayersSpec">
 PlayersSpec
 </a>
 </em>
@@ -3072,7 +3072,7 @@ PlayersSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#GameServerStatus">
+<a href="#agones.dev/v1.GameServerStatus">
 GameServerStatus
 </a>
 </em>
@@ -3082,7 +3082,7 @@ GameServerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerSet">GameServerSet
+<h3 id="agones.dev/v1.GameServerSet">GameServerSet
 </h3>
 <p>
 <p>GameServerSet is the data structure for a set of GameServers.
@@ -3118,7 +3118,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -3132,7 +3132,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#GameServerSetSpec">
+<a href="#agones.dev/v1.GameServerSetSpec">
 GameServerSetSpec
 </a>
 </em>
@@ -3167,7 +3167,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>template</code></br>
 <em>
-<a href="#GameServerTemplateSpec">
+<a href="#agones.dev/v1.GameServerTemplateSpec">
 GameServerTemplateSpec
 </a>
 </em>
@@ -3183,7 +3183,7 @@ GameServerTemplateSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#GameServerSetStatus">
+<a href="#agones.dev/v1.GameServerSetStatus">
 GameServerSetStatus
 </a>
 </em>
@@ -3193,12 +3193,12 @@ GameServerSetStatus
 </tr>
 </tbody>
 </table>
-<h3 id="AggregatedPlayerStatus">AggregatedPlayerStatus
+<h3 id="agones.dev/v1.AggregatedPlayerStatus">AggregatedPlayerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetStatus">FleetStatus</a>, 
-<a href="#GameServerSetStatus">GameServerSetStatus</a>)
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
 </p>
 <p>
 <p>AggregatedPlayerStatus stores total player tracking values</p>
@@ -3233,11 +3233,11 @@ int64
 </tr>
 </tbody>
 </table>
-<h3 id="FleetSpec">FleetSpec
+<h3 id="agones.dev/v1.FleetSpec">FleetSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Fleet">Fleet</a>)
+<a href="#agones.dev/v1.Fleet">Fleet</a>)
 </p>
 <p>
 <p>FleetSpec is the spec for a Fleet</p>
@@ -3265,7 +3265,7 @@ int32
 <td>
 <code>strategy</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#deploymentstrategy-v1-apps">
 Kubernetes apps/v1.DeploymentStrategy
 </a>
 </em>
@@ -3289,7 +3289,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>template</code></br>
 <em>
-<a href="#GameServerTemplateSpec">
+<a href="#agones.dev/v1.GameServerTemplateSpec">
 GameServerTemplateSpec
 </a>
 </em>
@@ -3300,12 +3300,12 @@ GameServerTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="FleetStatus">FleetStatus
+<h3 id="agones.dev/v1.FleetStatus">FleetStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Fleet">Fleet</a>, 
-<a href="#FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
+<a href="#agones.dev/v1.Fleet">Fleet</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
 </p>
 <p>
 <p>FleetStatus is the status of a Fleet</p>
@@ -3367,7 +3367,7 @@ int32
 <td>
 <code>players</code></br>
 <em>
-<a href="#AggregatedPlayerStatus">
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
 AggregatedPlayerStatus
 </a>
 </em>
@@ -3381,11 +3381,11 @@ Players are the current total player capacity and count for this Fleet</p>
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerPort">GameServerPort
+<h3 id="agones.dev/v1.GameServerPort">GameServerPort
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerSpec">GameServerSpec</a>)
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
 </p>
 <p>
 <p>GameServerPort defines a set of Ports that
@@ -3414,7 +3414,7 @@ string
 <td>
 <code>portPolicy</code></br>
 <em>
-<a href="#PortPolicy">
+<a href="#agones.dev/v1.PortPolicy">
 PortPolicy
 </a>
 </em>
@@ -3466,7 +3466,7 @@ int32
 <td>
 <code>protocol</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#protocol-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#protocol-v1-core">
 Kubernetes core/v1.Protocol
 </a>
 </em>
@@ -3477,11 +3477,11 @@ Kubernetes core/v1.Protocol
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerSetSpec">GameServerSetSpec
+<h3 id="agones.dev/v1.GameServerSetSpec">GameServerSetSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerSet">GameServerSet</a>)
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
 </p>
 <p>
 <p>GameServerSetSpec the specification for GameServerSet</p>
@@ -3520,7 +3520,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>template</code></br>
 <em>
-<a href="#GameServerTemplateSpec">
+<a href="#agones.dev/v1.GameServerTemplateSpec">
 GameServerTemplateSpec
 </a>
 </em>
@@ -3531,11 +3531,11 @@ GameServerTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerSetStatus">GameServerSetStatus
+<h3 id="agones.dev/v1.GameServerSetStatus">GameServerSetStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerSet">GameServerSet</a>)
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
 </p>
 <p>
 <p>GameServerSetStatus is the status of a GameServerSet</p>
@@ -3607,7 +3607,7 @@ int32
 <td>
 <code>players</code></br>
 <em>
-<a href="#AggregatedPlayerStatus">
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
 AggregatedPlayerStatus
 </a>
 </em>
@@ -3621,12 +3621,12 @@ Players are the current total player capacity and count for this GameServerSet</
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerSpec">GameServerSpec
+<h3 id="agones.dev/v1.GameServerSpec">GameServerSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServer">GameServer</a>, 
-<a href="#GameServerTemplateSpec">GameServerTemplateSpec</a>)
+<a href="#agones.dev/v1.GameServer">GameServer</a>, 
+<a href="#agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec</a>)
 </p>
 <p>
 <p>GameServerSpec is the spec for a GameServer resource</p>
@@ -3655,7 +3655,7 @@ container defined</p>
 <td>
 <code>ports</code></br>
 <em>
-<a href="#GameServerPort">
+<a href="#agones.dev/v1.GameServerPort">
 []GameServerPort
 </a>
 </em>
@@ -3668,7 +3668,7 @@ container defined</p>
 <td>
 <code>health</code></br>
 <em>
-<a href="#Health">
+<a href="#agones.dev/v1.Health">
 Health
 </a>
 </em>
@@ -3692,7 +3692,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>sdkServer</code></br>
 <em>
-<a href="#SdkServer">
+<a href="#agones.dev/v1.SdkServer">
 SdkServer
 </a>
 </em>
@@ -3705,7 +3705,7 @@ SdkServer
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -3718,7 +3718,7 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>players</code></br>
 <em>
-<a href="#PlayersSpec">
+<a href="#agones.dev/v1.PlayersSpec">
 PlayersSpec
 </a>
 </em>
@@ -3730,20 +3730,20 @@ PlayersSpec
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerState">GameServerState
+<h3 id="agones.dev/v1.GameServerState">GameServerState
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerStatus">GameServerStatus</a>)
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
 </p>
 <p>
 <p>GameServerState is the state for the GameServer</p>
 </p>
-<h3 id="GameServerStatus">GameServerStatus
+<h3 id="agones.dev/v1.GameServerStatus">GameServerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServer">GameServer</a>)
+<a href="#agones.dev/v1.GameServer">GameServer</a>)
 </p>
 <p>
 <p>GameServerStatus is the status for a GameServer resource</p>
@@ -3760,7 +3760,7 @@ PlayersSpec
 <td>
 <code>state</code></br>
 <em>
-<a href="#GameServerState">
+<a href="#agones.dev/v1.GameServerState">
 GameServerState
 </a>
 </em>
@@ -3773,7 +3773,7 @@ GameServerState
 <td>
 <code>ports</code></br>
 <em>
-<a href="#GameServerStatusPort">
+<a href="#agones.dev/v1.GameServerStatusPort">
 []GameServerStatusPort
 </a>
 </em>
@@ -3805,7 +3805,7 @@ string
 <td>
 <code>reservedUntil</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -3817,7 +3817,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>players</code></br>
 <em>
-<a href="#PlayerStatus">
+<a href="#agones.dev/v1.PlayerStatus">
 PlayerStatus
 </a>
 </em>
@@ -3830,12 +3830,12 @@ PlayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerStatusPort">GameServerStatusPort
+<h3 id="agones.dev/v1.GameServerStatusPort">GameServerStatusPort
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocationStatus">GameServerAllocationStatus</a>, 
-<a href="#GameServerStatus">GameServerStatus</a>)
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
 </p>
 <p>
 <p>GameServerStatusPort shows the port that was allocated to a
@@ -3871,12 +3871,12 @@ int32
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerTemplateSpec">GameServerTemplateSpec
+<h3 id="agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetSpec">FleetSpec</a>, 
-<a href="#GameServerSetSpec">GameServerSetSpec</a>)
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
 </p>
 <p>
 <p>GameServerTemplateSpec is a template for GameServers</p>
@@ -3893,7 +3893,7 @@ int32
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -3907,7 +3907,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#GameServerSpec">
+<a href="#agones.dev/v1.GameServerSpec">
 GameServerSpec
 </a>
 </em>
@@ -3932,7 +3932,7 @@ container defined</p>
 <td>
 <code>ports</code></br>
 <em>
-<a href="#GameServerPort">
+<a href="#agones.dev/v1.GameServerPort">
 []GameServerPort
 </a>
 </em>
@@ -3945,7 +3945,7 @@ container defined</p>
 <td>
 <code>health</code></br>
 <em>
-<a href="#Health">
+<a href="#agones.dev/v1.Health">
 Health
 </a>
 </em>
@@ -3969,7 +3969,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>sdkServer</code></br>
 <em>
-<a href="#SdkServer">
+<a href="#agones.dev/v1.SdkServer">
 SdkServer
 </a>
 </em>
@@ -3982,7 +3982,7 @@ SdkServer
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -3995,7 +3995,7 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>players</code></br>
 <em>
-<a href="#PlayersSpec">
+<a href="#agones.dev/v1.PlayersSpec">
 PlayersSpec
 </a>
 </em>
@@ -4010,11 +4010,11 @@ PlayersSpec
 </tr>
 </tbody>
 </table>
-<h3 id="Health">Health
+<h3 id="agones.dev/v1.Health">Health
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerSpec">GameServerSpec</a>)
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
 </p>
 <p>
 <p>Health configures health checking on the GameServer</p>
@@ -4073,11 +4073,11 @@ int32
 </tr>
 </tbody>
 </table>
-<h3 id="PlayerStatus">PlayerStatus
+<h3 id="agones.dev/v1.PlayerStatus">PlayerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerStatus">GameServerStatus</a>)
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
 </p>
 <p>
 <p>PlayerStatus stores the current player capacity values</p>
@@ -4122,11 +4122,11 @@ int64
 </tr>
 </tbody>
 </table>
-<h3 id="PlayersSpec">PlayersSpec
+<h3 id="agones.dev/v1.PlayersSpec">PlayersSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerSpec">GameServerSpec</a>)
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
 </p>
 <p>
 <p>PlayersSpec tracks the initial player capacity</p>
@@ -4151,20 +4151,20 @@ int64
 </tr>
 </tbody>
 </table>
-<h3 id="PortPolicy">PortPolicy
+<h3 id="agones.dev/v1.PortPolicy">PortPolicy
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerPort">GameServerPort</a>)
+<a href="#agones.dev/v1.GameServerPort">GameServerPort</a>)
 </p>
 <p>
 <p>PortPolicy is the port policy for the GameServer</p>
 </p>
-<h3 id="SdkServer">SdkServer
+<h3 id="agones.dev/v1.SdkServer">SdkServer
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerSpec">GameServerSpec</a>)
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
 </p>
 <p>
 <p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
@@ -4181,7 +4181,7 @@ int64
 <td>
 <code>logLevel</code></br>
 <em>
-<a href="#SdkServerLogLevel">
+<a href="#agones.dev/v1.SdkServerLogLevel">
 SdkServerLogLevel
 </a>
 </em>
@@ -4214,25 +4214,25 @@ int32
 </tr>
 </tbody>
 </table>
-<h3 id="SdkServerLogLevel">SdkServerLogLevel
+<h3 id="agones.dev/v1.SdkServerLogLevel">SdkServerLogLevel
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SdkServer">SdkServer</a>)
+<a href="#agones.dev/v1.SdkServer">SdkServer</a>)
 </p>
 <p>
 <p>SdkServerLogLevel is the log level for SDK server (sidecar) logs</p>
 </p>
 <hr/>
-<h2 id="allocation.agones.dev">allocation.agones.dev</h2>
+<h2 id="allocation.agones.dev/v1">allocation.agones.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#GameServerAllocation">GameServerAllocation</a>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>
 </li></ul>
-<h3 id="GameServerAllocation">GameServerAllocation
+<h3 id="allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation
 </h3>
 <p>
 <p>GameServerAllocation is the data structure for allocating against a set of
@@ -4267,7 +4267,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -4281,7 +4281,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#GameServerAllocationSpec">
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">
 GameServerAllocationSpec
 </a>
 </em>
@@ -4294,7 +4294,7 @@ GameServerAllocationSpec
 <td>
 <code>multiClusterSetting</code></br>
 <em>
-<a href="#MultiClusterSetting">
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
 MultiClusterSetting
 </a>
 </em>
@@ -4308,7 +4308,7 @@ Otherwise, allocation will happen locally.</p>
 <td>
 <code>required</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -4321,7 +4321,7 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <code>preferred</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 []Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -4347,7 +4347,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>metadata</code></br>
 <em>
-<a href="#MetaPatch">
+<a href="#allocation.agones.dev/v1.MetaPatch">
 MetaPatch
 </a>
 </em>
@@ -4364,7 +4364,7 @@ You can use this to tell the server necessary session data</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#GameServerAllocationStatus">
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">
 GameServerAllocationStatus
 </a>
 </em>
@@ -4374,11 +4374,11 @@ GameServerAllocationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerAllocationSpec">GameServerAllocationSpec
+<h3 id="allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocation">GameServerAllocation</a>)
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
 </p>
 <p>
 <p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
@@ -4395,7 +4395,7 @@ GameServerAllocationStatus
 <td>
 <code>multiClusterSetting</code></br>
 <em>
-<a href="#MultiClusterSetting">
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
 MultiClusterSetting
 </a>
 </em>
@@ -4409,7 +4409,7 @@ Otherwise, allocation will happen locally.</p>
 <td>
 <code>required</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -4422,7 +4422,7 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <code>preferred</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 []Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -4448,7 +4448,7 @@ agones.dev/agones/pkg/apis.SchedulingStrategy
 <td>
 <code>metadata</code></br>
 <em>
-<a href="#MetaPatch">
+<a href="#allocation.agones.dev/v1.MetaPatch">
 MetaPatch
 </a>
 </em>
@@ -4460,20 +4460,20 @@ You can use this to tell the server necessary session data</p>
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerAllocationState">GameServerAllocationState
+<h3 id="allocation.agones.dev/v1.GameServerAllocationState">GameServerAllocationState
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocationStatus">GameServerAllocationStatus</a>)
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
 </p>
 <p>
 <p>GameServerAllocationState is the Allocation state</p>
 </p>
-<h3 id="GameServerAllocationStatus">GameServerAllocationStatus
+<h3 id="allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocation">GameServerAllocation</a>)
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
 </p>
 <p>
 <p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
@@ -4490,7 +4490,7 @@ You can use this to tell the server necessary session data</p>
 <td>
 <code>state</code></br>
 <em>
-<a href="#GameServerAllocationState">
+<a href="#allocation.agones.dev/v1.GameServerAllocationState">
 GameServerAllocationState
 </a>
 </em>
@@ -4513,7 +4513,7 @@ string
 <td>
 <code>ports</code></br>
 <em>
-<a href="#GameServerStatusPort">
+<a href="#agones.dev/v1.GameServerStatusPort">
 []GameServerStatusPort
 </a>
 </em>
@@ -4543,11 +4543,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="MetaPatch">MetaPatch
+<h3 id="allocation.agones.dev/v1.MetaPatch">MetaPatch
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocationSpec">GameServerAllocationSpec</a>)
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
 </p>
 <p>
 <p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
@@ -4582,11 +4582,11 @@ map[string]string
 </tr>
 </tbody>
 </table>
-<h3 id="MultiClusterSetting">MultiClusterSetting
+<h3 id="allocation.agones.dev/v1.MultiClusterSetting">MultiClusterSetting
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocationSpec">GameServerAllocationSpec</a>)
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
 </p>
 <p>
 <p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
@@ -4613,7 +4613,7 @@ bool
 <td>
 <code>policySelector</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
 </a>
 </em>
@@ -4624,15 +4624,15 @@ Kubernetes meta/v1.LabelSelector
 </tbody>
 </table>
 <hr/>
-<h2 id="autoscaling.agones.dev">autoscaling.agones.dev</h2>
+<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#FleetAutoscaler">FleetAutoscaler</a>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
 </li></ul>
-<h3 id="FleetAutoscaler">FleetAutoscaler
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
 </h3>
 <p>
 <p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
@@ -4666,7 +4666,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -4680,7 +4680,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#FleetAutoscalerSpec">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
 FleetAutoscalerSpec
 </a>
 </em>
@@ -4703,7 +4703,7 @@ string
 <td>
 <code>policy</code></br>
 <em>
-<a href="#FleetAutoscalerPolicy">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
 FleetAutoscalerPolicy
 </a>
 </em>
@@ -4719,7 +4719,7 @@ FleetAutoscalerPolicy
 <td>
 <code>status</code></br>
 <em>
-<a href="#FleetAutoscalerStatus">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
 FleetAutoscalerStatus
 </a>
 </em>
@@ -4729,11 +4729,11 @@ FleetAutoscalerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="BufferPolicy">BufferPolicy
+<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
 </p>
 <p>
 <p>BufferPolicy controls the desired behavior of the buffer policy.</p>
@@ -4793,11 +4793,11 @@ capacity in the cluster etc)</p>
 </tr>
 </tbody>
 </table>
-<h3 id="FleetAutoscaleRequest">FleetAutoscaleRequest
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscaleReview">FleetAutoscaleReview</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
 </p>
 <p>
 <p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
@@ -4850,7 +4850,7 @@ string
 <td>
 <code>status</code></br>
 <em>
-<a href="#FleetStatus">
+<a href="#agones.dev/v1.FleetStatus">
 FleetStatus
 </a>
 </em>
@@ -4861,11 +4861,11 @@ FleetStatus
 </tr>
 </tbody>
 </table>
-<h3 id="FleetAutoscaleResponse">FleetAutoscaleResponse
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscaleReview">FleetAutoscaleReview</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
 </p>
 <p>
 <p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
@@ -4914,7 +4914,7 @@ int32
 </tr>
 </tbody>
 </table>
-<h3 id="FleetAutoscaleReview">FleetAutoscaleReview
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
 </h3>
 <p>
 <p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
@@ -4932,7 +4932,7 @@ and then returned with a populated Response.</p>
 <td>
 <code>request</code></br>
 <em>
-<a href="#FleetAutoscaleRequest">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
 FleetAutoscaleRequest
 </a>
 </em>
@@ -4944,7 +4944,7 @@ FleetAutoscaleRequest
 <td>
 <code>response</code></br>
 <em>
-<a href="#FleetAutoscaleResponse">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
 FleetAutoscaleResponse
 </a>
 </em>
@@ -4954,11 +4954,11 @@ FleetAutoscaleResponse
 </tr>
 </tbody>
 </table>
-<h3 id="FleetAutoscalerPolicy">FleetAutoscalerPolicy
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
 </p>
 <p>
 <p>FleetAutoscalerPolicy describes how to scale a fleet</p>
@@ -4975,7 +4975,7 @@ FleetAutoscaleResponse
 <td>
 <code>type</code></br>
 <em>
-<a href="#FleetAutoscalerPolicyType">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
 FleetAutoscalerPolicyType
 </a>
 </em>
@@ -4988,7 +4988,7 @@ FleetAutoscalerPolicyType
 <td>
 <code>buffer</code></br>
 <em>
-<a href="#BufferPolicy">
+<a href="#autoscaling.agones.dev/v1.BufferPolicy">
 BufferPolicy
 </a>
 </em>
@@ -5002,7 +5002,7 @@ BufferPolicy
 <td>
 <code>webhook</code></br>
 <em>
-<a href="#WebhookPolicy">
+<a href="#autoscaling.agones.dev/v1.WebhookPolicy">
 WebhookPolicy
 </a>
 </em>
@@ -5014,21 +5014,21 @@ WebhookPolicy
 </tr>
 </tbody>
 </table>
-<h3 id="FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
 </p>
 <p>
 <p>FleetAutoscalerPolicyType is the policy for autoscaling
 for a given Fleet</p>
 </p>
-<h3 id="FleetAutoscalerSpec">FleetAutoscalerSpec
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscaler">FleetAutoscaler</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
 </p>
 <p>
 <p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
@@ -5055,7 +5055,7 @@ string
 <td>
 <code>policy</code></br>
 <em>
-<a href="#FleetAutoscalerPolicy">
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
 FleetAutoscalerPolicy
 </a>
 </em>
@@ -5066,11 +5066,11 @@ FleetAutoscalerPolicy
 </tr>
 </tbody>
 </table>
-<h3 id="FleetAutoscalerStatus">FleetAutoscalerStatus
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscaler">FleetAutoscaler</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
 </p>
 <p>
 <p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
@@ -5111,7 +5111,7 @@ of the fleet managed by this autoscaler, as last calculated by the autoscaler</p
 <td>
 <code>lastScaleTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -5146,11 +5146,11 @@ defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="WebhookPolicy">WebhookPolicy
+<h3 id="autoscaling.agones.dev/v1.WebhookPolicy">WebhookPolicy
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
 </p>
 <p>
 <p>WebhookPolicy controls the desired behavior of the webhook policy.
@@ -5200,7 +5200,7 @@ allowed, either.</p>
 <td>
 <code>service</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicereference-v1beta1-admissionregistration">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#servicereference-v1beta1-admissionregistration">
 Kubernetes admissionregistration/v1beta1.ServiceReference
 </a>
 </em>
@@ -5228,20 +5228,16 @@ If unspecified, system trust roots on the apiserver are used.</p>
 </tbody>
 </table>
 <hr/>
-<h2 id="multicluster.agones.dev">multicluster.agones.dev</h2>
+<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#GameServerAllocationPolicy">GameServerAllocationPolicy</a>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
 </li></ul>
-<h3 id="GameServerAllocationPolicy">GameServerAllocationPolicy
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
 </h3>
-<p>
-(<em>Appears on:</em>
-<a href="#ConnectionInfoIterator">ConnectionInfoIterator</a>)
-</p>
 <p>
 <p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
 </p>
@@ -5274,7 +5270,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -5288,7 +5284,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#GameServerAllocationPolicySpec">
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
 GameServerAllocationPolicySpec
 </a>
 </em>
@@ -5321,7 +5317,7 @@ int
 <td>
 <code>connectionInfo</code></br>
 <em>
-<a href="#ClusterConnectionInfo">
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
 ClusterConnectionInfo
 </a>
 </em>
@@ -5334,11 +5330,11 @@ ClusterConnectionInfo
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterConnectionInfo">ClusterConnectionInfo
+<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
 </p>
 <p>
 <p>ClusterConnectionInfo defines the connection information for a cluster</p>
@@ -5410,7 +5406,7 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="ConnectionInfoIterator">ConnectionInfoIterator
+<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
 </h3>
 <p>
 <p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
@@ -5449,9 +5445,7 @@ int
 <td>
 <code>priorityToCluster</code></br>
 <em>
-<a href="#GameServerAllocationPolicy">
 map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
-</a>
 </em>
 </td>
 <td>
@@ -5471,11 +5465,11 @@ map[string]bool
 </tr>
 </tbody>
 </table>
-<h3 id="GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
 </p>
 <p>
 <p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
@@ -5512,7 +5506,7 @@ int
 <td>
 <code>connectionInfo</code></br>
 <em>
-<a href="#ClusterConnectionInfo">
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
 ClusterConnectionInfo
 </a>
 </em>

--- a/site/content/en/docs/Tutorials/allocator-service-go.md
+++ b/site/content/en/docs/Tutorials/allocator-service-go.md
@@ -55,7 +55,7 @@ containers:
 
 ### 2. Create Firewall Rules
 
-Let's making some [firewall](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/) rules that will be used by kubernetes health checks and the ingress which we will create shortly.
+Let's making some firewall rules that will be used by kubernetes health checks and the ingress which we will create shortly.
 
 First, we will make one for the HTTPS health checks that will be sent to our service by running:
 ```

--- a/site/gen-api-docs.sh
+++ b/site/gen-api-docs.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
+
 export GOPROXY=http://proxy.golang.org
 echo "using go proxy as a workaround for git.agache.org being down: $GOPROXY"
 
@@ -39,7 +41,7 @@ RESULT="/tmp/agones_crd_api_reference.html"
 # Version to compare
 OLD="/tmp/old_docs.html"
 
-./gen-crd-api-reference-docs --config ./example-config.json --api-dir ../../../agones.dev/agones/pkg/apis/ --out-file $RESULT
+./gen-crd-api-reference-docs --config ../../../agones.dev/agones/site/assets/templates/crd-doc-config.json --api-dir ../../../agones.dev/agones/pkg/apis/ --out-file $RESULT
 awk '/\ feature\ publishVersion/{flag=1;next}/\ \/feature/{flag=0}flag' $FILE > $OLD
 
 # Get the title lines from +++ till empty string
@@ -60,7 +62,7 @@ function sedeasy {
 }
 
 # do we have changes in generated API docs compared to previous version
-diff $RESULT $OLD
+diff $RESULT $OLD || true
 if [ $? -gt 0 ]
 then 
   echo "Output to a file $FILE"

--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -16,6 +16,7 @@ TestFilesConcurrently: false
 IgnoreInternalEmptyHash: true
 OutputDir: /go/src/agones.dev/agones/site/tmp
 OutputLogFile: .htmltest.log
+CheckExternal: true
 ExternalTimeout: 60
 IgnoreURLs:
   - http://localhost


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
Fixes blocking 404 in CI

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

- Updated gen-crd-api-reference-docs
- Added our own config to point to the version of K8s we want.
- Manually updated the older CRD ref to point to 1.15, since it doesn't
get updated automatically.
- Added the ability to the htmltest config to disable external testing,
  for easier local dev testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1617

**Special notes for your reviewer**:

None.