### PR TITLE
Fix parsing the media type in GameServerAllocation

### DIFF
--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -17,6 +17,7 @@ package gameserverallocations
 import (
 	"context"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"time"
 
@@ -175,7 +176,11 @@ func (c *Controller) allocationDeserialization(r *http.Request, namespace string
 	gsa.TypeMeta = metav1.TypeMeta{Kind: gvks[0].Kind, APIVersion: gvks[0].Version}
 
 	mediaTypes := scheme.Codecs.SupportedMediaTypes()
-	info, ok := k8sruntime.SerializerInfoForMediaType(mediaTypes, r.Header.Get("Content-Type"))
+	mt, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return gsa, errors.Wrap(err, "error parsing mediatype from a request header")
+	}
+	info, ok := k8sruntime.SerializerInfoForMediaType(mediaTypes, mt)
 	if !ok {
 		return gsa, errors.New("Could not find deserializer")
 	}


### PR DESCRIPTION
Add a call to filter out optional parameters send in an HTTP header.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

**What this PR does / Why we need it**:
There are parameters like `charset` which would coexist in `Content-Type` header. That's lead `runtime.SerializerInfoForMediaType` to fail, because unexpected parameter was provided.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1748 .

**Special notes for your reviewer**:
Thanks @markmandel for providing the solution in the issue comment

**Steps to reproduce**:
Proof of the fix:
```
export APISERVER=localhost:8001
$ kubectl proxy &
$ curl -X POST -H 'Content-Type: application/json; charset=utf-8' --data '
{
   "apiVersion": "allocation.agones.dev/v1",
   "kind": "GameServerAllocation",
   "spec": {
      "required": {
         "matchLabels": {
            "agones.dev/fleet": "simple-udp"
         }
      }
   }
}
' ${APISERVER}/apis/allocation.agones.dev/v1/namespaces/default/gameserverallocations
{"kind":"GameServerAllocation","apiVersion":"allocation.agones.dev/v1","metadata":{"name":"simple-udp-xv6d5-g4zsd","namespace":"default","creationTimestamp":"2020-08-13T09:05:15Z"},"spec":{"multiClusterSetting":{"policySelector":{}},"required":{"matchLabels":{"agones.dev/fleet":"simple-udp"}},"scheduling":"Packed","metadata":{}},"status":{"state":"Allocated","gameServerName":"simple-udp-xv6d5-g4zsd","ports":[{"name":"default","port":7870}],"address":"34.82.245.95","nodeName":"gke-test-cluster-default-dfffabe4-t97g"}}
```
