### PR TITLE
Supress fatal message in CPP example build

### DIFF
--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -48,6 +48,7 @@ if (Git_FOUND)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         RESULT_VARIABLE result
         OUTPUT_VARIABLE output
+        ERROR_QUIET
     )
     if (${result} EQUAL 0)
         string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" AGONES_VERSION ${output})


### PR DESCRIPTION
There is no .git folder in Docker when `make build` on `examples/cpp-simple`.
variable.
Note that when running next command `AGONES_VERSION` set as it should:
` make run-sdk-command SDK_FOLDER=cpp COMMAND=build`

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

 /kind cleanup

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1091 

**Special notes for your reviewer**:


