### PR TITLE
Docs: updating Minikube kubernetes version to 1.16

### DIFF
--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -26,7 +26,7 @@ kind-test-cluster: DOCKER_RUN_ARGS+=--network=host
 kind-test-cluster: $(ensure-build-image)
 	@if [ -z $$(kind get clusters | grep $(KIND_PROFILE)) ]; then\
 		echo "Could not find $(KIND_PROFILE) cluster. Creating...";\
-		kind create cluster --name $(KIND_PROFILE) --image kindest/node:v1.15.7 --wait 5m;\
+		kind create cluster --name $(KIND_PROFILE) --image kindest/node:v1.16.9 --wait 5m;\
 	fi
 
 # deletes the kind agones cluster

--- a/build/includes/minikube.mk
+++ b/build/includes/minikube.mk
@@ -27,7 +27,7 @@
 # (defaults virtualbox for Linux and macOS, hyperv for windows) if you so desire.
 minikube-test-cluster: DOCKER_RUN_ARGS+=--network=host -v $(minikube_cert_mount)
 minikube-test-cluster: $(ensure-build-image) minikube-agones-profile
-	$(MINIKUBE) start --kubernetes-version v1.15.11 --vm-driver $(MINIKUBE_DRIVER)
+	$(MINIKUBE) start --kubernetes-version v1.16.13 --vm-driver $(MINIKUBE_DRIVER)
 	# wait until the master is up
 	until docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) kubectl cluster-info; \
 		do \

--- a/site/content/en/docs/Installation/Creating Cluster/minikube.md
+++ b/site/content/en/docs/Installation/Creating Cluster/minikube.md
@@ -29,9 +29,16 @@ minikube profile agones
 The following command starts a local minikube cluster via virtualbox - but this can be
 replaced by a [vm-driver](https://github.com/kubernetes/minikube#requirements) of your choice.
 
+{{% feature expiryVersion="1.9.0" %}}
 ```bash
 minikube start --kubernetes-version v1.15.10 --vm-driver virtualbox
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.9.0" %}}
+```bash
+minikube start --kubernetes-version v1.16.13 --vm-driver virtualbox
+```
+{{% /feature %}}
 
 ## Next Steps
 


### PR DESCRIPTION
Also updating Kind and Minikube make targets to use 1.16.13 as current
GKE cluster version.

**What type of PR is this?**

/kind documentation

**What this PR does / Why we need it**:

It is crucial for those developers who use Minikube or Kind tools for testing their Agones gameservers to have the same development environment as the production one.

**Which issue(s) this PR fixes**:
Relates to #1649

**Special notes for your reviewer**:


