### PR TITLE
Docs: Fix rest `GetPlayerCount` description

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -262,9 +262,8 @@ Response:
 
 #### Alpha: GetPlayerCount
 
-This function returns if the playerID is currently connected to the GameServer. 
-This is always accurate from what has been set through this SDK,
-even if the value has yet to be updated on the GameServer status resource.
+This function retrieves the current player count. 
+This is always accurate from what has been set through this SDK, even if the value has yet to be updated on the GameServer status resource.
 
 ```bash
 $ curl -H "Content-Type: application/json" -X GET http://localhost:${AGONES_SDK_HTTP_PORT}/alpha/player/count


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / Why we need it**:

Fixes the REST docs

**Which issue(s) this PR fixes**:
Closes #1810 

**Special notes for your reviewer**:

I assumed that this behavior is also true for this entry:

> This is always accurate from what has been set through this SDK, even if the value has yet to be updated on the GameServer status resource.
