### PR TITLE
Fix Fleets RollingUpdate

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -59,7 +59,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/simple-game-server:0.1
 
-ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true&FixRollingUpdateScaleDown=true"
+ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true&FeatureRollingUpdateOnReady=true"
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/build/Makefile
+++ b/build/Makefile
@@ -59,7 +59,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/simple-game-server:0.1
 
-ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true&FeatureRollingUpdateOnReady=true"
+ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true&RollingUpdateOnReady=true"
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/build/Makefile
+++ b/build/Makefile
@@ -59,7 +59,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/simple-game-server:0.1
 
-ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true"
+ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true&FixRollingUpdateScaleDown=true"
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -232,7 +232,7 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true&FeatureRollingUpdateOnReady=true', 'e2e-test-cluster']
+  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true&RollingUpdateOnReady=true', 'e2e-test-cluster']
   id: e2e-feature-gates
   waitFor:
     - push-images

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -232,7 +232,7 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true&FixRollingUpdateScaleDown=true', 'e2e-test-cluster']
+  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true&FeatureRollingUpdateOnReady=true', 'e2e-test-cluster']
   id: e2e-feature-gates
   waitFor:
     - push-images

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -232,7 +232,7 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true', 'e2e-test-cluster']
+  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true&FixRollingUpdateScaleDown=true', 'e2e-test-cluster']
   id: e2e-feature-gates
   waitFor:
     - push-images

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.16.15
 	k8s.io/apimachinery v0.16.15
 	k8s.io/client-go v0.16.15
-	k8s.io/utils v0.0.0-20200124190032-861946025e34 // indirect
+	k8s.io/utils v0.0.0-20200124190032-861946025e34
 )
 
 replace google.golang.org/grpc v1.23.0 => google.golang.org/grpc v1.20.1 // apiserver updated grpc, but we aren't using that, so it's fine.

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -248,3 +248,15 @@ func SumSpecReplicas(list []*GameServerSet) int32 {
 
 	return total
 }
+
+// GetReadyReplicaCountForGameServerSets returns the total number of
+// Status.ReadyКReplicas in the list of GameServerSets
+func GetReadyReplicaCountForGameServerSets(gss []*GameServerSet) int32 {
+	totalReadyReplicas := int32(0)
+	for _, gss := range gss {
+		if gss != nil {
+			totalReadyReplicas += gss.Status.ReadyReplicas
+		}
+	}
+	return totalReadyReplicas
+}

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -238,6 +238,17 @@ func SumStatusReplicas(list []*GameServerSet) int32 {
 	return total
 }
 
+// SumSpecReplicas returns the total number of
+// Spec.Replicas in the list of GameServerSets
+func SumSpecReplicas(list []*GameServerSet) int32 {
+	total := int32(0)
+	for _, gsSet := range list {
+		total += gsSet.Spec.Replicas
+	}
+
+	return total
+}
+
 // GetReadyReplicaCountForGameServerSets returns the total number of
 // Status.ReadyReplicas in the list of GameServerSets
 func GetReadyReplicaCountForGameServerSets(gss []*GameServerSet) int32 {

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -238,19 +238,8 @@ func SumStatusReplicas(list []*GameServerSet) int32 {
 	return total
 }
 
-// SumSpecReplicas returns the total number of
-// Spec.Replicas in the list of GameServerSets
-func SumSpecReplicas(list []*GameServerSet) int32 {
-	total := int32(0)
-	for _, gsSet := range list {
-		total += gsSet.Spec.Replicas
-	}
-
-	return total
-}
-
 // GetReadyReplicaCountForGameServerSets returns the total number of
-// Status.ReadyКReplicas in the list of GameServerSets
+// Status.ReadyReplicas in the list of GameServerSets
 func GetReadyReplicaCountForGameServerSets(gss []*GameServerSet) int32 {
 	totalReadyReplicas := int32(0)
 	for _, gss := range gss {

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -237,3 +237,14 @@ func SumStatusReplicas(list []*GameServerSet) int32 {
 
 	return total
 }
+
+// SumSpecReplicas returns the total number of
+// Spec.Replicas in the list of GameServerSets
+func SumSpecReplicas(list []*GameServerSet) int32 {
+	total := int32(0)
+	for _, gsSet := range list {
+		total += gsSet.Spec.Replicas
+	}
+
+	return total
+}

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -243,7 +243,9 @@ func SumStatusReplicas(list []*GameServerSet) int32 {
 func SumSpecReplicas(list []*GameServerSet) int32 {
 	total := int32(0)
 	for _, gsSet := range list {
-		total += gsSet.Spec.Replicas
+		if gsSet != nil {
+			total += gsSet.Spec.Replicas
+		}
 	}
 
 	return total

--- a/pkg/apis/agones/v1/fleet_test.go
+++ b/pkg/apis/agones/v1/fleet_test.go
@@ -220,6 +220,28 @@ func TestSumStatusReplicas(t *testing.T) {
 	assert.Equal(t, int32(30), SumStatusReplicas(fixture))
 }
 
+func TestSumSpecReplicas(t *testing.T) {
+	fixture := []*GameServerSet{
+		{Spec: GameServerSetSpec{Replicas: 11}},
+		{Spec: GameServerSetSpec{Replicas: 14}},
+		{Spec: GameServerSetSpec{Replicas: 100}},
+		nil,
+	}
+
+	assert.Equal(t, int32(125), SumSpecReplicas(fixture))
+}
+
+func TestGetReadyReplicaCountForGameServerSets(t *testing.T) {
+	fixture := []*GameServerSet{
+		{Status: GameServerSetStatus{ReadyReplicas: 1000}},
+		{Status: GameServerSetStatus{ReadyReplicas: 15}},
+		{Status: GameServerSetStatus{ReadyReplicas: 5}},
+		nil,
+	}
+
+	assert.Equal(t, int32(1020), GetReadyReplicaCountForGameServerSets(fixture))
+}
+
 func defaultFleet() *Fleet {
 	gs := GameServer{
 		Spec: GameServerSpec{

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -531,12 +531,14 @@ func (c *Controller) rollingUpdateRestFixedOnReady(fleet *agonesv1.Fleet, active
 
 	if maxScaledDown <= 0 {
 		return nil
-
 	}
 	rest, _, err = c.cleanupUnhealthyReplicas(rest, fleet, maxScaledDown)
 	if err != nil {
 		c.loggerForFleet(fleet).WithField("fleet", fleet.ObjectMeta.Name).WithField("maxScaledDown", maxScaledDown).
 			Debug("Can not cleanup Unhealth Replicas")
+		// There could be the case when GameServerSet would be updated from another place, say Status or Spec would be updated
+		// We don't want to propagate such errors further
+		// And this set in sync with reconcileOldReplicaSets() Kubernetes code
 		return nil
 	}
 	// Resulting value is readyReplicasCount + unavailable - fleet.Spec.Replicas

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -493,7 +493,7 @@ func (c *Controller) rollingUpdateRest(fleet *agonesv1.Fleet, active *agonesv1.G
 	totalScaleDownCount := readyReplicasCount - minAvailable
 
 	for _, gsSet := range rest {
-		if runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateRest) {
+		if runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateScaleDown) {
 			if totalScaledDown >= totalScaleDownCount {
 				// No further scaling required.
 				break
@@ -515,7 +515,7 @@ func (c *Controller) rollingUpdateRest(fleet *agonesv1.Fleet, active *agonesv1.G
 		newReplicasCount := fleet.LowerBoundReplicas(gsSetCopy.Spec.Replicas - unavailable)
 		if gsSet.Status.ShutdownReplicas == 0 {
 			var scaleDownCount int32
-			if runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateRest) {
+			if runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateScaleDown) {
 				// Wait for new GameServers to become Ready before scaling down Inactive GameServerset
 				// Scale down.
 				scaleDownCount := int32(integer.IntMin(int(gsSet.Spec.Replicas), int(totalScaleDownCount-totalScaledDown)))
@@ -542,7 +542,7 @@ func (c *Controller) rollingUpdateRest(fleet *agonesv1.Fleet, active *agonesv1.G
 			c.recorder.Eventf(fleet, corev1.EventTypeNormal, "ScalingGameServerSet",
 				"Scaling inactive GameServerSet %s from %d to %d", gsSetCopy.ObjectMeta.Name, gsSet.Spec.Replicas, gsSetCopy.Spec.Replicas)
 
-			if runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateRest) {
+			if runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateScaleDown) {
 				totalScaledDown += scaleDownCount
 			} else {
 				// let's update just one at a time, slightly slower, but a simpler solution that doesn't require us

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -486,7 +486,7 @@ func (c *Controller) rollingUpdateRest(fleet *agonesv1.Fleet, rest []*agonesv1.G
 		}
 		gsSetCopy := gsSet.DeepCopy()
 		// Wait for new GameServers to become Ready before scaling down Inactive GameServerset
-		if gsSet.Status.ShutdownReplicas == 0 && fleet.Status.ReadyReplicas >= fleet.LowerBoundReplicas(fleet.Spec.Replicas-unavailable) {
+		if gsSet.Status.ShutdownReplicas == 0 && fleet.Status.ReadyReplicas > fleet.LowerBoundReplicas(fleet.Spec.Replicas-1) {
 			gsSetCopy.Spec.Replicas = fleet.LowerBoundReplicas(gsSetCopy.Spec.Replicas - unavailable)
 
 			c.loggerForFleet(fleet).Debug(fmt.Sprintf("Shutdownreplicas %d", gsSet.Status.ShutdownReplicas))

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -485,7 +485,8 @@ func (c *Controller) rollingUpdateRest(fleet *agonesv1.Fleet, rest []*agonesv1.G
 			break
 		}
 		gsSetCopy := gsSet.DeepCopy()
-		if gsSet.Status.ShutdownReplicas == 0 {
+		// Wait for new GameServers to become Ready before scaling down Inactive GameServerset
+		if gsSet.Status.ShutdownReplicas == 0 && fleet.Status.ReadyReplicas >= fleet.LowerBoundReplicas(fleet.Spec.Replicas-unavailable) {
 			gsSetCopy.Spec.Replicas = fleet.LowerBoundReplicas(gsSetCopy.Spec.Replicas - unavailable)
 
 			c.loggerForFleet(fleet).Debug(fmt.Sprintf("Shutdownreplicas %d", gsSet.Status.ShutdownReplicas))

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -17,7 +17,6 @@ package fleets
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -1075,7 +1074,6 @@ func TestFeatureFixRollingUpdateScaleDown(t *testing.T) {
 			f := defaultFixture()
 			f.Spec.Replicas = 75
 			f.Status.ReadyReplicas = 0
-			fmt.Println("k")
 
 			active := f.GameServerSet()
 			active.ObjectMeta.Name = "active"

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1098,7 +1098,7 @@ func TestFeatureRollingUpdateOnReady(t *testing.T) {
 			})
 
 			replicas, err := c.rollingUpdateDeployment(f, active, []*agonesv1.GameServerSet{inactive})
-			assert.Nil(t, err, "no error")
+			require.NoError(t, err, "no error")
 
 			assert.Equal(t, v.expected.replicas, replicas)
 			assert.Equal(t, v.expected.updated, updated)
@@ -1118,14 +1118,14 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 	utilruntime.FeatureTestMutex.Lock()
 	defer utilruntime.FeatureTestMutex.Unlock()
 
-	inactiveReplicas1 := int32(3)
-	inactiveReplicas2 := int32(65)
+	inactiveReplicas1 := int32(65)
+	inactiveReplicas2 := int32(3)
 
-	// TODO(alekser) Fix the scaling logic for a new feature or prove this change useful
 	if utilruntime.FeatureEnabled(utilruntime.FeatureRollingUpdateOnReady) {
-		inactiveReplicas1 = 4
-		inactiveReplicas2 = 45
+		inactiveReplicas1 = 45
+		inactiveReplicas2 = 4
 	}
+
 	type expected struct {
 		inactiveSpecReplicas int32
 		replicas             int32
@@ -1200,7 +1200,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			inactiveSpecReplicas:   95,
 			inactiveStatusReplicas: 95,
 			expected: expected{
-				inactiveSpecReplicas: inactiveReplicas2,
+				inactiveSpecReplicas: inactiveReplicas1,
 				replicas:             30,
 				updated:              true,
 			},
@@ -1226,7 +1226,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			inactiveStatusAllocationReplicas: 2,
 
 			expected: expected{
-				inactiveSpecReplicas: inactiveReplicas1,
+				inactiveSpecReplicas: inactiveReplicas2,
 				replicas:             2,
 				updated:              true,
 			},

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1153,10 +1153,10 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			inactiveStatusReplicas: 100,
 			nilMaxUnavailable:      true,
 			expected: expected{
-				err: "error calculating scaling gameserverset: fleet-1: nil value for IntOrString",
+				err: "error parsing MaxUnavailable value: fleet-1: nil value for IntOrString",
 			},
 		},
-		"nil MaxSurge, err excpected": {
+		"nil MaxSurge, err expected": {
 			fleetSpecReplicas:      100,
 			activeSpecReplicas:     0,
 			activeStatusReplicas:   0,
@@ -1164,7 +1164,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			inactiveStatusReplicas: 100,
 			nilMaxSurge:            true,
 			expected: expected{
-				err: "error calculating scaling gameserverset: fleet-1: nil value for IntOrString",
+				err: "error parsing MaxSurge value: fleet-1: nil value for IntOrString",
 			},
 		},
 		"full inactive, empty inactive": {

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1003,13 +1003,13 @@ func TestControllerRollingUpdateDeploymentGSSUpdateFailedErrExpected(t *testing.
 	assert.EqualError(t, err, "error updating gameserverset inactive: random-err")
 }
 
-func TestFeatureFixRollingUpdateScaleDown(t *testing.T) {
+func TestFeatureRollingUpdateOnReady(t *testing.T) {
 	t.Parallel()
 
 	utilruntime.FeatureTestMutex.Lock()
 	defer utilruntime.FeatureTestMutex.Unlock()
 
-	assert.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeatureFixRollingUpdateScaleDown)+"=true"))
+	assert.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeatureRollingUpdateOnReady)+"=true"))
 
 	type expected struct {
 		inactiveSpecReplicas int32
@@ -1124,7 +1124,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 	inactiveReplicas2 := int32(65)
 
 	// TODO(alekser) Fix the scaling logic for a new feature or prove this change useful
-	if utilruntime.FeatureEnabled(utilruntime.FeatureFixRollingUpdateScaleDown) {
+	if utilruntime.FeatureEnabled(utilruntime.FeatureRollingUpdateOnReady) {
 		inactiveReplicas1 = 4
 		inactiveReplicas2 = 45
 	}

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1118,13 +1118,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 	utilruntime.FeatureTestMutex.Lock()
 	defer utilruntime.FeatureTestMutex.Unlock()
 
-	inactiveReplicas1 := int32(65)
-	inactiveReplicas2 := int32(3)
-
-	if utilruntime.FeatureEnabled(utilruntime.FeatureRollingUpdateOnReady) {
-		inactiveReplicas1 = 45
-		inactiveReplicas2 = 4
-	}
+	assert.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeatureRollingUpdateOnReady)+"=false"))
 
 	type expected struct {
 		inactiveSpecReplicas int32
@@ -1200,7 +1194,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			inactiveSpecReplicas:   95,
 			inactiveStatusReplicas: 95,
 			expected: expected{
-				inactiveSpecReplicas: inactiveReplicas1,
+				inactiveSpecReplicas: 65,
 				replicas:             30,
 				updated:              true,
 			},
@@ -1226,7 +1220,7 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			inactiveStatusAllocationReplicas: 2,
 
 			expected: expected{
-				inactiveSpecReplicas: inactiveReplicas2,
+				inactiveSpecReplicas: 3,
 				replicas:             2,
 				updated:              true,
 			},

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1036,7 +1036,7 @@ func TestFeatureRollingUpdateOnReady(t *testing.T) {
 			allocatedReplicas:           5,
 			expected: expected{
 				updated:              true,
-				inactiveSpecReplicas: 0,
+				inactiveSpecReplicas: 5,
 				replicas:             70,
 			},
 		},
@@ -1059,7 +1059,7 @@ func TestFeatureRollingUpdateOnReady(t *testing.T) {
 			allocatedReplicas:           0,
 			expected: expected{
 				updated:              true,
-				inactiveSpecReplicas: 9,
+				inactiveSpecReplicas: 8,
 				replicas:             75,
 			},
 		},

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -198,6 +198,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		f := defaultFixture()
 		f.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 		f.Spec.Template.Spec.Ports = []agonesv1.GameServerPort{{HostPort: 5555}}
+		f.Status.ReadyReplicas = 5
 		c, m := newFakeController()
 		gsSet := f.GameServerSet()
 		gsSet.ObjectMeta.Name = "gsSet1"
@@ -974,6 +975,7 @@ func TestControllerRollingUpdateDeploymentGSSUpdateFailedErrExpected(t *testing.
 
 	f := defaultFixture()
 	f.Spec.Replicas = 75
+	f.Status.ReadyReplicas = 75
 
 	active := f.GameServerSet()
 	active.ObjectMeta.Name = "active"
@@ -1127,6 +1129,10 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			mu := intstr.FromString("30%")
 			f.Spec.Strategy.RollingUpdate.MaxUnavailable = &mu
 			f.Spec.Replicas = v.fleetSpecReplicas
+
+			// Inactive GameServerSet is downscaled second time only after
+			// ReadyReplicas has raised.
+			f.Status.ReadyReplicas = v.fleetSpecReplicas
 
 			if v.nilMaxSurge {
 				f.Spec.Strategy.RollingUpdate.MaxSurge = nil

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1004,8 +1004,6 @@ func TestControllerRollingUpdateDeploymentGSSUpdateFailedErrExpected(t *testing.
 }
 
 func TestFeatureRollingUpdateOnReady(t *testing.T) {
-	t.Parallel()
-
 	utilruntime.FeatureTestMutex.Lock()
 	defer utilruntime.FeatureTestMutex.Unlock()
 
@@ -1073,7 +1071,7 @@ func TestFeatureRollingUpdateOnReady(t *testing.T) {
 
 			f := defaultFixture()
 			f.Spec.Replicas = 75
-			f.Status.ReadyReplicas = 0
+			f.Status.ReadyReplicas = v.activeStatusReadyReplicas + v.inactiveStatusReadyReplicas
 
 			active := f.GameServerSet()
 			active.ObjectMeta.Name = "active"

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -196,6 +196,8 @@ func TestControllerSyncFleet(t *testing.T) {
 	})
 
 	t.Run("gameserverset with different image details", func(t *testing.T) {
+		assert.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeaturePlayerTracking)+"=true"))
+
 		f := defaultFixture()
 		f.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 		f.Spec.Template.Spec.Ports = []agonesv1.GameServerPort{{HostPort: 5555}}
@@ -1000,13 +1002,13 @@ func TestControllerRollingUpdateDeploymentGSSUpdateFailedErrExpected(t *testing.
 	assert.EqualError(t, err, "error updating gameserverset inactive: random-err")
 }
 
-func TestFeatureFixRollingUpdateRest(t *testing.T) {
+func TestFeatureFixRollingUpdateScaleDown(t *testing.T) {
 	t.Parallel()
 
 	utilruntime.FeatureTestMutex.Lock()
 	defer utilruntime.FeatureTestMutex.Unlock()
 
-	assert.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeatureFixRollingUpdateRest)+"=true"))
+	assert.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeatureFixRollingUpdateScaleDown)+"=true"))
 
 	type expected struct {
 		inactiveSpecReplicas int32

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -39,6 +39,9 @@ const (
 
 	// FeatureSDKWatchSendOnExecute is a feature flag to enable/disable immediate game server return after SDK.WatchGameServer is called
 	FeatureSDKWatchSendOnExecute Feature = "SDKWatchSendOnExecute"
+
+	// FeatureFixRollingUpdateRest is a feature flag to enable/disable rolling update fixes
+	FeatureFixRollingUpdateRest Feature = "FixRollingUpdate"
 )
 
 var (
@@ -50,6 +53,7 @@ var (
 		FeaturePlayerTracking:          false,
 		FeatureContainerPortAllocation: true,
 		FeatureSDKWatchSendOnExecute:   false,
+		FeatureFixRollingUpdateRest:    false,
 	}
 
 	// featureGates is the storage of what features are enabled

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -40,8 +40,9 @@ const (
 	// FeatureSDKWatchSendOnExecute is a feature flag to enable/disable immediate game server return after SDK.WatchGameServer is called
 	FeatureSDKWatchSendOnExecute Feature = "SDKWatchSendOnExecute"
 
-	// FeatureFixRollingUpdateRest is a feature flag to enable/disable rolling update fixes
-	FeatureFixRollingUpdateRest Feature = "FixRollingUpdate"
+	// FeatureFixRollingUpdateScaleDown is a feature flag to enable/disable rolling update fix of scale down, when ReadyReplicas
+	// count is taken into account
+	FeatureFixRollingUpdateScaleDown Feature = "FixRollingUpdateScaleDown"
 )
 
 var (
@@ -49,11 +50,10 @@ var (
 	// operational in Agones, and what their default configuration is.
 	// alpha features are disabled
 	featureDefaults = map[Feature]bool{
-		FeatureExample:                 true,
-		FeaturePlayerTracking:          false,
-		FeatureContainerPortAllocation: true,
-		FeatureSDKWatchSendOnExecute:   false,
-		FeatureFixRollingUpdateRest:    false,
+		FeatureExample:                   true,
+		FeaturePlayerTracking:            false,
+		FeatureContainerPortAllocation:   true,
+		FeatureFixRollingUpdateScaleDown: false,
 	}
 
 	// featureGates is the storage of what features are enabled

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -53,6 +53,7 @@ var (
 		FeatureExample:                   true,
 		FeaturePlayerTracking:            false,
 		FeatureContainerPortAllocation:   true,
+		FeatureSDKWatchSendOnExecute:     false,
 		FeatureFixRollingUpdateScaleDown: false,
 	}
 

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -40,9 +40,9 @@ const (
 	// FeatureSDKWatchSendOnExecute is a feature flag to enable/disable immediate game server return after SDK.WatchGameServer is called
 	FeatureSDKWatchSendOnExecute Feature = "SDKWatchSendOnExecute"
 
-	// FeatureFixRollingUpdateScaleDown is a feature flag to enable/disable rolling update fix of scale down, when ReadyReplicas
+	// FeatureRollingUpdateOnReady is a feature flag to enable/disable rolling update fix of scale down, when ReadyReplicas
 	// count is taken into account
-	FeatureFixRollingUpdateScaleDown Feature = "FixRollingUpdateScaleDown"
+	FeatureRollingUpdateOnReady Feature = "RollingUpdateOnReady"
 )
 
 var (
@@ -50,11 +50,11 @@ var (
 	// operational in Agones, and what their default configuration is.
 	// alpha features are disabled
 	featureDefaults = map[Feature]bool{
-		FeatureExample:                   true,
-		FeaturePlayerTracking:            false,
-		FeatureContainerPortAllocation:   true,
-		FeatureSDKWatchSendOnExecute:     false,
-		FeatureFixRollingUpdateScaleDown: false,
+		FeatureExample:                 true,
+		FeaturePlayerTracking:          false,
+		FeatureContainerPortAllocation: true,
+		FeatureSDKWatchSendOnExecute:   false,
+		FeatureRollingUpdateOnReady:    false,
 	}
 
 	// featureGates is the storage of what features are enabled

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -31,6 +31,7 @@ The current set of `alpha` and `beta` feature gates are:
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
 | [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
+| [Fix RollingUpdate Scaling Down ](https://github.com/googleforgames/agones/issues/1625) | `FeatureFixRollingUpdateRest` | Disabled | `Alpha` | 1.7.0 |
 
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -24,6 +24,7 @@ that can be found in the [Helm configuration]({{< ref "/docs/Installation/Instal
 
 The current set of `alpha` and `beta` feature gates are:
 
+{{% feature publishVersion="1.9.0" %}}
 | Feature Name | Gate    | Default | Stage | Since |
 |--------------|---------|---------|-------|-------|
 | Multicluster Allocation<sup>*</sup> | N/A | Enabled | `Beta` | 1.6.0 |
@@ -31,8 +32,17 @@ The current set of `alpha` and `beta` feature gates are:
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
 | [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
-| [Fix RollingUpdate Scaling Down ](https://github.com/googleforgames/agones/issues/1625) | `RollingUpdateOnReady` | Disabled | `Alpha` | 1.9.0 |
-
+| Fix for RollingUpdate [Scale down](https://github.com/googleforgames/agones/issues/1625) and additional [details]({{< ref "/docs/Guides/fleet-updates.md#alpha-feature-rollingupdateonready" >}}) | `RollingUpdateOnReady` | Disabled | `Alpha` | 1.9.0 |
+{{% /feature %}}
+{{% feature expiryVersion="1.9.0" %}}
+| Feature Name | Gate    | Default | Stage | Since |
+|--------------|---------|---------|-------|-------|
+| Multicluster Allocation<sup>*</sup> | N/A | Enabled | `Beta` | 1.6.0 |
+| Example Gate (not in use) | `Example` | Disabled | None | 0.13.0 |
+| [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
+| [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
+| [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
+{{% /feature %}}
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.
 

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -31,7 +31,7 @@ The current set of `alpha` and `beta` feature gates are:
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
 | [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
-| [Fix RollingUpdate Scaling Down ](https://github.com/googleforgames/agones/issues/1625) | `FeatureFixRollingUpdateRest` | Disabled | `Alpha` | 1.7.0 |
+| [Fix RollingUpdate Scaling Down ](https://github.com/googleforgames/agones/issues/1625) | `FeatureRollingUpdateOnReady` | Disabled | `Alpha` | 1.7.0 |
 
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -31,7 +31,7 @@ The current set of `alpha` and `beta` feature gates are:
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
 | [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
-| [Fix RollingUpdate Scaling Down ](https://github.com/googleforgames/agones/issues/1625) | `FeatureRollingUpdateOnReady` | Disabled | `Alpha` | 1.7.0 |
+| [Fix RollingUpdate Scaling Down ](https://github.com/googleforgames/agones/issues/1625) | `RollingUpdateOnReady` | Disabled | `Alpha` | 1.9.0 |
 
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.

--- a/site/content/en/docs/Guides/fleet-updates.md
+++ b/site/content/en/docs/Guides/fleet-updates.md
@@ -105,4 +105,11 @@ Fleets through that mechanism. The `preferred` label matching selector tells the
 all `GameServers` with the `v2` `Fleet` label, and if not found, search through the rest of the set.
 
 The above `GameServerAllocation` can then be used while you scale up the `v2` Fleet and scale down the original Fleet at
-the rate that you deem fit for your specific rollout. 
+the rate that you deem fit for your specific rollout.
+
+## Alpha Feature RollingUpdateOnReady
+
+{{< alpha title="Rolling Update on Ready" gate="RollingUpdateOnReady" >}}
+
+If we are updating the Fleet configuration, the new GameServerSet would be created with 0 GameServers at the beginning, if RollingUpdate deployment strategy is used. After creating a first batch of `MaxSurge` GameServers, old GameServerSet should be waiting before some of them become Ready, before scaling down GameServers which belong to an old GameServerSet.
+With this feature disabled old GameServerSet could scale down all of its GameServers down to zero and total number of Ready GameServers could be 0 which is more than `MaxUnavailable`, which could not be more than 99%, so this should never happen.

--- a/site/content/en/docs/Guides/fleet-updates.md
+++ b/site/content/en/docs/Guides/fleet-updates.md
@@ -111,5 +111,7 @@ the rate that you deem fit for your specific rollout.
 
 {{< alpha title="Rolling Update on Ready" gate="RollingUpdateOnReady" >}}
 
-If we are updating the Fleet configuration, the new GameServerSet would be created with 0 GameServers at the beginning, if RollingUpdate deployment strategy is used. After creating a first batch of `MaxSurge` GameServers, old GameServerSet should be waiting before some of them become Ready, before scaling down GameServers which belong to an old GameServerSet.
-With this feature disabled old GameServerSet could scale down all of its GameServers down to zero and total number of Ready GameServers could be 0 which is more than `MaxUnavailable`, which could not be more than 99%, so this should never happen.
+When this feature is enabled, Fleets will wait for the new GameSevers to become Ready during a Rolling Update, to ensure there is always a set of Ready GameServers before attempting to shut down the previous version Fleet's GameServers.
+
+This ensures a Fleet cannot accidentally have 0 GameServers Ready if something goes wrong during a Rolling Update, or GameServers have a long delay when moving to a Ready state.
+

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -294,7 +294,7 @@ func TestFleetRollingUpdate(t *testing.T) {
 					assert.Nil(t, err)
 					target := float64(targetScale)
 
-					if !runtime.FeatureEnabled(runtime.FeatureFixRollingUpdateScaleDown) {
+					if !runtime.FeatureEnabled(runtime.FeatureRollingUpdateOnReady) {
 						if len(list.Items) > int(target+math.Ceil(target*float64(maxSurge)/100.)+math.Ceil(target*float64(maxUnavailable)/100.)) {
 							err = errors.New(fmt.Sprintf("New replicas should be less than target + maxSurge + maxUnavailable %d %d", len(list.Items), int(target+math.Ceil(target*float64(maxSurge)/100.)+math.Ceil(target*float64(maxUnavailable)/100.))))
 						}

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -27,7 +27,6 @@ import (
 	typedagonesv1 "agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1"
 	"agones.dev/agones/pkg/util/runtime"
 	e2e "agones.dev/agones/test/e2e/framework"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -301,12 +300,13 @@ func TestFleetRollingUpdate(t *testing.T) {
 						if maxUnavailable == 0 {
 							maxUnavailable = 1
 						}
+						// This difference is inevitable, also could be seen with Deployments and ReplicaSeets
 						shift = maxUnavailable
 					}
 					assert.Nil(t, err)
 
 					if len(list.Items) > targetScale+maxSurge+maxUnavailable+shift {
-						err = errors.New(fmt.Sprintf("New replicas should be less than target + maxSurge + maxUnavailable %d %d", len(list.Items), targetScale+maxSurge+maxUnavailable+shift))
+						err = fmt.Errorf("New replicas should be less than target + maxSurge + maxUnavailable %d %d", len(list.Items), targetScale+maxSurge+maxUnavailable+shift)
 					}
 					if err != nil {
 						return false, err

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -294,7 +294,11 @@ func TestFleetRollingUpdate(t *testing.T) {
 					maxUnavailable, err := intstr.GetValueFromIntOrPercent(flt.Spec.Strategy.RollingUpdate.MaxUnavailable, 100, true)
 					assert.Nil(t, err)
 					target := float64(targetScale)
-					if len(list.Items) > int(target+math.Ceil(target*float64(maxSurge)/100.)+math.Ceil(target*float64(maxUnavailable)/100.)) {
+					if len(list.Items) > int(target+math.Ceil(target*float64(maxSurge)/100.)+math.Floor(target*float64(maxUnavailable)/100.)) {
+						for i, v := range list.Items {
+							fmt.Println("List of Gameservers ", i, v)
+						}
+						fmt.Println("compare ", len(list.Items), "  - ", int(target+math.Ceil(target*float64(maxSurge)/100.)+math.Ceil(target*float64(maxUnavailable)/100.)))
 						err = errors.New("New replicas should be less than target + maxSurge + maxUnavailable")
 					}
 					if err != nil {


### PR DESCRIPTION
Make sure that GameServers actually are Ready before scaling down
inactive GameServerSet.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

 /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
If creating new `GameServers` take more than 30 seconds there is a situation when all GameServers would go down to 0 and all new `GameServers` would be in a `Scheduled` state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1625

**Special notes for your reviewer**:

There are steps to reproduce inline with a ticket. Will create a simple E2E test to make sure this functionality is covered.