### PR TITLE
Move the loadBalancerIP to helm installation as best effort

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -298,6 +298,7 @@ install: PING_SERVICE_TYPE := "LoadBalancer"
 install: ALLOCATOR_SERVICE_TYPE := "LoadBalancer"
 install: CRD_CLEANUP := true
 install: LOG_LEVEL := "debug"
+install: EXTERNAL_IP ?= $(shell $(DOCKER_RUN) kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 install: FEATURE_GATES ?= $(ALPHA_FEATURE_GATES)
 install: HELM_ARGS ?=
 install: $(ensure-build-image) install-custom-pull-secret
@@ -312,14 +313,14 @@ install: $(ensure-build-image) install-custom-pull-secret
 		--set agones.controller.logLevel=$(LOG_LEVEL) \
 		--set agones.crds.cleanupOnDelete=$(CRD_CLEANUP) \
 		--set agones.featureGates=$(FEATURE_GATES) \
+		--set agones.allocator.http.loadBalancerIP=$(EXTERNAL_IP) \
 		$(HELM_ARGS) \
 		agones $(mount_path)/install/helm/agones/
 
-update-allocation-certs: EXTERNAL_IP ?= $(shell $(DOCKER_RUN) kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 update-allocation-certs: NAMESPACE ?= default
+update-allocation-certs: install
 update-allocation-certs:
 	-mkdir -p $(agones_path)/build/allocation
-	$(MAKE) install HELM_ARGS="--set agones.allocator.http.loadBalancerIP=$(EXTERNAL_IP)"
 	$(DOCKER_RUN) bash -c 'kubectl get secret allocator-client.default -n $(NAMESPACE) -ojsonpath="{.data.tls\.crt}" | base64 -d > $(mount_path)/build/allocation/client.crt'
 	$(DOCKER_RUN) bash -c 'kubectl get secret allocator-client.default -n $(NAMESPACE) -ojsonpath="{.data.tls\.key}" | base64 -d > $(mount_path)/build/allocation/client.key'
 	$(DOCKER_RUN) bash -c 'kubectl get secret allocator-tls-ca -n agones-system -ojsonpath="{.data.tls-ca\.crt}" | base64 -d > $(mount_path)/build/allocation/ca.crt'


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind cleanup

**What this PR does / Why we need it**:
Change the `make install` to use allocator loadBalancerIP helm configuration as best effort. If the service is already installed and is just upgrading, then loadBalancerIP is reused and valid allocator certificate gets issued for the service. Otherwise, the current behavior remains.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


