### PR TITLE
Update GKE Terraform clusters to 1.16

### DIFF
--- a/build/terraform/gke/module.tf
+++ b/build/terraform/gke/module.tf
@@ -97,10 +97,6 @@ variable "feature_gates" {
   default = ""
 }
 
-variable "kubernetes_version" {
-  default = "1.15"
-}
-
 module "gke_cluster" {
   source = "../../../install/terraform/modules/gke"
 
@@ -111,7 +107,6 @@ module "gke_cluster" {
     "initialNodeCount"  = var.node_count
     "project"           = var.project
     "network"           = var.network
-    "kubernetesVersion" = var.kubernetes_version
   }
 }
 

--- a/build/terraform/prow/module.tf
+++ b/build/terraform/prow/module.tf
@@ -25,7 +25,7 @@ resource "google_container_cluster" "prow-build-cluster" {
   project = var.project
   location = "us-west1-c"
   description = "Prow cluster to run tests for Agones"
-  min_master_version = "1.15"
+  min_master_version = "1.16"
   initial_node_count = 8
   node_config {
     machine_type = "n1-standard-4"

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -29,7 +29,7 @@ locals {
   initialNodeCount  = lookup(var.cluster, "initialNodeCount", "4")
   network           = lookup(var.cluster, "network", "default")
   subnetwork        = lookup(var.cluster, "subnetwork", "")
-  kubernetesVersion = lookup(var.cluster, "kubernetesVersion", "1.15")
+  kubernetesVersion = lookup(var.cluster, "kubernetesVersion", "1.16")
 }
 
 # echo command used for debugging purpose
@@ -57,6 +57,7 @@ resource "google_container_cluster" "primary" {
   node_pool {
     name       = "default"
     node_count = local.initialNodeCount
+    version = local.kubernetesVersion
 
     management {
       auto_upgrade = false
@@ -80,6 +81,7 @@ resource "google_container_cluster" "primary" {
   node_pool {
     name       = "agones-system"
     node_count = 1
+    version = local.kubernetesVersion
 
     management {
       auto_upgrade = false
@@ -111,6 +113,7 @@ resource "google_container_cluster" "primary" {
   node_pool {
     name       = "agones-metrics"
     node_count = 1
+    version = local.kubernetesVersion
 
     management {
       auto_upgrade = false

--- a/install/terraform/modules/gke/variables.tf
+++ b/install/terraform/modules/gke/variables.tf
@@ -32,7 +32,7 @@ variable "cluster" {
     "project"           = "agones"
     "network"           = "default"
     "subnetwork"        = ""
-    "kubernetesVersion" = "1.15"
+    "kubernetesVersion" = "1.16"
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

kind breaking

> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This includes upgrade for:
- Agones Development GKE cluster
- e2e GKE test clusters
- Terraform GKE user cluster

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #1649

**Special notes for your reviewer**:

Also fixes issue on upgrade of a cluster, in that the nodepools are now upgraded as well.

Removed the kubernetes version from the dev cluster variables, as it wasn't being used, and made updating to the new version more complex.

I've run a few e2e tests against the 1.16 cluster with no issue. Once this approved and merged, I'll update the e2e cluster.