### PR TITLE
CI: website htmltest fix returning error from the loop

### DIFF
--- a/build/includes/website.mk
+++ b/build/includes/website.mk
@@ -64,7 +64,7 @@ hugo-test: site-static-preview
 		do echo "Html Test: Attempt $$i" && \
 		  docker run --rm -t -e "TERM=xterm-256color" $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
 			"mkdir -p /tmp/website && cp -r $(mount_path)/site/public /tmp/website/site && htmltest -c $(mount_path)/site/htmltest.yaml /tmp/website" && \
-	break || sleep 60; done
+	break || sleep 60 && false; done
 
 site-test:
 	# generate actual html and run test against - provides a more accurate tests


### PR DESCRIPTION
Previously `htmltest` 5-iterations loop returned the error code of the `sleep 60` call, which is always 0.
Ideally we should remove last one minute sleep also.


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1712.

**Special notes for your reviewer**:
A separate PR with all 404 errors fixes. And this will help to identify that now `htmltest` does not give false positive results always. Merge PR #1716 first. As you can see this PR would fail without website fix merged.