### PR TITLE
Flaky: e2e namespace deletion

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -581,13 +581,13 @@ func (f *Framework) DeleteNamespace(namespace string) error {
 			}}
 			payloadBytes, _ := json.Marshal(payload)
 			if _, err := kubeCore.Pods(namespace).Patch(pod.Name, types.JSONPatchType, payloadBytes); err != nil {
-				return errors.Errorf("updating pod %s failed: %s", pod.GetName(), err)
+				return errors.Wrapf(err, "updating pod %s failed", pod.GetName())
 			}
 		}
 	}
 
 	if err := kubeCore.Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
-		return errors.Errorf("deleting namespace %s failed: %s", namespace, err)
+		return errors.Wrapf(err, "deleting namespace %s failed", namespace)
 	}
 	logrus.Infof("Namespace %s is deleted", namespace)
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This fixes the issue if the e2e test tries to delete namespace that is already in a Terminating state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
None

**Special notes for your reviewer**:

None
