### PR TITLE
Add TypeMeta to GameServerAllocation when doing convertion

### DIFF
--- a/pkg/allocation/converters/converter.go
+++ b/pkg/allocation/converters/converter.go
@@ -171,6 +171,10 @@ func ConvertAllocationResponseToGSA(in *pb.AllocationResponse) *allocationv1.Gam
 	}
 
 	out := &allocationv1.GameServerAllocation{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       allocationv1.SchemeGroupVersion.Group,
+			APIVersion: allocationv1.SchemeGroupVersion.Version,
+		},
 		Status: allocationv1.GameServerAllocationStatus{
 			State:          allocationv1.GameServerAllocationAllocated,
 			GameServerName: in.GameServerName,

--- a/pkg/allocation/converters/converter_test.go
+++ b/pkg/allocation/converters/converter_test.go
@@ -231,6 +231,10 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 		{
 			name: "status state is set to allocated",
 			in: &allocationv1.GameServerAllocation{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "allocation.agones.dev",
+					APIVersion: "v1",
+				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State:          allocationv1.GameServerAllocationAllocated,
 					GameServerName: "GSN",
@@ -263,6 +267,10 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 		{
 			name: "status field is set to unallocated",
 			in: &allocationv1.GameServerAllocation{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "allocation.agones.dev",
+					APIVersion: "v1",
+				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State:          allocationv1.GameServerAllocationUnAllocated,
 					GameServerName: "GSN",
@@ -284,6 +292,10 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 		{
 			name: "status state is set to contention",
 			in: &allocationv1.GameServerAllocation{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "allocation.agones.dev",
+					APIVersion: "v1",
+				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State: allocationv1.GameServerAllocationContention,
 				},
@@ -294,6 +306,10 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 		{
 			name: "Empty fields",
 			in: &allocationv1.GameServerAllocation{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "allocation.agones.dev",
+					APIVersion: "v1",
+				},
 				Status: allocationv1.GameServerAllocationStatus{
 					Ports: []agonesv1.GameServerStatusPort{},
 				},
@@ -304,6 +320,10 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 		{
 			name: "Empty objects",
 			in: &allocationv1.GameServerAllocation{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "allocation.agones.dev",
+					APIVersion: "v1",
+				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State: allocationv1.GameServerAllocationAllocated,
 				},
@@ -355,6 +375,10 @@ func TestConvertAllocationResponseToGSA(t *testing.T) {
 				Ports: []*pb.AllocationResponse_GameServerStatusPort{},
 			},
 			want: &allocationv1.GameServerAllocation{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "allocation.agones.dev",
+					APIVersion: "v1",
+				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State: allocationv1.GameServerAllocationAllocated,
 				},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:
Adds `TypeMeta` to `GameServerAllocation` response when doing conversion in multicluster allocation as the `kubectl ` command line fails if the `Kind` is not set.

**Which issue(s) this PR fixes**:
Closes #1864


