### PR TITLE
E2E: Invert ContainerPortAllocation FeatureGate

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -228,11 +228,11 @@ steps:
     - GO111MODULE=on
 
 #
-# Run the e2e tests with FeatureGates
+# Run the e2e tests with FeatureGates inverted compared to Stable
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&ContainerPortAllocation=true', 'e2e-test-cluster']
+  args: ['PlayerTracking=true&ContainerPortAllocation=false', 'e2e-test-cluster']
   id: e2e-feature-gates
   waitFor:
     - push-images


### PR DESCRIPTION
ContainerPortAllocation now turned on by default, switching it off for E2E tests.

An idea behind is to invert all FeatureGates compared to default values for a second E2E test run.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


