### PR TITLE
Fix kind on GameServerAllocation converter

### DIFF
--- a/pkg/allocation/converters/converter.go
+++ b/pkg/allocation/converters/converter.go
@@ -171,10 +171,6 @@ func ConvertAllocationResponseToGSA(in *pb.AllocationResponse) *allocationv1.Gam
 	}
 
 	out := &allocationv1.GameServerAllocation{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       allocationv1.SchemeGroupVersion.Group,
-			APIVersion: allocationv1.SchemeGroupVersion.Version,
-		},
 		Status: allocationv1.GameServerAllocationStatus{
 			State:          allocationv1.GameServerAllocationAllocated,
 			GameServerName: in.GameServerName,
@@ -183,6 +179,7 @@ func ConvertAllocationResponseToGSA(in *pb.AllocationResponse) *allocationv1.Gam
 			Ports:          convertAllocationPortsToGSAAgonesPorts(in.Ports),
 		},
 	}
+	out.SetGroupVersionKind(allocationv1.SchemeGroupVersion.WithKind("GameServerAllocation"))
 
 	return out
 }

--- a/pkg/allocation/converters/converter_test.go
+++ b/pkg/allocation/converters/converter_test.go
@@ -232,8 +232,8 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 			name: "status state is set to allocated",
 			in: &allocationv1.GameServerAllocation{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "allocation.agones.dev",
-					APIVersion: "v1",
+					Kind:       "GameServerAllocation",
+					APIVersion: "allocation.agones.dev/v1",
 				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State:          allocationv1.GameServerAllocationAllocated,
@@ -268,8 +268,8 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 			name: "status field is set to unallocated",
 			in: &allocationv1.GameServerAllocation{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "allocation.agones.dev",
-					APIVersion: "v1",
+					Kind:       "GameServerAllocation",
+					APIVersion: "allocation.agones.dev/v1",
 				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State:          allocationv1.GameServerAllocationUnAllocated,
@@ -293,8 +293,8 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 			name: "status state is set to contention",
 			in: &allocationv1.GameServerAllocation{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "allocation.agones.dev",
-					APIVersion: "v1",
+					Kind:       "GameServerAllocation",
+					APIVersion: "allocation.agones.dev/v1",
 				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State: allocationv1.GameServerAllocationContention,
@@ -307,8 +307,8 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 			name: "Empty fields",
 			in: &allocationv1.GameServerAllocation{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "allocation.agones.dev",
-					APIVersion: "v1",
+					Kind:       "GameServerAllocation",
+					APIVersion: "allocation.agones.dev/v1",
 				},
 				Status: allocationv1.GameServerAllocationStatus{
 					Ports: []agonesv1.GameServerStatusPort{},
@@ -321,8 +321,8 @@ func TestConvertGSAToAllocationResponse(t *testing.T) {
 			name: "Empty objects",
 			in: &allocationv1.GameServerAllocation{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "allocation.agones.dev",
-					APIVersion: "v1",
+					Kind:       "GameServerAllocation",
+					APIVersion: "allocation.agones.dev/v1",
 				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State: allocationv1.GameServerAllocationAllocated,
@@ -376,8 +376,8 @@ func TestConvertAllocationResponseToGSA(t *testing.T) {
 			},
 			want: &allocationv1.GameServerAllocation{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "allocation.agones.dev",
-					APIVersion: "v1",
+					Kind:       "GameServerAllocation",
+					APIVersion: "allocation.agones.dev/v1",
 				},
 				Status: allocationv1.GameServerAllocationStatus{
 					State: allocationv1.GameServerAllocationAllocated,


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / Why we need it**:
Kind was not correctly set for "GameServerAllocation" on gRPC to GameServerAllocation response converter.

**Which issue(s) this PR fixes**:
Closes #1864

**Special notes for your reviewer**:


