### PR TITLE
Make Unreal lambda bindings on the AgonesComponent safe

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -95,8 +95,8 @@ void UAgonesComponent::ConnectSuccess(const FGameServerResponse GameServerRespon
 void UAgonesComponent::Ready(const FReadyDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("ready");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
-		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(
+		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({});
@@ -111,7 +111,7 @@ void UAgonesComponent::Ready(const FReadyDelegate SuccessDelegate, const FAgones
 void UAgonesComponent::GameServer(const FGameServerDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("gameserver", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -152,7 +152,7 @@ void UAgonesComponent::SetLabel(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("metadata/label", FHttpVerb::Put, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -175,7 +175,7 @@ void UAgonesComponent::SetLabel(
 void UAgonesComponent::Health(const FHealthDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("health");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -198,8 +198,8 @@ void UAgonesComponent::Health(const FHealthDelegate SuccessDelegate, const FAgon
 void UAgonesComponent::Shutdown(const FShutdownDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("shutdown");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
-		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(
+		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -223,8 +223,8 @@ void UAgonesComponent::SetAnnotation(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("metadata/annotation", FHttpVerb::Put, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
-		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(
+		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -239,8 +239,8 @@ void UAgonesComponent::SetAnnotation(
 void UAgonesComponent::Allocate(const FAllocateDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("allocate");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
-		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(
+		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -264,8 +264,8 @@ void UAgonesComponent::Reserve(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("reserve", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
-		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(
+		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -292,7 +292,7 @@ void UAgonesComponent::PlayerConnect(
 	Json = Json.Replace(TEXT("playerId"), TEXT("playerID"));
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/connect", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -336,7 +336,7 @@ void UAgonesComponent::PlayerDisconnect(
 	Json = Json.Replace(TEXT("playerId"), TEXT("playerID"));
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/disconnect", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -377,8 +377,8 @@ void UAgonesComponent::SetPlayerCapacity(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
-		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(
+		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -393,7 +393,7 @@ void UAgonesComponent::SetPlayerCapacity(
 void UAgonesComponent::GetPlayerCapacity(FGetPlayerCapacityDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -418,7 +418,7 @@ void UAgonesComponent::GetPlayerCapacity(FGetPlayerCapacityDelegate SuccessDeleg
 void UAgonesComponent::GetPlayerCount(FGetPlayerCountDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/count", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -452,7 +452,7 @@ void UAgonesComponent::IsPlayerConnected(
 {
 	TSharedRef<IHttpRequest> Request =
 		BuildAgonesRequest(FString::Format(TEXT("alpha/player/connected/{0}"), {*PlayerId}), FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -485,7 +485,7 @@ void UAgonesComponent::GetConnectedPlayers(
 	const FGetConnectedPlayersDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/connected/{0}", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindWeakLambda(this, 
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{

--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -73,7 +73,7 @@ void UAgonesComponent::Connect()
 	FGameServerDelegate SuccessDel;
 	SuccessDel.BindUFunction(this, FName("ConnectSuccess"));
 	FTimerDelegate ConnectDel;
-	ConnectDel.BindUObject(this, &UAgonesComponent::GameServer, SuccessDel, FAgonesErrorDelegate()));
+	ConnectDel.BindUObject(this, &UAgonesComponent::GameServer, SuccessDel, FAgonesErrorDelegate());
 	GetWorld()->GetTimerManager().ClearTimer(ConnectDelTimerHandle);
 	GetWorld()->GetTimerManager().SetTimer(ConnectDelTimerHandle, ConnectDel, 5.f, true);
 }

--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -95,8 +95,8 @@ void UAgonesComponent::ConnectSuccess(const FGameServerResponse GameServerRespon
 void UAgonesComponent::Ready(const FReadyDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("ready");
-	Request->OnProcessRequestComplete().BindWeakLambda(
-		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
+		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({});
@@ -198,8 +198,8 @@ void UAgonesComponent::Health(const FHealthDelegate SuccessDelegate, const FAgon
 void UAgonesComponent::Shutdown(const FShutdownDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("shutdown");
-	Request->OnProcessRequestComplete().BindWeakLambda(
-		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
+		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -223,8 +223,8 @@ void UAgonesComponent::SetAnnotation(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("metadata/annotation", FHttpVerb::Put, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(
-		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
+		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -239,8 +239,8 @@ void UAgonesComponent::SetAnnotation(
 void UAgonesComponent::Allocate(const FAllocateDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("allocate");
-	Request->OnProcessRequestComplete().BindWeakLambda(
-		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
+		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -264,8 +264,8 @@ void UAgonesComponent::Reserve(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("reserve", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(
-		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
+		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});
@@ -377,8 +377,8 @@ void UAgonesComponent::SetPlayerCapacity(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindWeakLambda(
-		this, [SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
+	Request->OnProcessRequestComplete().BindWeakLambda(this,
+		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
 				ErrorDelegate.ExecuteIfBound({"Unsuccessful Call"});

--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -63,7 +63,7 @@ void UAgonesComponent::HealthPing(const float RateSeconds)
 	}
 
 	FTimerDelegate TimerDel;
-	TimerDel.BindLambda([this] { Health({}, {}); });
+	TimerDel.BindUObject(this, &UAgonesComponent::Health, FHealthDelegate(), FAgonesErrorDelegate());
 	GetWorld()->GetTimerManager().ClearTimer(HealthTimerHandler);
 	GetWorld()->GetTimerManager().SetTimer(HealthTimerHandler, TimerDel, RateSeconds, true);
 }
@@ -73,7 +73,7 @@ void UAgonesComponent::Connect()
 	FGameServerDelegate SuccessDel;
 	SuccessDel.BindUFunction(this, FName("ConnectSuccess"));
 	FTimerDelegate ConnectDel;
-	ConnectDel.BindLambda([this, SuccessDel] { GameServer(SuccessDel, {}); });
+	ConnectDel.BindUObject(this, &UAgonesComponent::GameServer, SuccessDel, FAgonesErrorDelegate()));
 	GetWorld()->GetTimerManager().ClearTimer(ConnectDelTimerHandle);
 	GetWorld()->GetTimerManager().SetTimer(ConnectDelTimerHandle, ConnectDel, 5.f, true);
 }
@@ -88,7 +88,7 @@ void UAgonesComponent::ConnectSuccess(const FGameServerResponse GameServerRespon
 void UAgonesComponent::Ready(const FReadyDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("ready");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -104,7 +104,7 @@ void UAgonesComponent::Ready(const FReadyDelegate SuccessDelegate, const FAgones
 void UAgonesComponent::GameServer(const FGameServerDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("gameserver", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -145,7 +145,7 @@ void UAgonesComponent::SetLabel(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("metadata/label", FHttpVerb::Put, Json);
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -168,7 +168,7 @@ void UAgonesComponent::SetLabel(
 void UAgonesComponent::Health(const FHealthDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("health");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -191,7 +191,7 @@ void UAgonesComponent::Health(const FHealthDelegate SuccessDelegate, const FAgon
 void UAgonesComponent::Shutdown(const FShutdownDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("shutdown");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -216,7 +216,7 @@ void UAgonesComponent::SetAnnotation(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("metadata/annotation", FHttpVerb::Put, Json);
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -232,7 +232,7 @@ void UAgonesComponent::SetAnnotation(
 void UAgonesComponent::Allocate(const FAllocateDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("allocate");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -257,7 +257,7 @@ void UAgonesComponent::Reserve(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("reserve", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -285,7 +285,7 @@ void UAgonesComponent::PlayerConnect(
 	Json = Json.Replace(TEXT("playerId"), TEXT("playerID"));
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/connect", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -329,7 +329,7 @@ void UAgonesComponent::PlayerDisconnect(
 	Json = Json.Replace(TEXT("playerId"), TEXT("playerID"));
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/disconnect", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -370,7 +370,7 @@ void UAgonesComponent::SetPlayerCapacity(
 	}
 
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Post, Json);
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -386,7 +386,7 @@ void UAgonesComponent::SetPlayerCapacity(
 void UAgonesComponent::GetPlayerCapacity(FGetPlayerCapacityDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -411,7 +411,7 @@ void UAgonesComponent::GetPlayerCapacity(FGetPlayerCapacityDelegate SuccessDeleg
 void UAgonesComponent::GetPlayerCount(FGetPlayerCountDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/count", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -445,7 +445,7 @@ void UAgonesComponent::IsPlayerConnected(
 {
 	TSharedRef<IHttpRequest> Request =
 		BuildAgonesRequest(FString::Format(TEXT("alpha/player/connected/{0}"), {*PlayerId}), FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{
@@ -478,7 +478,7 @@ void UAgonesComponent::GetConnectedPlayers(
 	const FGetConnectedPlayersDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	TSharedRef<IHttpRequest> Request = BuildAgonesRequest("alpha/player/connected/{0}", FHttpVerb::Get, "");
-	Request->OnProcessRequestComplete().BindLambda(
+	Request->OnProcessRequestComplete().BindWeakLambda(this, 
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, const FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!bSucceeded)
 			{

--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -40,6 +40,13 @@ void UAgonesComponent::BeginPlay()
 void UAgonesComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
 	Super::EndPlay(EndPlayReason);
+
+	const UWorld* World = GetWorld();
+	if (World != nullptr)
+	{
+		World->GetTimerManager().ClearTimer(ConnectDelTimerHandle);
+		World->GetTimerManager().ClearTimer(HealthTimerHandler);
+	}
 }
 
 TSharedRef<IHttpRequest> UAgonesComponent::BuildAgonesRequest(const FString Path, const FHttpVerb Verb, const FString Content)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
This PR fixes a crash in Unreal projects using the plugin, whenever a World is unloaded (loading a new level).
The issue was with lamda bindings that were being called from the engine's TimerManger, but without passing the calling object, which meant the TimerManager did not know that the object was destroyed and tried to invoke the lambda anyway.
The method we can use instead to avoid this is `BindUObject`, which works with any member UFUNCTION and is invalidation-safe.
Additionally, I replaced the other `BindLambda` calls in the file with `BindWeakLambda`, which is also invalidation-safe. These instances were not causing crashes, but if the ownership of the caller changes in the future, they could potentially crash then, and `BindWeakLambda` is a good practice in general.
EDIT: Added missing clearances of TimerHandles when EndPlay is called also. This would also fix the crashes, but also just serves as state clean-up.


**UE4 Build Output:**
```
1>------ Build started: Project: AgonesTestProject, Configuration: Development_Editor x64 ------
1>Using 'git status' to determine working set for adaptive non-unity build (D:\UE4_Vela_4.24.1).
1>Building AgonesTestProjectEditor and ShaderCompileWorker...
1>Using Visual Studio 2019 14.24.28314 toolchain (C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.24.28314) and Windows 10.0.18362.0 SDK (C:\Program Files (x86)\Windows Kits\10).
1>[Upgrade]
1>[Upgrade] Using backward-compatible build settings. The latest version of UE4 sets the following values by default, which may require code changes:
1>[Upgrade]     bLegacyPublicIncludePaths = false                 => Omits subfolders from public include paths to reduce compiler command line length. (Previously: true).
1>[Upgrade]     ShadowVariableWarningLevel = WarningLevel.Error   => Treats shadowed variable warnings as errors. (Previously: WarningLevel.Warning).
1>[Upgrade]     PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs   => Set in build.cs files to enables IWYU-style PCH model. See https://docs.unrealengine.com/en-US/Programming/BuildTools/UnrealBuildTool/IWYU/index.html. (Previously: PCHUsageMode.UseSharedPCHs).
1>[Upgrade] Suppress this message by setting 'DefaultBuildSettings = BuildSettingsVersion.V2;' in AgonesTestProjectEditor.Target.cs, and explicitly overriding settings that differ from the new defaults.
1>[Upgrade]
1>Building 12 actions with 12 processes...
1>  [1/12] Module.Voice.cpp
1>  [2/12] UE4Editor-Voice.lib
1>     Creating library D:\UE4_Vela_4.24.1\Engine\Intermediate\Build\Win64\UE4Editor\Development\Voice\UE4Editor-Voice.lib and object D:\UE4_Vela_4.24.1\Engine\Intermediate\Build\Win64\UE4Editor\Development\Voice\UE4Editor-Voice.exp
1>  [3/12] Module.OnlineSubsystemUtils.gen.cpp
1>  [4/12] UE4Editor-Voice.dll
1>     Creating library D:\UE4_Vela_4.24.1\Engine\Intermediate\Build\Win64\UE4Editor\Development\Voice\UE4Editor-Voice.suppressed.lib and object D:\UE4_Vela_4.24.1\Engine\Intermediate\Build\Win64\UE4Editor\Development\Voice\UE4Editor-Voice.suppressed.exp
1>  [5/12] Module.OnlineSubsystemUtils.cpp
1>  [6/12] UE4Editor-OnlineSubsystemUtils.lib
1>     Creating library D:\UE4_Vela_4.24.1\Engine\Plugins\Online\OnlineSubsystemUtils\Intermediate\Build\Win64\UE4Editor\Development\OnlineSubsystemUtils\UE4Editor-OnlineSubsystemUtils.lib and object D:\UE4_Vela_4.24.1\Engine\Plugins\Online\OnlineSubsystemUtils\Intermediate\Build\Win64\UE4Editor\Development\OnlineSubsystemUtils\UE4Editor-OnlineSubsystemUtils.exp
1>  [7/12] UE4Editor-OnlineSubsystemUtils.dll
1>     Creating library D:\UE4_Vela_4.24.1\Engine\Plugins\Online\OnlineSubsystemUtils\Intermediate\Build\Win64\UE4Editor\Development\OnlineSubsystemUtils\UE4Editor-OnlineSubsystemUtils.suppressed.lib and object D:\UE4_Vela_4.24.1\Engine\Plugins\Online\OnlineSubsystemUtils\Intermediate\Build\Win64\UE4Editor\Development\OnlineSubsystemUtils\UE4Editor-OnlineSubsystemUtils.suppressed.exp
1>  [8/12] Module.Agones.gen.cpp
1>  [9/12] Module.Agones.cpp
1>  [10/12] UE4Editor-Agones.lib
1>     Creating library D:\Repos\AgonesTestProject\AgonesTestProject\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.lib and object D:\Repos\AgonesTestProject\AgonesTestProject\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.exp
1>  [11/12] UE4Editor-Agones.dll
1>     Creating library D:\Repos\AgonesTestProject\AgonesTestProject\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.suppressed.lib and object D:\Repos\AgonesTestProject\AgonesTestProject\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.suppressed.exp
1>  [12/12] AgonesTestProjectEditor.target
1>Total time in Parallel executor: 113.88 seconds
1>Total execution time: 116.05 seconds
========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
```
