### PR TITLE
Fix for `gcloud-terraform-cluster` make target

### DIFF
--- a/build/terraform/gke/module.tf
+++ b/build/terraform/gke/module.tf
@@ -116,7 +116,7 @@ module "gke_cluster" {
 }
 
 module "helm_agones" {
-  source = "../../../install/terraform/modules/helm"
+  source = "../../../install/terraform/modules/helm3"
 
   agones_version         = var.agones_version
   values_file            = var.values_file

--- a/site/content/en/docs/Installation/Install Agones/yaml.md
+++ b/site/content/en/docs/Installation/Install Agones/yaml.md
@@ -25,14 +25,14 @@ Example of setting `featureGates` and `generateTLS` helm parameters in `install.
 ```
 helm pull --untar https://agones.dev/chart/stable/agones-{{< release-version >}}.tgz && \
 cd agones && \
-helm3 template agones-manual --namespace agones-system  . \
+helm template agones-manual --namespace agones-system  . \
   --set agones.controller.generateTLS=false \
   --set agones.allocator.generateTLS=false \
   --set agones.crds.cleanupOnDelete=false \
   --set agones.featureGates="PlayerTracking=true" \
   > install-custom.yaml
 ```
-Note: `pull` command was introduced in helm 3.
+Note: `pull` command was introduced in Helm version 3.
 
 You can also find the install.yaml in the latest `agones-install` zip from the [releases](https://github.com/googleforgames/agones/releases) archive.
 


### PR DESCRIPTION
Update Terraform build config to use helm3 module.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature

/kind hotfix

**What this PR does / Why we need it**:

`make gcloud-terraform-cluster` is broken.

There is an issue with old module that in Dockerfile there is no Helm 2
binary and new one fails with meessage: Helm does not support `helm init`.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
Needed for the test https://github.com/googleforgames/agones/pull/1483 to pass .



