### PR TITLE
Fix replacement bug in gen-api-docs.sh

### DIFF
--- a/site/gen-api-docs.sh
+++ b/site/gen-api-docs.sh
@@ -62,8 +62,7 @@ function sedeasy {
 }
 
 # do we have changes in generated API docs compared to previous version
-diff $RESULT $OLD || true
-if [ $? -gt 0 ]
+if ! diff $RESULT $OLD;
 then 
   echo "Output to a file $FILE"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

I introduced a bug in #1621 that means that the publish/expiry
replacement would never happen.

This fixes that issue, while also allowing us to maintain the `set -e`
within the bash script.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
None

**Special notes for your reviewer**:
None