### PR TITLE
Terraform Helm enforcing string for set values

### DIFF
--- a/install/terraform/modules/helm3/helm.tf
+++ b/install/terraform/modules/helm3/helm.tf
@@ -93,7 +93,7 @@ resource "helm_release" "agones" {
 
   set {
     name  = "gameservers.namespaces"
-    value = var.gameserver_namespaces
+    value = "{${join(",", var.gameserver_namespaces)}}"
   }
 
   set {

--- a/install/terraform/modules/helm3/variables.tf
+++ b/install/terraform/modules/helm3/variables.tf
@@ -78,4 +78,5 @@ variable "gameserver_maxPort" {
 
 variable "gameserver_namespaces" {
   default = ["default"]
+  type = list(string)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Looks like the most recent Helm provider forces that set value to be a
string.

Since we set it as an array in the Terraform value, this fix does the
work to convert it to Helm array syntax.

See:
https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set

**Which issue(s) this PR fixes**:

Found this while I'm slowly removing deployment manager! (I should probably have a ticket for this)

**Special notes for your reviewer**:

None


