### PR TITLE
Flaky: TestControllerGameServersNodeState

### DIFF
--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -37,6 +37,12 @@ import (
 // newFakeController returns a controller, backed by the fake Clientset
 func newFakeController() *fakeController {
 	m := agtesting.NewMocks()
+	return newFakeControllerWithMock(m)
+}
+
+// newFakeControllerWithMock returns a Controller with a pre-populated mock.
+// This is useful if you want to populate a data set before the informer starts.
+func newFakeControllerWithMock(m agtesting.Mocks) *fakeController {
 	c := NewController(m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
 	gsWatch := watch.NewFake()
 	fasWatch := watch.NewFake()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This involves two things:

(1) Adding a newFakeControllerWithMock to the metric test utilities to allow for pre-population -- which with the client-go updates make it far easier to write deterministic tests.

(2) Updated TestControllerGameServersNodeState with the new mock construction.

This included removing the c.run() command, which can run c.collect() at any point in time, and any number of times before the tests being checked, and replaced this a c.collect() so we can control exactly when metric collection occurs during the tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Ran this a few hundred times, no failures.