### PR TITLE
Fix typo in gameserverallocations

### DIFF
--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -122,7 +122,7 @@ type response struct {
 	err     error
 }
 
-// NewAllocator creates an instance off Allocator
+// NewAllocator creates an instance of Allocator
 func NewAllocator(policyInformer multiclusterinformerv1.GameServerAllocationPolicyInformer, secretInformer informercorev1.SecretInformer,
 	kubeClient kubernetes.Interface, readyGameServerCache *ReadyGameServerCache) *Allocator {
 	ah := &Allocator{
@@ -403,7 +403,7 @@ func (c *Allocator) getClientCertificates(namespace, secretName string) (clientC
 		return nil, nil, nil, err
 	}
 	if secret == nil || len(secret.Data) == 0 {
-		return nil, nil, nil, fmt.Errorf("secert %s does not have data", secretName)
+		return nil, nil, nil, fmt.Errorf("secret %s does not have data", secretName)
 	}
 
 	// Create http client using cert


### PR DESCRIPTION
Fix error message and comment.


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

 /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Clean up the code

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none


