### PR TITLE
Cleanup e2e namespaces before test start

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -58,6 +58,10 @@ const (
 	AutoCleanupLabelValue = "true"
 )
 
+// NamespaceLabel is the label that is put on all namespaces that are created
+// for e2e tests.
+var NamespaceLabel = map[string]string{"owner": "e2e-test"}
+
 // Framework is a testing framework
 type Framework struct {
 	KubeClient      kubernetes.Interface
@@ -500,7 +504,7 @@ func (f *Framework) CreateNamespace(namespace string) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,
-			Labels: map[string]string{"owner": "e2e-test"},
+			Labels: NamespaceLabel,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

When an e2e test panics, it can leave behind populated GameServer namespaces, that are never cleaned up!

This implements a fix in which the e2e test will search for e2e namespaces in the cluster, and delete them all before tests begin.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1653

**Special notes for your reviewer**:

None.


