### PR TITLE
[Doc] Mark multicluster allocation feature as stable

### DIFF
--- a/site/content/en/docs/Advanced/multi-cluster-allocation.md
+++ b/site/content/en/docs/Advanced/multi-cluster-allocation.md
@@ -5,10 +5,6 @@ description: >
   In order to allow allocation from multiple clusters, Agones provides a mechanism to set redirect rules for allocation requests to the right cluster.
 ---
 
-{{< alert title="Beta" color="warning">}}
-This feature is in a pre-release state and might change.
-{{< /alert >}}
-
 There may be different types of clusters, such as on-premise, and Google Kubernetes Engine (GKE), used by a game to help with the cost-saving and availability. 
 For this purpose, Agones provides a mechanism to define priorities on the clusters. Priorities are defined on {{< ghlink href="pkg/apis/multicluster/v1/gameserverallocationpolicy.go" >}}GameServerAllocationPolicy{{< /ghlink >}} agones CRD. A matchmaker can enable the multi-cluster rules on a request and target [agones-allocator]({{< relref "allocator-service.md">}}) endpoint in any of the clusters and get resources allocated on the cluster with the highest priority. If the cluster with the highest priority is overloaded, the allocation request is redirected to the cluster with the next highest priority.
 

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -27,7 +27,6 @@ The current set of `alpha` and `beta` feature gates are:
 {{% feature publishVersion="1.9.0" %}}
 | Feature Name | Gate    | Default | Stage | Since |
 |--------------|---------|---------|-------|-------|
-| Multicluster Allocation<sup>*</sup> | N/A | Enabled | `Beta` | 1.6.0 |
 | Example Gate (not in use) | `Example` | Disabled | None | 0.13.0 |
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
@@ -37,14 +36,11 @@ The current set of `alpha` and `beta` feature gates are:
 {{% feature expiryVersion="1.9.0" %}}
 | Feature Name | Gate    | Default | Stage | Since |
 |--------------|---------|---------|-------|-------|
-| Multicluster Allocation<sup>*</sup> | N/A | Enabled | `Beta` | 1.6.0 |
 | Example Gate (not in use) | `Example` | Disabled | None | 0.13.0 |
 | [Port Allocations to Multiple Containers]({{< ref "/docs/Reference/gameserver.md" >}}) | `ContainerPortAllocation` | Enabled | `Beta` | 1.7.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
 | [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Disabled | `Alpha` | 1.7.0 |
 {{% /feature %}}
-<sup>*</sup>Multicluster Allocation was started before this process was in place, and therefore does not have a
- feature gate and cannot be disabled.
 
 ## Description of Stages
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

 /kind documentation

**What this PR does / Why we need it**:
Changing the multicluster allocation version to stable

Closes #1780



