### PR TITLE
Website: Update CRD API docs only if sorted files different

### DIFF
--- a/site/gen-api-docs.sh
+++ b/site/gen-api-docs.sh
@@ -62,7 +62,7 @@ function sedeasy {
 }
 
 # do we have changes in generated API docs compared to previous version
-if ! diff $RESULT $OLD;
+if ! diff <(sort $RESULT) <(sort $OLD);
 then 
   echo "Output to a file $FILE"
 


### PR DESCRIPTION
`make test-gen-api-docs` gives lots of false positive failures.

**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

The tool we are using could not preserve the ordering for APIGroups that's why file could be presented in a number of different ways.

Ordering of APIGroups do not change the logic of the resulted file contents especially for the case when they are on the same level in the docs.
Commutative property of the set (of APIGroups).

**Which issue(s) this PR fixes**:
Closes #1690

**Special notes for your reviewer**:
Thank you.





