### PR TITLE
Move supported site K8s version to shortcodes

### DIFF
--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -37,6 +37,8 @@ and copy it into a release issue. Fill in relevant values, found inside {}
     - [ ] If full release, update `release_branch` to the new release branch for {version}.
     - [ ] If full release, update `release-version` with the new release version {version}.
     - [ ] If full release, copy `dev_supported_k8s` to `supported_k8s`.
+    - [ ] If full release, copy `dev_aks_minor_supported_k8s` to `aks_minor_supported_k8s`.
+    - [ ] If full release, copy `dev_minikube_minor_supported_k8s` to `minikube_minor_supported_k8s`.
     - [ ] If full release, update documentation with updated example images tags.
 - [ ] Create PR with these changes, and merge them with an approval.
 - [ ] Confirm local git remote `upstream` points at `git@github.com:googleforgames/agones.git`

--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -32,11 +32,13 @@ and copy it into a release issue. Fill in relevant values, found inside {}
   - [ ] Copy the draft release content into a new `/site/content/en/blog/releases` content (this will be what you send via email). 
   - [ ] Review all `link_test` and `data-proofer-ignore` attributes and remove for link testing
   - [ ] If full release, review and remove all instances of the `feature` shortcode
-  - [ ] If full release, update to the new release branch {version}.
-  - [ ] If full release, update site with the new release version (`release-version` in config.toml) to {version}
-  - [ ] If full release, update documentation with updated example images tags
-  - [ ] If full release, add link to previous version's documentation to nav dropdown
-- [ ] Create PR with these changes, and merge them with approval
+  - [ ] If full release, add a link to previous version's documentation to nav dropdown.
+  - [ ] config.toml updates:
+    - [ ] If full release, update `release_branch` to the new release branch for {version}.
+    - [ ] If full release, update `release-version` with the new release version {version}.
+    - [ ] If full release, copy `dev_supported_k8s` to `supported_k8s`.
+    - [ ] If full release, update documentation with updated example images tags.
+- [ ] Create PR with these changes, and merge them with an approval.
 - [ ] Confirm local git remote `upstream` points at `git@github.com:googleforgames/agones.git`
 - [ ] Run `git remote update && git checkout master && git reset --hard upstream/master` to ensure your code is in line with upstream  (unless this is a hotfix, then do the same, but for the release branch)
 - [ ] Publish SDK packages

--- a/site/config.toml
+++ b/site/config.toml
@@ -86,6 +86,11 @@ release_branch = "release-1.10.0"
 # the main version. Never is rc.
 release_version = "1.10.0"
 
+# shown for production
+supported_k8s = "1.16"
+# shown in development (or the next version that will be supported)
+dev_supported_k8s = "1.17"
+
 # example tag
 example_image_tag = "gcr.io/agones-images/udp-server:0.21"
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -88,8 +88,12 @@ release_version = "1.10.0"
 
 # shown for production
 supported_k8s = "1.16"
+aks_minor_supported_k8s = "13"
+minikube_minor_supported_k8s = "13"
 # shown in development (or the next version that will be supported)
 dev_supported_k8s = "1.17"
+dev_aks_minor_supported_k8s = "13"
+dev_minikube_minor_supported_k8s = "13"
 
 # example tag
 example_image_tag = "gcr.io/agones-images/udp-server:0.21"

--- a/site/content/en/docs/Advanced/limiting-resources.md
+++ b/site/content/en/docs/Advanced/limiting-resources.md
@@ -19,8 +19,8 @@ Kubernetes documentation for more details on "requests" and "limits" to both CPU
 
 ## GameServers
 
-Since the `GameServer` specification provides a full [`PodSpecTemplate`](https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplatespec-v1-core),
-we can take advantage of both resource limits and requests in our `GameServer` configurations. 
+Since the `GameServer` specification provides a full [`PodSpecTemplate`]({{% k8s-api href="#podtemplatespec-v1-core" %}}),
+we can take advantage of both resource limits and requests in our `GameServer` configurations.
 
 For example, to set a CPU limit on our `GameServer` configuration of `250m/0.25` of a CPU,
 we could do so as followed:

--- a/site/content/en/docs/Installation/Creating Cluster/aks.md
+++ b/site/content/en/docs/Installation/Creating Cluster/aks.md
@@ -28,8 +28,8 @@ az group create --name $AKS_RESOURCE_GROUP --location $AKS_LOCATION
 
 # Create the AKS cluster - this might take some time. Type 'az aks create -h' to see all available options
 
-# The following command will create a four Node AKS cluster. Node size is Standard A1 v1 and Kubernetes version is {{% k8s-version %}}.13. Plus, SSH keys will be generated for you, use --ssh-key-value to provide your values
-az aks create --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME --node-count 4 --generate-ssh-keys --node-vm-size Standard_A4_v2 --kubernetes-version {{% k8s-version %}}.13
+# The following command will create a four Node AKS cluster. Node size is Standard A1 v1 and Kubernetes version is {{% k8s-version %}}.{{% aks-k8s-minor-version %}}. Plus, SSH keys will be generated for you, use --ssh-key-value to provide your values
+az aks create --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME --node-count 4 --generate-ssh-keys --node-vm-size Standard_A4_v2 --kubernetes-version {{% k8s-version %}}.{{% aks-k8s-minor-version %}}
 
 # Install kubectl
 sudo az aks install-cli

--- a/site/content/en/docs/Installation/Creating Cluster/aks.md
+++ b/site/content/en/docs/Installation/Creating Cluster/aks.md
@@ -28,8 +28,8 @@ az group create --name $AKS_RESOURCE_GROUP --location $AKS_LOCATION
 
 # Create the AKS cluster - this might take some time. Type 'az aks create -h' to see all available options
 
-# The following command will create a four Node AKS cluster. Node size is Standard A1 v1 and Kubernetes version is 1.16.13. Plus, SSH keys will be generated for you, use --ssh-key-value to provide your values
-az aks create --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME --node-count 4 --generate-ssh-keys --node-vm-size Standard_A4_v2 --kubernetes-version 1.16.13
+# The following command will create a four Node AKS cluster. Node size is Standard A1 v1 and Kubernetes version is {{% k8s-version %}}.13. Plus, SSH keys will be generated for you, use --ssh-key-value to provide your values
+az aks create --resource-group $AKS_RESOURCE_GROUP --name $AKS_NAME --node-count 4 --generate-ssh-keys --node-vm-size Standard_A4_v2 --kubernetes-version {{% k8s-version %}}.13
 
 # Install kubectl
 sudo az aks install-cli

--- a/site/content/en/docs/Installation/Creating Cluster/eks.md
+++ b/site/content/en/docs/Installation/Creating Cluster/eks.md
@@ -18,7 +18,7 @@ Possible steps are the following:
 ```
 eksctl create cluster \
 --name prod \
---version 1.16 \
+--version {{% k8s-version %}} \
 --nodegroup-name standard-workers \
 --node-type t3.medium \
 --nodes 3 \

--- a/site/content/en/docs/Installation/Creating Cluster/gke.md
+++ b/site/content/en/docs/Installation/Creating Cluster/gke.md
@@ -71,7 +71,7 @@ To install `gcloud` and `kubectl`, perform the following steps:
 A [cluster][cluster] consists of at least one *cluster master* machine and multiple worker machines called *nodes*: [Compute Engine virtual machine][vms] instances that run the Kubernetes processes necessary to make them part of the cluster.
 
 ```bash
-gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.16 \
+gcloud container clusters create [CLUSTER_NAME] --cluster-version={{% k8s-version %}} \
   --tags=game-server \
   --scopes=gke-default \
   --num-nodes=4 \
@@ -81,7 +81,7 @@ gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.16 \
 
 Flag explanations:
 
-* cluster-version: Agones requires Kubernetes version 1.16.
+* cluster-version: Agones requires Kubernetes version {{% k8s-version %}}.
 * tags: Defines the tags that will be attached to new nodes in the cluster. This is to grant access through ports via the firewall created in the next step.
 * scopes: Defines the Oauth scopes required by the nodes.
 * num-nodes: The number of nodes to be created in each of the cluster's zones. Default: 4. Depending on the needs of your game, this parameter should be adjusted.

--- a/site/content/en/docs/Installation/Creating Cluster/minikube.md
+++ b/site/content/en/docs/Installation/Creating Cluster/minikube.md
@@ -30,7 +30,7 @@ The following command starts a local minikube cluster via virtualbox - but this 
 replaced by a [vm-driver](https://github.com/kubernetes/minikube#requirements) of your choice.
 
 ```bash
-minikube start --kubernetes-version v1.16.13 --vm-driver virtualbox
+minikube start --kubernetes-version v{{% k8s-version %}}.13 --vm-driver virtualbox
 ```
 
 ## Next Steps

--- a/site/content/en/docs/Installation/Creating Cluster/minikube.md
+++ b/site/content/en/docs/Installation/Creating Cluster/minikube.md
@@ -30,7 +30,7 @@ The following command starts a local minikube cluster via virtualbox - but this 
 replaced by a [vm-driver](https://github.com/kubernetes/minikube#requirements) of your choice.
 
 ```bash
-minikube start --kubernetes-version v{{% k8s-version %}}.13 --vm-driver virtualbox
+minikube start --kubernetes-version v{{% k8s-version %}}.{{% minikube-k8s-minor-version %}} --vm-driver virtualbox
 ```
 
 ## Next Steps

--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -8,7 +8,7 @@ description: >
 
 ## Usage Requirements
 
-- **Kubernetes cluster version 1.16**
+- **Kubernetes cluster version {{% k8s-version %}}**
     - [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/),
       [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/),
       [Amazon EKS](https://aws.amazon.com/eks/) and [Minikube](https://github.com/kubernetes/minikube) have been tested
@@ -22,7 +22,7 @@ description: >
 - Game Servers must have the [game server SDK]({{< ref "/docs/Guides/Client SDKs/_index.md"  >}}) integrated, to manage Game Server state, health checking, etc.
 
 {{< alert title="Warning" color="warning">}}
-Later versions of Kubernetes may work, but this project is tested against 1.16, and is therefore the supported version.
+Later versions of Kubernetes may work, but this project is tested against {{% k8s-version %}}, and is therefore the supported version.
 Agones will update its support to n-1 version of what is available across the majority of major cloud providers - GKE, EKS and
 AKS, while also ensuring that all Cloud providers can support that version.
 {{< /alert >}}

--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -16,7 +16,7 @@ A full `Fleet` specification is available below and in the {{< ghlink href="exam
 apiVersion: "agones.dev/v1"
 kind: Fleet
 # Fleet Metadata
-# https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta
+# {{< k8s-api href="#objectmeta-v1-meta" >}}
 metadata:
   name: fleet-example
 spec:

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -13,7 +13,7 @@ A full `FleetAutoscaler` specification is available below and in the
 apiVersion: "autoscaling.agones.dev/v1"
 kind: FleetAutoscaler
 # FleetAutoscaler Metadata
-# https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta
+# {{< k8s-api href="#objectmeta-v1-meta" >}}
 metadata:
   name: fleet-autoscaler-example
 spec:

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -12,8 +12,8 @@ A full GameServer specification is available below and in the {{< ghlink href="e
 ```yaml
 apiVersion: "agones.dev/v1"
 kind: GameServer
-# GameServer Metadata
-# https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta
+# GameServer Metadata 
+# {{< k8s-api href="#objectmeta-v1-meta" >}}
 metadata:
   # generateName: "gds-example" # generate a unique name, with the given prefix
   name: "gds-example" # set a fixed name
@@ -79,7 +79,7 @@ spec:
   #   # set this GameServer's initial player capacity
   #   initialCapacity: 10
   # Pod template configuration
-  # https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplate-v1-core
+  # {{< k8s-api href="#podtemplate-v1-core" >}}
   template:
     # pod metadata. Name & Namespace is overwritten
     metadata:
@@ -121,7 +121,7 @@ The `spec` field is the actual GameServer specification and it is composed as fo
   - `grpcPort` the port that the SDK Server binds to for gRPC connections
   - `httpPort` the port that the SDK Server binds to for HTTP gRPC gateway connections
 - `players` (Alpha, behind "PlayerTracking" feature gate), sets this GameServer's initial player capacity
-- `template` the [pod spec template](https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplatespec-v1-core) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
+- `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
 ## GameServer State Diagram
 

--- a/site/layouts/shortcodes/aks-k8s-minor-version.html
+++ b/site/layouts/shortcodes/aks-k8s-minor-version.html
@@ -1,0 +1,5 @@
+{{- if eq (getenv "HUGO_ENV") "production" }}
+{{- $.Page.Site.Params.aks_minor_supported_k8s }}
+{{- else }}
+{{- $.Page.Site.Params.dev_aks_minor_supported_k8s }}
+{{- end }}

--- a/site/layouts/shortcodes/feature.html
+++ b/site/layouts/shortcodes/feature.html
@@ -1,5 +1,4 @@
 {{- $version := getenv "RELEASE_VERSION" | default $.Page.Site.Params.release_version }}
-
 {{- with or (.Get "publishVersion") (.Get "expiryVersion")}}
 {{- else }}
     {{ errorf "missing value for either publishVersion or expiryVersion: %s" .Position}}
@@ -15,20 +14,20 @@
 {{- $expire := 0}}
 {{- $index := 0}}
 
-{{/*Generate initial shift for most significant number*/}}
+{{- /*Generate initial shift for most significant number*/}}
 {{- $shift := 1 }}
 {{- range $curDigits}}
     {{- $shift = mul $shift $multiplier }}
 {{- end}}
 {{- $shift = div $shift $multiplier }}
 
-{{/* loop three times */}}
+{{- /* loop three times */}}
 {{- range $curDigits}}
-    {{/* Get integer from dot separated string at index */}}
+    {{- /* Get integer from dot separated string at index */}}
     {{- $c := int (index $curDigits $index)}}
     {{- $p := int (index $publDigits $index)}}
     {{- $e := int (index $expDigits $index)}}
-    {{/* current += digit * shift */}}
+    {{- /* current += digit * shift */}}
     {{- $current =  (add $current (mul $c  $shift ))}}
     {{- $publish =  (add $publish (mul $p $shift ))}}
     {{- $expire =  (add $expire (mul $e  $shift ))}}

--- a/site/layouts/shortcodes/k8s-api.html
+++ b/site/layouts/shortcodes/k8s-api.html
@@ -1,0 +1,2 @@
+{{- $version := cond (eq (getenv "HUGO_ENV") "production") $.Page.Site.Params.supported_k8s $.Page.Site.Params.dev_supported_k8s }}
+{{- $prefix := replace $version "." "-" }}https://v{{- $prefix }}.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v{{- $version }}/#podtemplatespec-v1-core

--- a/site/layouts/shortcodes/k8s-version.html
+++ b/site/layouts/shortcodes/k8s-version.html
@@ -1,0 +1,5 @@
+{{- if eq (getenv "HUGO_ENV") "production" }}
+{{- $.Page.Site.Params.supported_k8s }}
+{{- else }}
+{{- $.Page.Site.Params.dev_supported_k8s }}
+{{- end }}

--- a/site/layouts/shortcodes/minikube-k8s-minor-version.html
+++ b/site/layouts/shortcodes/minikube-k8s-minor-version.html
@@ -1,0 +1,5 @@
+{{- if eq (getenv "HUGO_ENV") "production" }}
+{{- $.Page.Site.Params.minikube_minor_supported_k8s }}
+{{- else }}
+{{- $.Page.Site.Params.dev_minikube_minor_supported_k8s }}
+{{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Implements two new shortcodes:
* {{% k8s-version %}} - which outputs the currently supported version
* {{% k8s-api href="#podtemplatespec-v1-core" %}} - which outputs the api reference url to the supported k8s version.

These shortcode utilise the `HUGO_ENV` environment to determine if it should show the current K8s version, or the next - as it is only set to the value of "production" when it is generated for the release version of the agones.dev website.

Also added updates to the release checklist to manage this as well.

Ideally, this will remove lots of busy work of feature shortcoding a lot of content as we churn through Kubernetes versions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #1824

**Special notes for your reviewer**:

Long term, we may want to expand this to include separate tools for current and next full semver versions - i.e. rather than just
1.16 ➡ 1.17, but something like 1.16.3 ➡ 1.17.14.

We cheat a little on this release as there is 1.16.13 and 1.17.13 released on both 1.16 and 1.17.