### PR TITLE
Fix findOpenPorts portAllocator function

### DIFF
--- a/pkg/gameservers/portallocator.go
+++ b/pkg/gameservers/portallocator.go
@@ -120,6 +120,9 @@ func (pa *PortAllocator) Allocate(gs *agonesv1.GameServer) *agonesv1.GameServer 
 	// Also the return gives an escape from the double loop
 	findOpenPorts := func(amount int) []pn {
 		var ports []pn
+		if amount <= 0 {
+			return ports
+		}
 		for _, n := range pa.portAllocations {
 			for p, taken := range n {
 				if !taken {

--- a/pkg/gameservers/portallocator_test.go
+++ b/pkg/gameservers/portallocator_test.go
@@ -253,7 +253,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 		assert.True(t, cache.WaitForCacheSync(stop, pa.nodeSynced))
 
 		err := pa.syncAll()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// single port empty
 		fd := fixture.DeepCopy()

--- a/pkg/gameservers/portallocator_test.go
+++ b/pkg/gameservers/portallocator_test.go
@@ -40,6 +40,37 @@ var (
 	n3 = corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3", UID: "node3"}}
 )
 
+func TestEmptyPortPolicy(t *testing.T) {
+	t.Parallel()
+	fixture := dynamicGameServerFixture()
+
+	t.Run("test portPolicy as an empty string", func(t *testing.T) {
+		m := agtesting.NewMocks()
+		pa := NewPortAllocator(10, 50, m.KubeInformerFactory, m.AgonesInformerFactory)
+		nodeWatch := watch.NewFake()
+		m.KubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
+
+		stop, cancel := agtesting.StartInformers(m, pa.nodeSynced)
+		defer cancel()
+
+		// Make sure the add's don't corrupt the sync
+		// (no longer an issue, but leave this here for posterity)
+		nodeWatch.Add(&n1)
+		nodeWatch.Add(&n2)
+		assert.True(t, cache.WaitForCacheSync(stop, pa.nodeSynced))
+
+		err := pa.syncAll()
+		assert.Nil(t, err)
+
+		// single port empty
+		fd := fixture.DeepCopy()
+		fd.Spec.Ports[0].PortPolicy = ""
+		pa.Allocate(fd)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, countTotalAllocatedPorts(pa))
+	})
+}
+
 func TestPortAllocatorAllocate(t *testing.T) {
 	t.Parallel()
 	fixture := dynamicGameServerFixture()


### PR DESCRIPTION
There could be the possible case when we set PortPolicy as an empty
string on update of GameServer.


**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

There is a way to cause infinite loop (recursion) in `Allocate()` function using `kubectl edit gameservers`, if you update the `PortPolicy` to an empty string "" and one more field. Then you would receive the state when Agones controller could not allocate any ports and got stuck in this state:
```
kubectl get gs
NAME                     STATE            ADDRESS         PORT   NODE                                     AGE
simple-udp-2skbm-657tc   PortAllocation                                                                   18m
simple-udp-2skbm-894s9   PortAllocation                                                                   18m
simple-udp-7xxfz         PortAllocation   35.230.21.139          gke-test-cluster-default-5847533f-6z66   73m
``` 

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
This is not expected scenario of editing `GameServer` but I assume that restarting agones controller with deleting bad GameServer would recover from this situation.
