### PR TITLE
Fix tests timeout, WatchGameServer recent feature

### DIFF
--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -497,7 +497,6 @@ func (s *SDKServer) GetGameServer(context.Context, *sdk.Empty) (*sdk.GameServer,
 // backing GameServer configuration / status
 func (s *SDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameServerServer) error {
 	s.logger.Debug("Received WatchGameServer request, adding stream to connectedStreams")
-	s.streamMutex.Lock()
 
 	if runtime.FeatureEnabled(runtime.FeatureSDKWatchSendOnExecute) {
 		gs, err := s.GetGameServer(context.Background(), &sdk.Empty{})
@@ -511,6 +510,7 @@ func (s *SDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameServer
 		}
 	}
 
+	s.streamMutex.Lock()
 	s.connectedStreams = append(s.connectedStreams, stream)
 	s.streamMutex.Unlock()
 	// don't exit until we shutdown, because that will close the stream

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -648,6 +648,14 @@ func TestSDKServerGetGameServer(t *testing.T) {
 
 func TestSDKServerWatchGameServer(t *testing.T) {
 	t.Parallel()
+
+	agruntime.FeatureTestMutex.Lock()
+	defer agruntime.FeatureTestMutex.Unlock()
+	err := agruntime.ParseFeatures(string(agruntime.FeatureSDKWatchSendOnExecute) + "=false")
+	if !assert.NoError(t, err) {
+		t.Fatal("Can not parse FeatureSDKWatchSendOnExecute")
+	}
+
 	m := agtesting.NewMocks()
 	sc, err := defaultSidecar(m)
 	assert.Nil(t, err)
@@ -745,6 +753,14 @@ func TestSDKServerWatchGameServerFeatureSDKWatchSendOnExecute(t *testing.T) {
 
 func TestSDKServerSendGameServerUpdate(t *testing.T) {
 	t.Parallel()
+
+	agruntime.FeatureTestMutex.Lock()
+	defer agruntime.FeatureTestMutex.Unlock()
+	err := agruntime.ParseFeatures(string(agruntime.FeatureSDKWatchSendOnExecute) + "=false")
+	if !assert.NoError(t, err) {
+		t.Fatal("Can not parse FeatureSDKWatchSendOnExecute")
+	}
+
 	m := agtesting.NewMocks()
 	sc, err := defaultSidecar(m)
 	assert.Nil(t, err)
@@ -774,8 +790,15 @@ func TestSDKServerSendGameServerUpdate(t *testing.T) {
 
 func TestSDKServerUpdateEventHandler(t *testing.T) {
 	t.Parallel()
-	m := agtesting.NewMocks()
 
+	agruntime.FeatureTestMutex.Lock()
+	defer agruntime.FeatureTestMutex.Unlock()
+	err := agruntime.ParseFeatures(string(agruntime.FeatureSDKWatchSendOnExecute) + "=false")
+	if !assert.NoError(t, err) {
+		t.Fatal("Can not parse FeatureSDKWatchSendOnExecute")
+	}
+
+	m := agtesting.NewMocks()
 	fakeWatch := watch.NewFake()
 	m.AgonesClient.AddWatchReactor("gameservers", k8stesting.DefaultWatchReactor(fakeWatch, nil))
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature

/kind hotfix

**What this PR does / Why we need it**:

Move GetGameServer() call out of streamMutex lock.
Add previously written tests to run without this feature, as they
timeouts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1672 

**Special notes for your reviewer**:
A way to check that test do not freeze now:
```
cd ./pkg/sdkserver
go test -run SDKServer
```


