### PR TITLE
csharp SDK: exposes the Alpha SDK via the main interface

### DIFF
--- a/sdks/csharp/sdk/IAgonesSDK.cs
+++ b/sdks/csharp/sdk/IAgonesSDK.cs
@@ -31,5 +31,6 @@ namespace Agones
         Task<Status> SetLabelAsync(string key, string value);
         Task<Status> SetAnnotationAsync(string key, string value);
         Task<Status> HealthAsync();
+        IAgonesAlphaSDK Alpha();
     }
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / Why we need it**:
Exposes the alpha sdk object for those who implement their code against the main `IAgonesSDK` interface in the csharp SDK.

This is for classes like so:
```
public class AgonesStateService {
    private readonly IAgonesSDK m_agonesClient;
    public AgonesStateService(IAgonesSDK agonesClient) {
      m_agonesClient = agonesClient ?? new AgonesSDK();
    }
}
```

I want to be able to access the Alpha SDK methods like this:
```
private async Task<bool> PlayerConnectAsync(string playerId) {
    await m_agonesClient.Alpha().PlayerConnectAsync(playerId);
}
```

Without this change, I would have to implement code directly against the `AgonesSDK`.
       

**Special notes for your reviewer**:
(If there is another intended way this was to be exposed, let me know.  I wish I would have suggested this in the original PR)

