### PR TITLE
Corrected gke docs 'release-release' typo

### DIFF
--- a/site/content/en/docs/Installation/Terraform/gke.md
+++ b/site/content/en/docs/Installation/Terraform/gke.md
@@ -102,8 +102,8 @@ On the lines that read `source = "git::https://github.com/googleforgames/agones.
 make sure to change `?ref=master` to match your targeted Agones release, as Terraform modules can change between
 releases.
 
-For example, if you are targeting release {{< release-branch >}}, then you will want to have 
-`source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-{{< release-branch >}}"`
+For example, if you are targeting {{< release-branch >}}, then you will want to have 
+`source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref={{< release-branch >}}"`
 as your source.
 {{% /alert %}}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

A small typo existed in [an installation step](https://agones.dev/site/docs/installation/terraform/gke/), so this PR corrects for that. 

The current text is as follows:

> For example, if you are targeting release release-1.8.0, then you will want to have source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-release-1.8.0" as your source.

This should instead say `?ref=release-1.8.0`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
