### PR TITLE
Fix Directory variable used and defined in different make targets

### DIFF
--- a/build/includes/google-cloud.mk
+++ b/build/includes/google-cloud.mk
@@ -39,27 +39,27 @@ clean-gcloud-test-cluster: $(ensure-build-image)
 gcloud-e2e-test-cluster: GCP_PROJECT ?= $(current_project)
 gcloud-e2e-test-cluster: $(ensure-build-image)
 gcloud-e2e-test-cluster:
-	$(MAKE) terraform-init DIRECTORY=e2e
+	$(MAKE) terraform-init TERRAFORM_BUILD_DIR=$(mount_path)/build/terraform/e2e
 	docker run --rm -it $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c 'cd $(mount_path)/build/terraform/e2e && \
       	terraform apply -auto-approve -var project="$(GCP_PROJECT)"'
 
 # Deletes the gcloud e2e cluster and cleanup any left pvc volumes
 clean-gcloud-e2e-test-cluster: $(ensure-build-image)
 clean-gcloud-e2e-test-cluster:
-	$(MAKE) terraform-init DIRECTORY=e2e
+	$(MAKE) terraform-init TERRAFORM_BUILD_DIR=$(mount_path)/build/terraform/e2e
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/e2e && terraform destroy -var project=$(GCP_PROJECT) -auto-approve'
 
 # Creates a gcloud cluster for prow
 gcloud-prow-build-cluster: GCP_PROJECT ?= $(current_project)
 gcloud-prow-build-cluster: $(ensure-build-image)
 gcloud-prow-build-cluster:
-	$(MAKE) terraform-init DIRECTORY=prow
+	$(MAKE) terraform-init TERRAFORM_BUILD_DIR=$(mount_path)/build/terraform/prow
 	docker run --rm -it $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c 'cd $(mount_path)/build/terraform/prow && \
       	terraform apply -auto-approve -var project="$(GCP_PROJECT)"'
 
 # Deletes the gcloud prow build cluster
 clean-gcloud-prow-build-cluster: $(ensure-build-image)
-	$(MAKE) terraform-init DIRECTORY=prow
+	$(MAKE) terraform-init TERRAFORM_BUILD_DIR=$(mount_path)/build/terraform/prow
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/prow && terraform destroy -var project=$(GCP_PROJECT) -auto-approve'
 
 # Pulls down authentication information for kubectl against a cluster, name can be specified through GCP_CLUSTER_NAME

--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -44,7 +44,7 @@ gcloud-terraform-cluster: $(ensure-build-image)
 gcloud-terraform-cluster: FEATURE_GATES := ""
 gcloud-terraform-cluster: GCP_PROJECT ?= $(current_project)
 gcloud-terraform-cluster:
-	$(MAKE) terraform-init DIRECTORY=gke
+	$(MAKE) terraform-init
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && \
 		 terraform apply -auto-approve -var agones_version="$(AGONES_VERSION)" \
 		-var name=$(GCP_TF_CLUSTER_NAME) -var machine_type="$(GCP_CLUSTER_NODEPOOL_MACHINETYPE)" \
@@ -69,7 +69,7 @@ gcloud-terraform-install: LOG_LEVEL ?= debug
 gcloud-terraform-install: FEATURE_GATES := $(ALPHA_FEATURE_GATES)
 gcloud-terraform-install: GCP_PROJECT ?= $(current_project)
 gcloud-terraform-install:
-	$(MAKE) terraform-init DIRECTORY=gke
+	$(MAKE) terraform-init
 	$(DOCKER_RUN) bash -c ' \
 	cd $(mount_path)/build/terraform/gke && terraform apply -auto-approve -var agones_version="$(VERSION)" -var image_registry="$(REGISTRY)" \
 		-var pull_policy="$(IMAGE_PULL_POLICY)" \


### PR DESCRIPTION
There was a discrepancy in E2E and Prow cluster targets in init
 Terraform directory.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
We should use the same variables all over the Makefile and mk includes.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:


