### PR TITLE
Remove Make commands from Metrics documentation

### DIFF
--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -132,12 +132,6 @@ helm upgrade --install --wait prom stable/prometheus --namespace metrics \
     -f ./build/prometheus.yaml
 ```
 
-{{% alert title="Note" color="info"%}}
-You can also run our {{< ghlink href="/build/Makefile" branch="master" branch="master" >}}Makefile{{< /ghlink >}} target `make setup-prometheus`
-or `make kind-setup-prometheus` and `make minikube-setup-prometheus` 
-for {{< ghlink href="/build/README.md#running-a-test-kind-cluster" branch="master" >}}Kind{{< /ghlink >}} and {{< ghlink href="/build/README.md#running-a-test-minikube-cluster" branch="master" >}}Minikube{{< /ghlink >}}.
-{{% /alert %}}
-
 For resiliency it is recommended to run Prometheus on a dedicated node which is separate from nodes where Game Servers
 are scheduled. If you use the above command, with our {{< ghlink href="/build/prometheus.yaml" branch="master" >}}prometheus.yaml{{< /ghlink >}} to set up Prometheus, it will schedule Prometheus pods on nodes
 tainted with `agones.dev/agones-metrics=true:NoExecute` and labeled with `agones.dev/agones-metrics=true` if available.
@@ -162,11 +156,6 @@ Finally to access Prometheus metrics, rules and alerts explorer use
 ```bash
 kubectl port-forward deployments/prom-prometheus-server 9090 -n metrics
 ```
-
-{{< alert title="Note" color="info">}}
- Again you can use our Makefile {{< ghlink href="/build/README.md#prometheus-portforward" branch="master" >}}`make prometheus-portforward`{{< /ghlink >}}.
-  (For {{< ghlink href="/build/README.md#running-a-test-kind-cluster" branch="master" >}}Kind{{< /ghlink >}} and {{< ghlink href="/build/README.md#running-a-test-minikube-cluster" branch="master" >}}Minikube{{< /ghlink >}} use their specific targets `make kind-prometheus-portforward` and `make minikube-prometheus-portforward`)
-{{< /alert >}}
 
 Now you can access the prometheus dashboard [http://localhost:9090](http://localhost:9090).
 
@@ -197,10 +186,6 @@ helm install --wait --name grafana stable/grafana --version=5.0.13 --namespace m
 
 This will install Grafana with our prepopulated dashboards and prometheus datasource [previously installed](#prometheus-installation)
 
-{{< alert title="Note" color="info">}}
-You can also use our {{< ghlink href="/build/Makefile" branch="master" >}}Makefile{{< /ghlink >}} targets (`setup-grafana`, `minikube-setup-grafana` and `kind-setup-grafana`).
-{{< /alert >}}
-
 Finally to access dashboards run
 
 ```bash
@@ -208,10 +193,6 @@ kubectl port-forward deployments/grafana 3000 -n metrics
 ```
 
 Open a web browser to [http://localhost:3000](http://localhost:3000), you should see Agones [dashboards](#grafana-dashboards) after login as admin.
-
-{{< alert title="Note" color="info">}}
-You can also use our `Makefile` targets `make grafana-portforward`, `make kind-grafana-portforward` and `make minikube-grafana-portforward`.
-{{< /alert >}}
 
 ### Stackdriver installation
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Users shouldn't be seeing the internal development tooling, so I removed the references to `build/` Make commands from the metrics setup and usage documentation.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A