### PR TITLE
Add fuzzer for runtime package

### DIFF
--- a/pkg/testing/fuzz/fuzz.go
+++ b/pkg/testing/fuzz/fuzz.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runtime
+package fuzz
 
 // This file holds fuzzers that are implemented
 // using go-fuzz. More info about go-fuzz can
@@ -25,9 +25,11 @@ package runtime
 // 4) $GOPATH/bin/go-fuzz-build
 // 5) $GOPATH/bin/go-fuzz
 
+import "agones.dev/agones/pkg/util/runtime"
+
 // Fuzz implements a fuzzer that targets ParseFeatures
 func Fuzz(data []byte) int {
-	err := ParseFeatures(string(data))
+	err := runtime.ParseFeatures(string(data))
 	if err != nil {
 		return 0
 	}

--- a/pkg/util/runtime/fuzz.go
+++ b/pkg/util/runtime/fuzz.go
@@ -1,6 +1,31 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtime
 
-// Fuzz implements the fuzz test
+// This file holds fuzzers that are implemented
+// using go-fuzz. More info about go-fuzz can
+// be found at https://github.com/dvyukov/go-fuzz
+
+// To run the below fuzzer locally, follow these steps:
+// 1) go get -u github.com/dvyukov/go-fuzz/go-fuzz
+// 2) go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
+// 3) cd to directory of fuzz.go
+// 4) $GOPATH/bin/go-fuzz-build
+// 5) $GOPATH/bin/go-fuzz
+
+// Fuzz implements a fuzzer that targets ParseFeatures
 func Fuzz(data []byte) int {
 	err := ParseFeatures(string(data))
 	if err != nil {

--- a/pkg/util/runtime/fuzz.go
+++ b/pkg/util/runtime/fuzz.go
@@ -1,0 +1,9 @@
+package runtime
+
+func Fuzz(data []byte) int {
+	err := ParseFeatures(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/util/runtime/fuzz.go
+++ b/pkg/util/runtime/fuzz.go
@@ -1,5 +1,6 @@
 package runtime
 
+// Fuzz implements the fuzz test
 func Fuzz(data []byte) int {
 	err := ParseFeatures(string(data))
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:
This PR introduces a [go-fuzz](https://github.com/dvyukov/go-fuzz) fuzzer that targets a parser in the runtime library.

**Which issue(s) this PR fixes**:
The PR answers https://github.com/googleforgames/agones/issues/1098.
As mentioned in this issue, there is interest in running continuous fuzzing of Agones through OSS-fuzz. OSS-fuzz supports go-fuzz, and I can confirm that this added fuzzer runs on OSS-fuzz's infrastructure. I will be happy to integrate Agones into OSS-fuzz.
Integration will allow OSS-fuzz to run all Agones' fuzzers continuously and provide detailed reports once bugs are found. OSS-fuzz is free but does have an implied expectation that bugs are fixed, so that the resources spent on fuzzing Agones are put to good use.
All I need to integrate Agones are email addresses for the bug reports. These email addresses will be public and can be changed at any time.

I am interested in working more on fuzzing Agones in the future, so if you have any feedback on areas to target first, it will be my pleasure to hear it.

**Special notes for your reviewer**:
The fuzzer can be run locally, but since there is interest in fuzzing continuously, I haven't included instruction on how to do that. 