### PR TITLE
Add Custom VPC support to Terraform GKE Module

### DIFF
--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -28,6 +28,7 @@ locals {
   machineType       = lookup(var.cluster, "machineType", "n1-standard-4")
   initialNodeCount  = lookup(var.cluster, "initialNodeCount", "4")
   network           = lookup(var.cluster, "network", "default")
+  subnetwork        = lookup(var.cluster, "subnetwork", "")
   kubernetesVersion = lookup(var.cluster, "kubernetesVersion", "1.15")
 }
 
@@ -49,6 +50,7 @@ resource "google_container_cluster" "primary" {
   location = local.zone
   project  = local.project
   network  = local.network
+  subnetwork = local.subnetwork
 
   min_master_version = local.kubernetesVersion
 

--- a/install/terraform/modules/gke/variables.tf
+++ b/install/terraform/modules/gke/variables.tf
@@ -31,6 +31,7 @@ variable "cluster" {
     "initialNodeCount"  = "4"
     "project"           = "agones"
     "network"           = "default"
+    "subnetwork"        = ""
     "kubernetesVersion" = "1.15"
   }
 }


### PR DESCRIPTION
Give users the ability the define a custom VPC by adding a subnetwork flag. (fixes #1641 )

To use a custom VPC the network flag has to be specified alongside the subnetwork flag.

When using a default VPC subnetwork can be left blank or undefined.


**Special notes for your reviewer**:
- A separate PR updating the Terraform examples for GKE and docs will be submitted once this is approved. 


