### PR TITLE
Add load balancer configuration for Helm options

### DIFF
--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -108,6 +108,15 @@ spec:
       targetPort: 8080
       protocol: TCP
   type: {{ .Values.agones.ping.http.serviceType }}
+{{- if eq .Values.agones.ping.http.serviceType "LoadBalancer" }}
+  {{- if .Values.agones.ping.http.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.agones.ping.http.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.agones.ping.http.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.agones.ping.http.loadBalancerSourceRanges | indent 4 }}
+  {{- end }}
+{{- end }}
   {{- end }}
 
   {{- if .Values.agones.ping.udp.expose }}
@@ -136,6 +145,15 @@ spec:
       targetPort: 8080
       protocol: UDP
   type: {{ .Values.agones.ping.udp.serviceType }}
+{{- if eq .Values.agones.ping.udp.serviceType "LoadBalancer" }}
+  {{- if .Values.agones.ping.udp.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.agones.ping.udp.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.agones.ping.udp.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.agones.ping.udp.loadBalancerSourceRanges | indent 4 }}
+  {{- end }}
+{{- end }}
   {{- end }}
 
 {{- end }}

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -42,6 +42,12 @@ spec:
 {{- if $useLoadBalancerIP }}
   loadBalancerIP: {{ .Values.agones.allocator.http.loadBalancerIP }}
 {{- end }}
+{{- if eq .Values.agones.allocator.http.serviceType "LoadBalancer" }}
+  {{- if .Values.agones.allocator.http.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.agones.allocator.http.loadBalancerSourceRanges | indent 4 }}
+  {{- end }}
+{{- end }}
 
 ---
 # Deploy a pod to run the agones-allocator code

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -88,12 +88,16 @@ agones:
       response: ok
       port: 80
       serviceType: LoadBalancer
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
       annotations: {}
     udp:
       expose: true
       rateLimit: 20
       port: 50000
       serviceType: LoadBalancer
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
       annotations: {}
     healthCheck:
       initialDelaySeconds: 3
@@ -125,6 +129,7 @@ agones:
       port: 443
       serviceType: LoadBalancer
       loadBalancerIP: ""
+      loadBalancerSourceRanges: []
       annotations: {}
     generateTLS: true
     generateClientTLS: true

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -228,7 +228,12 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
-| `agones.allocator.http.loadBalancerIP`              | The [Load Balancer IP][loadBalancerIP] of the Agones allocator load balancer. Only works if the Kubernetes provider supports this option. | ""                     |
+| `agones.allocator.http.loadBalancerIP`              | The [Load Balancer IP][loadBalancer] of the Agones allocator load balancer. Only works if the Kubernetes provider supports this option. | ""                     |
+| `agones.allocator.http.loadBalancerSourceRanges`    | The [Load Balancer SourceRanges][loadBalancer] of the Agones allocator load balancer. Only works if the Kubernetes provider supports this option. | `[]`         |
+| `agones.ping.http.loadBalancerIP`                   | The [Load Balancer IP][loadBalancer] of the HTTP Service load balancer. Only works if the Kubernetes provider supports this option.               | ""           |
+| `agones.ping.http.loadBalancerSourceRanges`         | The [Load Balancer SourceRanges][loadBalancer] of the HTTP Service load balancer. Only works if the Kubernetes provider supports this option.     | `[]`         |
+| `agones.ping.udp.loadBalancerIP`                    | The [Load Balancer IP][loadBalancer] of the UDP Service load balancer. Only works if the Kubernetes provider supports this option.                | ""           |
+| `agones.ping.udp.loadBalancerSourceRanges`          | The [Load Balancer SourceRanges][loadBalancer] of the UDP Service load balancer. Only works if the Kubernetes provider supports this option.      | `[]`         |
 | `agones.allocator.disableMTLS`                      | Turns off client cert authentication for incoming connections to the allocator.            | `false`                |
 | `agones.allocator.disableTLS`                       | Turns off TLS security for incoming connections to the allocator. | `false`                |
 
@@ -242,7 +247,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 [ping]: {{< ref "/docs/Guides/ping-service.md" >}}
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [allocator]: {{< ref "/docs/advanced/allocator-service.md" >}}
-[loadBalancerIP]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+[loadBalancer]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Added the following Helm configuration options:

* `agones.allocator.http.loadBalancerSourceRanges`
* `agones.ping.http.loadBalancerIP`
* `agones.ping.http.loadBalancerSourceRanges`
* `agones.ping.udp.loadBalancerIP`
* `agones.ping.udp.loadBalancerSourceRanges`

This allows the Helm installation to configure the LoadBalancer loadBalancerIP and loadBalancerSourceRanges.

