### PR TITLE
Update helm installation to include a step to update helm repo

### DIFF
--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -33,6 +33,7 @@ To install the chart with the release name `my-release` using our stable helm re
 
 ```bash
 $ helm repo add agones https://agones.dev/chart/stable
+$ helm repo update
 $ helm install my-release --namespace agones-system --create-namespace agones/agones
 ```
 


### PR DESCRIPTION
Add `helm repo update` to the instruction to update the helm

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind documentation

**What this PR does / Why we need it**:
When a new version of Agones is released, in order to use the new helm configurations, helm repo needs to get updated. Adding Agones chart to helm, if already available, does not update the chart.

