### PR TITLE
Locking Rust libz-sys version

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -27,3 +27,4 @@ protobuf = "2.16.2"
 futures = { version = "0.3", features = ["compat"] }
 futures01 = "0.1"
 error-chain = "0.12.3"
+libz-sys = "=1.0.25" # = Can be removed when https://github.com/rust-lang/libz-sys/issues/65 is fixed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Because of https://github.com/rust-lang/libz-sys/issues/65 Locking the libz-sys version, which will unlock CI as well

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

CI is currently blocked until this is fixed (unless the libz-sys team gets to it first)
