### PR TITLE
Add Uninstall instructions when using install.yaml

### DIFF
--- a/site/content/en/docs/Installation/Install Agones/yaml.md
+++ b/site/content/en/docs/Installation/Install Agones/yaml.md
@@ -6,6 +6,8 @@ description: >
   We can install Agones to the cluster using an install.yaml file.
 ---
 
+### Installing Agones
+
 {{< alert title="Warning" color="warning">}}
 Installing Agones with the `install.yaml` will setup the TLS certificates stored in this repository for securing
 kubernetes webhooks communication. 
@@ -35,6 +37,19 @@ helm template agones-manual --namespace agones-system  . \
 Note: `pull` command was introduced in Helm version 3.
 
 You can also find the install.yaml in the latest `agones-install` zip from the [releases](https://github.com/googleforgames/agones/releases) archive.
+
+### Uninstalling Agones
+
+To uninstall/delete the `Agones` deployment and delete `agones-system` namespace:
+
+```bash
+$ kubectl delete fleets --all --all-namespaces
+$ kubectl delete gameservers --all --all-namespaces
+$ kubectl delete -f https://raw.githubusercontent.com/googleforgames/agones/{{< release-branch >}}/install/yaml/install.yaml
+$ kubectl delete namespace agones-system
+```
+
+Note: you should wait up to a couple of minutes until all resources described in `install.yaml` file would be deleted.
 
 ## Next Steps
 


### PR DESCRIPTION
Add some instructions on how to delete Agones resources and remove the `agones-system`
namespace.

**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:
We have instructions how to `helm uninstall agones`, but there is no details on how to properly cleanup cluster, after using `kubectl apply -f ./install.yaml`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1778

**Special notes for your reviewer**:

Without `kubectl delete gameservers` and `fleets` steps, `kubectl delete -f` stucks on removing `gameservers` CRD.