### PR TITLE
New feature: SDK cached gameserver

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -59,7 +59,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/udp-server:0.21
 
-ALPHA_FEATURE_GATES ?= "PlayerTracking=true&GameServerCaching=true"
+ALPHA_FEATURE_GATES ?= "PlayerTracking=true&SDKWatchSendOnExecute=true"
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/build/Makefile
+++ b/build/Makefile
@@ -59,7 +59,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/udp-server:0.21
 
-ALPHA_FEATURE_GATES ?= "PlayerTracking=true"
+ALPHA_FEATURE_GATES ?= "PlayerTracking=true&GameServerCaching=true"
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -232,7 +232,7 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&ContainerPortAllocation=false', 'e2e-test-cluster']
+  args: ['PlayerTracking=true&ContainerPortAllocation=false&SDKWatchSendOnExecute=true', 'e2e-test-cluster']
   id: e2e-feature-gates
   waitFor:
     - push-images

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -510,15 +510,17 @@ func (s *SDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameServer
 	s.logger.Debug("Received WatchGameServer request, adding stream to connectedStreams")
 	s.streamMutex.Lock()
 
-	if runtime.FeatureEnabled(runtime.FeatureGameServerCaching) {
+	if runtime.FeatureEnabled(runtime.FeatureSDKWatchSendOnExecute) {
 		gs, err := s.getCachedGameServer()
 		if err != nil {
 			s.logger.WithError(errors.WithStack(err)).Error("error getting cached game server")
-		} else {
-			err := stream.Send(gs)
-			if err != nil {
-				s.logger.WithError(errors.WithStack(err)).Error("error sending cached game server")
-			}
+			return err
+		}
+
+		err = stream.Send(gs)
+		if err != nil {
+			s.logger.WithError(errors.WithStack(err)).Error("error sending cached game server")
+			return err
 		}
 	}
 

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -665,7 +665,7 @@ func TestSDKServerWatchGameServer(t *testing.T) {
 	assert.Equal(t, stream, sc.connectedStreams[1])
 }
 
-func TestSDKServerWatchGameServer_FeatureGameServerCaching(t *testing.T) {
+func TestSDKServerWatchGameServerFeatureSDKWatchSendOnExecute(t *testing.T) {
 	t.Parallel()
 
 	agruntime.FeatureTestMutex.Lock()
@@ -686,9 +686,9 @@ func TestSDKServerWatchGameServer_FeatureGameServerCaching(t *testing.T) {
 		return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{*fixture}}, nil
 	})
 
-	err := agruntime.ParseFeatures(string(agruntime.FeatureGameServerCaching) + "=true")
+	err := agruntime.ParseFeatures(string(agruntime.FeatureSDKWatchSendOnExecute) + "=true")
 	if !assert.NoError(t, err) {
-		t.Fatal("Can not parse FeatureGameServerCaching")
+		t.Fatal("Can not parse FeatureSDKWatchSendOnExecute")
 	}
 
 	sc, err := defaultSidecar(m)

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -38,7 +38,7 @@ const (
 	FeatureContainerPortAllocation Feature = "ContainerPortAllocation"
 
 	// FeatureGameServerCaching is a feature flag to enable/disable game server caching
-	FeatureGameServerCaching Feature = "FeatureGameServerCaching"
+	FeatureGameServerCaching Feature = "GameServerCaching"
 )
 
 var (

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -36,6 +36,9 @@ const (
 
 	// FeatureContainerPortAllocation is a feature flag to enable/disable allocating ports to several containers in a pod
 	FeatureContainerPortAllocation Feature = "ContainerPortAllocation"
+
+	// FeatureGameServerCaching is a feature flag to enable/disable game server caching
+	FeatureGameServerCaching Feature = "FeatureGameServerCaching"
 )
 
 var (
@@ -46,6 +49,7 @@ var (
 		FeatureExample:                 true,
 		FeaturePlayerTracking:          false,
 		FeatureContainerPortAllocation: true,
+		FeatureGameServerCaching:       false,
 	}
 
 	// featureGates is the storage of what features are enabled

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -37,8 +37,8 @@ const (
 	// FeatureContainerPortAllocation is a feature flag to enable/disable allocating ports to several containers in a pod
 	FeatureContainerPortAllocation Feature = "ContainerPortAllocation"
 
-	// FeatureGameServerCaching is a feature flag to enable/disable game server caching
-	FeatureGameServerCaching Feature = "GameServerCaching"
+	// FeatureSDKWatchSendOnExecute is a feature flag to enable/disable immediate game server return after SDK.WatchGameServer is called
+	FeatureSDKWatchSendOnExecute Feature = "SDKWatchSendOnExecute"
 )
 
 var (
@@ -49,7 +49,7 @@ var (
 		FeatureExample:                 true,
 		FeaturePlayerTracking:          false,
 		FeatureContainerPortAllocation: true,
-		FeatureGameServerCaching:       false,
+		FeatureSDKWatchSendOnExecute:   false,
 	}
 
 	// featureGates is the storage of what features are enabled

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -164,7 +164,7 @@ For language specific documentation, have a look at the respective source (linke
 and the {{< ghlink href="examples" >}}examples{{< /ghlink >}}.
 
 {{% feature publishVersion="1.7.0" %}}
-You can use `SDKWatchSendOnExecute` feature passed as a feature gate if you want a `GameServer` to be returned right after `SDK.WatchGameServer` is called.
+You can use `SDKWatchSendOnExecute` feature passed as a [feature gate] ({{< ref "/docs/Guides/feature-stages.md#feature-gates" >}}) if you want a `GameServer` to be returned right after `SDK.WatchGameServer` is called.
 {{% /feature %}}
 
 ### Metadata Management

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -163,7 +163,9 @@ the `message GameServer`.
 For language specific documentation, have a look at the respective source (linked above), 
 and the {{< ghlink href="examples" >}}examples{{< /ghlink >}}.
 
-You can use `GameServerCaching` feature passed as a feature gate if you want a `GameServer` to be returned right after `GameServerFeature` is called.
+{{% feature publishVersion="1.7.0" %}}
+You can use `SDKWatchSendOnExecute` feature passed as a feature gate if you want a `GameServer` to be returned right after `SDK.WatchGameServer` is called.
+{{% /feature %}}
 
 ### Metadata Management
 

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -163,6 +163,8 @@ the `message GameServer`.
 For language specific documentation, have a look at the respective source (linked above), 
 and the {{< ghlink href="examples" >}}examples{{< /ghlink >}}.
 
+You can use `GameServerCaching` feature passed as a feature gate if you want a `GameServer` to be returned right after `GameServerFeature` is called.
+
 ### Metadata Management
 
 #### SetLabel(key, value)

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -42,7 +42,7 @@ The current set of `alpha` and `beta` feature gates are:
 | Example Gate (not in use) | `Example` | Disabled | None | 0.13.0 |
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
-| [SDK Send Game Server on Watch]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserver-function-gameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
+| [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserver-function-gameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.
  {{% /feature %}}

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -42,6 +42,7 @@ The current set of `alpha` and `beta` feature gates are:
 | Example Gate (not in use) | `Example` | Disabled | None | 0.13.0 |
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
+| [Game Server Caching]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserver-function-gameserver" >}}) | `GameServerCaching` | Disabled | `Alpha` | 1.7.0 |
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.
  {{% /feature %}}

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -42,7 +42,7 @@ The current set of `alpha` and `beta` feature gates are:
 | Example Gate (not in use) | `Example` | Disabled | None | 0.13.0 |
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
-| [Game Server Caching]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserver-function-gameserver" >}}) | `GameServerCaching` | Disabled | `Alpha` | 1.7.0 |
+| [SDK Send Game Server on Watch]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserver-function-gameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
 <sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
  feature gate and cannot be disabled.
  {{% /feature %}}


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / Why we need it**:
Return GS immediately after WatchGameServer is called. Long discussion [here](https://github.com/googleforgames/agones/issues/1630).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1630 

**Special notes for your reviewer**:
Should _feature-stages.md_ be also updated?
