### PR TITLE
Move admissionregistration to v1

### DIFF
--- a/pkg/apis/autoscaling/v1/fleetautoscaler.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
-	admregv1b "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -108,7 +108,7 @@ type BufferPolicy struct {
 // WebhookPolicy controls the desired behavior of the webhook policy.
 // It contains the description of the webhook autoscaler service
 // used to form url which is accessible inside the cluster
-type WebhookPolicy admregv1b.WebhookClientConfig
+type WebhookPolicy admregv1.WebhookClientConfig
 
 // FleetAutoscalerStatus defines the current status of a FleetAutoscaler
 type FleetAutoscalerStatus struct {

--- a/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	admregv1b "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -234,7 +234,7 @@ func customFixture(t FleetAutoscalerPolicyType) *FleetAutoscaler {
 		res.Spec.Policy.Buffer = nil
 		url := "/scale"
 		res.Spec.Policy.Webhook = &WebhookPolicy{
-			Service: &admregv1b.ServiceReference{
+			Service: &admregv1.ServiceReference{
 				Name:      "service1",
 				Namespace: "default",
 				Path:      &url,

--- a/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@
 package v1
 
 import (
-	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -235,7 +235,7 @@ func (in *WebhookPolicy) DeepCopyInto(out *WebhookPolicy) {
 	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
-		*out = new(v1beta1.ServiceReference)
+		*out = new(admissionregistrationv1.ServiceReference)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.CABundle != nil {

--- a/pkg/fleetautoscalers/controller_test.go
+++ b/pkg/fleetautoscalers/controller_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
-	admregv1b "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -739,7 +739,7 @@ func defaultWebhookFixtures() (*autoscalingv1.FleetAutoscaler, *agonesv1.Fleet) 
 	fas.Spec.Policy.Buffer = nil
 	url := "/autoscaler"
 	fas.Spec.Policy.Webhook = &autoscalingv1.WebhookPolicy{
-		Service: &admregv1b.ServiceReference{
+		Service: &admregv1.ServiceReference{
 			Name: "fleetautoscaler-service",
 			Path: &url,
 		},

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -27,7 +27,7 @@ import (
 
 	autoscalingv1 "agones.dev/agones/pkg/apis/autoscaling/v1"
 	"github.com/stretchr/testify/assert"
-	admregv1b "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -407,7 +407,7 @@ func TestApplyWebhookPolicy(t *testing.T) {
 		{
 			description: "URL and Service are not nil",
 			webhookPolicy: &autoscalingv1.WebhookPolicy{
-				Service: &admregv1b.ServiceReference{
+				Service: &admregv1.ServiceReference{
 					Name:      "service1",
 					Namespace: "default",
 					Path:      &url,
@@ -447,7 +447,7 @@ func TestApplyWebhookPolicy(t *testing.T) {
 		{
 			description: "Service name is empty",
 			webhookPolicy: &autoscalingv1.WebhookPolicy{
-				Service: &admregv1b.ServiceReference{
+				Service: &admregv1.ServiceReference{
 					Name:      "",
 					Namespace: "default",
 					Path:      &url,
@@ -462,7 +462,7 @@ func TestApplyWebhookPolicy(t *testing.T) {
 		{
 			description: "No certs",
 			webhookPolicy: &autoscalingv1.WebhookPolicy{
-				Service: &admregv1b.ServiceReference{
+				Service: &admregv1.ServiceReference{
 					Name:      "service1",
 					Namespace: "default",
 					Path:      &url,
@@ -559,7 +559,7 @@ func TestApplyWebhookPolicyNilFleet(t *testing.T) {
 
 	url := "scale"
 	w := &autoscalingv1.WebhookPolicy{
-		Service: &admregv1b.ServiceReference{
+		Service: &admregv1.ServiceReference{
 			Name:      "service1",
 			Namespace: "default",
 			Path:      &url,
@@ -651,7 +651,7 @@ func TestBuildURLFromWebhookPolicyNoNamespace(t *testing.T) {
 		{
 			description: "No namespace provided, default should be used",
 			webhookPolicy: &autoscalingv1.WebhookPolicy{
-				Service: &admregv1b.ServiceReference{
+				Service: &admregv1.ServiceReference{
 					Name:      "service1",
 					Namespace: "",
 					Path:      &url,
@@ -665,7 +665,7 @@ func TestBuildURLFromWebhookPolicyNoNamespace(t *testing.T) {
 		{
 			description: "No url provided, empty string should be used",
 			webhookPolicy: &autoscalingv1.WebhookPolicy{
-				Service: &admregv1b.ServiceReference{
+				Service: &admregv1.ServiceReference{
 					Name:      "service1",
 					Namespace: "test",
 					Path:      nil,

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -3,2762 +3,7 @@ title="Agones Kubernetes API"
 description="Detailed list of Agones Custom Resource Definitions available"
 +++
 
-{{% feature expiryVersion="1.9.0" %}}
-<p>Packages:</p>
-<ul>
-<li>
-<a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
-</li>
-<li>
-<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
-</li>
-<li>
-<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
-</li>
-<li>
-<a href="#agones.dev%2fv1">agones.dev/v1</a>
-</li>
-</ul>
-<h2 id="allocation.agones.dev/v1">allocation.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>
-</li></ul>
-<h3 id="allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation
-</h3>
-<p>
-<p>GameServerAllocation is the data structure for allocating against a set of
-GameServers, defined <code>required</code> and <code>preferred</code> selectors</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-allocation.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GameServerAllocation</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">
-GameServerAllocationSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>multiClusterSetting</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.MultiClusterSetting">
-MultiClusterSetting
-</a>
-</em>
-</td>
-<td>
-<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
-Otherwise, allocation will happen locally.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>required</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<p>Required The required allocation. Defaults to all GameServers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>preferred</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
-[]Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<p>Preferred ordered list of preferred allocations out of the <code>required</code> set.
-If the first selector is not matched,
-the selection attempts the second selector, and so on.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.MetaPatch">
-MetaPatch
-</a>
-</em>
-</td>
-<td>
-<p>MetaPatch is optional custom metadata that is added to the game server at allocation
-You can use this to tell the server necessary session data</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">
-GameServerAllocationStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
-</p>
-<p>
-<p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>multiClusterSetting</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.MultiClusterSetting">
-MultiClusterSetting
-</a>
-</em>
-</td>
-<td>
-<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
-Otherwise, allocation will happen locally.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>required</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<p>Required The required allocation. Defaults to all GameServers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>preferred</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
-[]Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<p>Preferred ordered list of preferred allocations out of the <code>required</code> set.
-If the first selector is not matched,
-the selection attempts the second selector, and so on.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.MetaPatch">
-MetaPatch
-</a>
-</em>
-</td>
-<td>
-<p>MetaPatch is optional custom metadata that is added to the game server at allocation
-You can use this to tell the server necessary session data</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerAllocationState">GameServerAllocationState
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
-</p>
-<p>
-<p>GameServerAllocationState is the Allocation state</p>
-</p>
-<h3 id="allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
-</p>
-<p>
-<p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>state</code></br>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationState">
-GameServerAllocationState
-</a>
-</em>
-</td>
-<td>
-<p>GameServerState is the current state of an GameServerAllocation, e.g. Allocated, or UnAllocated</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>gameServerName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerStatusPort">
-[]GameServerStatusPort
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.MetaPatch">MetaPatch
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>labels</code></br>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code></br>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.MultiClusterSetting">MultiClusterSetting
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>enabled</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policySelector</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
-</li></ul>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
-</h3>
-<p>
-<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-autoscaling.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>FleetAutoscaler</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
-FleetAutoscalerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>fleetName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Autoscaling policy</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
-FleetAutoscalerStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>maxReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
-It must be bigger than both MinReplicas and BufferSize</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>MinReplicas is the minimum amount of replicas that the fleet must have
-If zero, it is ignored.
-If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code></br>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
-Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
-Absolute number is calculated from percentage by rounding up.
-Example: when this is set to 20%, the autoscaler will make sure that 20%
-of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
-the autoscaler will make sure that there are 20 available game servers
-Must be bigger than 0
-Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
-and computation stability in different edge case (fleet just created, not enough
-capacity in the cluster etc)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
-</p>
-<p>
-<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
-otherwise identical (parallel requests, requests when earlier requests did not modify etc)
-The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
-It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the Fleet being scaled</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Namespace is the namespace associated with the request (if any).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#agones.dev/v1.FleetStatus">
-FleetStatus
-</a>
-</em>
-</td>
-<td>
-<p>The Fleet&rsquo;s status values</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
-</p>
-<p>
-<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<p>UID is an identifier for the individual request/response.
-This should be copied over from the corresponding FleetAutoscaleRequest.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scale</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Set to false if no scaling should occur to the Fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>The targeted replica count</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
-</h3>
-<p>
-<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
-and then returned with a populated Response.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>request</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
-FleetAutoscaleRequest
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>response</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
-FleetAutoscaleResponse
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
-</p>
-<p>
-<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
-FleetAutoscalerPolicyType
-</a>
-</em>
-</td>
-<td>
-<p>Type of autoscaling policy.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>buffer</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.BufferPolicy">
-BufferPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>webhook</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.WebhookPolicy">
-WebhookPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Protocol is the network protocol being used. Defaults to UDP. TCP and TCPUDP are other options</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>FleetAutoscalerPolicyType is the policy for autoscaling
-for a given Fleet</p>
-</p>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
-</p>
-<p>
-<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>fleetName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Autoscaling policy</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
-</p>
-<p>
-<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currentReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>CurrentReplicas is the current number of gameserver replicas
-of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>desiredReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>DesiredReplicas is the desired number of gameserver replicas
-of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lastScaleTime</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ableToScale</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>AbleToScale indicates that we can access the target fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scalingLimited</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>ScalingLimited indicates that the calculated scale would be above or below the range
-defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.WebhookPolicy">WebhookPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>WebhookPolicy controls the desired behavior of the webhook policy.
-It contains the description of the webhook autoscaler service
-used to form url which is accessible inside the cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>url</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>url</code> gives the location of the webhook, in standard URL form
-(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
-must be specified.</p>
-<p>The <code>host</code> should not refer to a service running in the cluster; use
-the <code>service</code> field instead. The host might be resolved via external
-DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
-in-cluster DNS as that would be a layering violation). <code>host</code> may
-also be an IP address.</p>
-<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
-risky unless you take great care to run this webhook on all hosts
-which run an apiserver which might need to make calls to this
-webhook. Such installs are likely to be non-portable, i.e., not easy
-to turn up in a new cluster.</p>
-<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
-<p>A path is optional, and if present may be any string permissible in
-a URL. You may use the path to pass an arbitrary string to the
-webhook, for example, a cluster identifier.</p>
-<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
-allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
-allowed, either.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>service</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#servicereference-v1beta1-admissionregistration">
-Kubernetes admissionregistration/v1beta1.ServiceReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>service</code> is a reference to the service for this webhook. Either
-<code>service</code> or <code>url</code> must be specified.</p>
-<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caBundle</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
-If unspecified, system trust roots on the apiserver are used.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
-</li></ul>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
-</h3>
-<p>
-<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-multicluster.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GameServerAllocationPolicy</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
-GameServerAllocationPolicySpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>priority</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
-</p>
-<p>
-<p>ClusterConnectionInfo defines the connection information for a cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>clusterName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Optional: the name of the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationEndpoints</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>The endpoints for the allocator service in the targeted cluster.
-If the AllocationEndpoints is not set, the allocation happens on local cluster.
-If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The cluster namespace from which to allocate gameservers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serverCa</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
-</h3>
-<p>
-<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currPriority</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-<p>currPriority Current priority index from the orderedPriorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>orderedPriorities</code></br>
-<em>
-[]int32
-</em>
-</td>
-<td>
-<p>orderedPriorities list of ordered priorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorityToCluster</code></br>
-<em>
-map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
-</em>
-</td>
-<td>
-<p>priorityToCluster Map of priority to cluster-policies map</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>clusterBlackList</code></br>
-<em>
-map[string]bool
-</em>
-</td>
-<td>
-<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
-</p>
-<p>
-<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>priority</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="agones.dev/v1">agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#agones.dev/v1.Fleet">Fleet</a>
-</li><li>
-<a href="#agones.dev/v1.GameServer">GameServer</a>
-</li><li>
-<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>
-</li></ul>
-<h3 id="agones.dev/v1.Fleet">Fleet
-</h3>
-<p>
-<p>Fleet is the data structure for a Fleet resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Fleet</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#agones.dev/v1.FleetSpec">
-FleetSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>strategy</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#deploymentstrategy-v1-apps">
-Kubernetes apps/v1.DeploymentStrategy
-</a>
-</em>
-</td>
-<td>
-<p>Deployment strategy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this Fleet</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#agones.dev/v1.FleetStatus">
-FleetStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServer">GameServer
-</h3>
-<p>
-<p>GameServer is the data structure for a GameServer resource.
-It is worth noting that while there is a <code>GameServerStatus</code> Status entry for the <code>GameServer</code>, it is not
-defined as a subresource - unlike <code>Fleet</code> and other Agones resources.
-This is so that we can retain the ability to change multiple aspects of a <code>GameServer</code> in a single atomic operation,
-which is particularly useful for operations such as allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GameServer</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerSpec">
-GameServerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>container</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Container specifies which Pod container is the game server. Only required if there is more than one
-container defined</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerPort">
-[]GameServerPort
-</a>
-</em>
-</td>
-<td>
-<p>Ports are the array of ports that can be exposed via the game server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>health</code></br>
-<em>
-<a href="#agones.dev/v1.Health">
-Health
-</a>
-</em>
-</td>
-<td>
-<p>Health configures health checking</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sdkServer</code></br>
-<em>
-<a href="#agones.dev/v1.SdkServer">
-SdkServer
-</a>
-</em>
-</td>
-<td>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the Pod that will be created for the GameServer</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code></br>
-<em>
-<a href="#agones.dev/v1.PlayersSpec">
-PlayersSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerStatus">
-GameServerStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSet">GameServerSet
-</h3>
-<p>
-<p>GameServerSet is the data structure for a set of GameServers.
-This matches philosophically with the relationship between
-Deployments and ReplicaSets</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GameServerSet</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerSetSpec">
-GameServerSetSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this GameServerSet</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerSetStatus">
-GameServerSetStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.AggregatedPlayerStatus">AggregatedPlayerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
-<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
-</p>
-<p>
-<p>AggregatedPlayerStatus stores total player tracking values</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>count</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.FleetSpec">FleetSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.Fleet">Fleet</a>)
-</p>
-<p>
-<p>FleetSpec is the spec for a Fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>strategy</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#deploymentstrategy-v1-apps">
-Kubernetes apps/v1.DeploymentStrategy
-</a>
-</em>
-</td>
-<td>
-<p>Deployment strategy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this Fleet</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.FleetStatus">FleetStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.Fleet">Fleet</a>, 
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
-</p>
-<p>
-<p>FleetStatus is the status of a Fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas the total number of current GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readyReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReadyReplicas are the number of Ready GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reservedReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
-Reserved instances won&rsquo;t be deleted on scale down, but won&rsquo;t cause an autoscaler to scale up.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocatedReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code></br>
-<em>
-<a href="#agones.dev/v1.AggregatedPlayerStatus">
-AggregatedPlayerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerTracking]
-Players are the current total player capacity and count for this Fleet</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerPort">GameServerPort
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>GameServerPort defines a set of Ports that
-are to be exposed via the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the descriptive name of the port</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>portPolicy</code></br>
-<em>
-<a href="#agones.dev/v1.PortPolicy">
-PortPolicy
-</a>
-</em>
-</td>
-<td>
-<p>PortPolicy defines the policy for how the HostPort is populated.
-Dynamic port will allocate a HostPort within the selected MIN_PORT and MAX_PORT range passed to the controller
-at installation time.
-When <code>Static</code> portPolicy is specified, <code>HostPort</code> is required, to specify the port that game clients will
-connect to</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>container</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Container is the name of the container on which to open the port. Defaults to the game server container.
-This field is beta-level and is enabled by default, could be disabled by the &ldquo;ContainerPortAllocation&rdquo; feature.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>containerPort</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ContainerPort is the port that is being opened on the specified container&rsquo;s process</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>hostPort</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>HostPort the port exposed on the host for clients to connect to</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>protocol</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#protocol-v1-core">
-Kubernetes core/v1.Protocol
-</a>
-</em>
-</td>
-<td>
-<p>Protocol is the network protocol being used. Defaults to UDP. TCP is the only other option</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSetSpec">GameServerSetSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
-</p>
-<p>
-<p>GameServerSetSpec the specification for GameServerSet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this GameServerSet</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSetStatus">GameServerSetStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
-</p>
-<p>
-<p>GameServerSetStatus is the status of a GameServerSet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas is the total number of current GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readyReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReadyReplicas is the number of Ready GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reservedReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReservedReplicas is the number of Reserved GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocatedReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>AllocatedReplicas is the number of Allocated GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>shutdownReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ShutdownReplicas is the number of Shutdown GameServers replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code></br>
-<em>
-<a href="#agones.dev/v1.AggregatedPlayerStatus">
-AggregatedPlayerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerTracking]
-Players is the current total player capacity and count for this GameServerSet</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSpec">GameServerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServer">GameServer</a>, 
-<a href="#agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec</a>)
-</p>
-<p>
-<p>GameServerSpec is the spec for a GameServer resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>container</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Container specifies which Pod container is the game server. Only required if there is more than one
-container defined</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerPort">
-[]GameServerPort
-</a>
-</em>
-</td>
-<td>
-<p>Ports are the array of ports that can be exposed via the game server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>health</code></br>
-<em>
-<a href="#agones.dev/v1.Health">
-Health
-</a>
-</em>
-</td>
-<td>
-<p>Health configures health checking</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sdkServer</code></br>
-<em>
-<a href="#agones.dev/v1.SdkServer">
-SdkServer
-</a>
-</em>
-</td>
-<td>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the Pod that will be created for the GameServer</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code></br>
-<em>
-<a href="#agones.dev/v1.PlayersSpec">
-PlayersSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerState">GameServerState
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
-</p>
-<p>
-<p>GameServerState is the state for the GameServer</p>
-</p>
-<h3 id="agones.dev/v1.GameServerStatus">GameServerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServer">GameServer</a>)
-</p>
-<p>
-<p>GameServerStatus is the status for a GameServer resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>state</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerState">
-GameServerState
-</a>
-</em>
-</td>
-<td>
-<p>GameServerState is the current state of a GameServer, e.g. Creating, Starting, Ready, etc</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerStatusPort">
-[]GameServerStatusPort
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>reservedUntil</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code></br>
-<em>
-<a href="#agones.dev/v1.PlayerStatus">
-PlayerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerTracking]</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerStatusPort">GameServerStatusPort
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>, 
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
-</p>
-<p>
-<p>GameServerStatusPort shows the port that was allocated to a
-GameServer.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>port</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
-<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
-</p>
-<p>
-<p>GameServerTemplateSpec is a template for GameServers</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerSpec">
-GameServerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>container</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Container specifies which Pod container is the game server. Only required if there is more than one
-container defined</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code></br>
-<em>
-<a href="#agones.dev/v1.GameServerPort">
-[]GameServerPort
-</a>
-</em>
-</td>
-<td>
-<p>Ports are the array of ports that can be exposed via the game server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>health</code></br>
-<em>
-<a href="#agones.dev/v1.Health">
-Health
-</a>
-</em>
-</td>
-<td>
-<p>Health configures health checking</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code></br>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sdkServer</code></br>
-<em>
-<a href="#agones.dev/v1.SdkServer">
-SdkServer
-</a>
-</em>
-</td>
-<td>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the Pod that will be created for the GameServer</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code></br>
-<em>
-<a href="#agones.dev/v1.PlayersSpec">
-PlayersSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.Health">Health
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>Health configures health checking on the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>disabled</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Disabled is whether health checking is disabled or not</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>periodSeconds</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>PeriodSeconds is the number of seconds each health ping has to occur in</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>failureThreshold</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>FailureThreshold how many failures in a row constitutes unhealthy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>initialDelaySeconds</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>InitialDelaySeconds initial delay before checking health</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.PlayerStatus">PlayerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
-</p>
-<p>
-<p>PlayerStatus stores the current player capacity values</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>count</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>ids</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.PlayersSpec">PlayersSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>PlayersSpec tracks the initial player capacity</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>initialCapacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.PortPolicy">PortPolicy
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerPort">GameServerPort</a>)
-</p>
-<p>
-<p>PortPolicy is the port policy for the GameServer</p>
-</p>
-<h3 id="agones.dev/v1.SdkServer">SdkServer
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>logLevel</code></br>
-<em>
-<a href="#agones.dev/v1.SdkServerLogLevel">
-SdkServerLogLevel
-</a>
-</em>
-</td>
-<td>
-<p>LogLevel for SDK server (sidecar) logs. Defaults to &ldquo;Info&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>grpcPort</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>GRPCPort is the port on which the SDK Server binds the gRPC server to accept incoming connections</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>httpPort</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>HTTPPort is the port on which the SDK Server binds the HTTP gRPC gateway server to accept incoming connections</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.SdkServerLogLevel">SdkServerLogLevel
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.SdkServer">SdkServer</a>)
-</p>
-<p>
-<p>SdkServerLogLevel is the log level for SDK server (sidecar) logs</p>
-</p>
-<hr/>
-<p><em>
-Generated with <code>gen-crd-api-reference-docs</code>.
-</em></p>
-{{% /feature %}}
-{{% feature publishVersion="1.9.0" %}}
+{{% feature expiryVersion="1.11.0" %}}
 <p>Packages:</p>
 <ul>
 <li>
@@ -5195,6 +2440,2762 @@ allowed, either.</p>
 <em>
 <a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#servicereference-v1beta1-admissionregistration">
 Kubernetes admissionregistration/v1beta1.ServiceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>service</code> is a reference to the service for this webhook. Either
+<code>service</code> or <code>url</code> must be specified.</p>
+<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caBundle</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
+If unspecified, system trust roots on the apiserver are used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
+</li></ul>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
+</h3>
+<p>
+<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+multicluster.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerAllocationPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
+GameServerAllocationPolicySpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>priority</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
+</p>
+<p>
+<p>ClusterConnectionInfo defines the connection information for a cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clusterName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Optional: the name of the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationEndpoints</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The endpoints for the allocator service in the targeted cluster.
+If the AllocationEndpoints is not set, the allocation happens on local cluster.
+If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The cluster namespace from which to allocate gameservers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverCa</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
+</h3>
+<p>
+<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currPriority</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>currPriority Current priority index from the orderedPriorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>orderedPriorities</code></br>
+<em>
+[]int32
+</em>
+</td>
+<td>
+<p>orderedPriorities list of ordered priorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorityToCluster</code></br>
+<em>
+map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
+</em>
+</td>
+<td>
+<p>priorityToCluster Map of priority to cluster-policies map</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterBlackList</code></br>
+<em>
+map[string]bool
+</em>
+</td>
+<td>
+<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
+</p>
+<p>
+<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>priority</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>
+{{% /feature %}}
+{{% feature publishVersion="1.11.0" %}}
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#agones.dev%2fv1">agones.dev/v1</a>
+</li>
+<li>
+<a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
+</li>
+<li>
+<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
+</li>
+<li>
+<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
+</li>
+</ul>
+<h2 id="agones.dev/v1">agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#agones.dev/v1.Fleet">Fleet</a>
+</li><li>
+<a href="#agones.dev/v1.GameServer">GameServer</a>
+</li><li>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>
+</li></ul>
+<h3 id="agones.dev/v1.Fleet">Fleet
+</h3>
+<p>
+<p>Fleet is the data structure for a Fleet resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Fleet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#agones.dev/v1.FleetSpec">
+FleetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServer">GameServer
+</h3>
+<p>
+<p>GameServer is the data structure for a GameServer resource.
+It is worth noting that while there is a <code>GameServerStatus</code> Status entry for the <code>GameServer</code>, it is not
+defined as a subresource - unlike <code>Fleet</code> and other Agones resources.
+This is so that we can retain the ability to change multiple aspects of a <code>GameServer</code> in a single atomic operation,
+which is particularly useful for operations such as allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code></br>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code></br>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code></br>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerStatus">
+GameServerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSet">GameServerSet
+</h3>
+<p>
+<p>GameServerSet is the data structure for a set of GameServers.
+This matches philosophically with the relationship between
+Deployments and ReplicaSets</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerSet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerSetSpec">
+GameServerSetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerSetStatus">
+GameServerSetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedPlayerStatus">AggregatedPlayerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedPlayerStatus stores total player tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.FleetSpec">FleetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Fleet">Fleet</a>)
+</p>
+<p>
+<p>FleetSpec is the spec for a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.FleetStatus">FleetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Fleet">Fleet</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
+</p>
+<p>
+<p>FleetStatus is the status of a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas are the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+Reserved instances won&rsquo;t be deleted on scale down, but won&rsquo;t cause an autoscaler to scale up.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code></br>
+<em>
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
+AggregatedPlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]
+Players are the current total player capacity and count for this Fleet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerPort">GameServerPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>GameServerPort defines a set of Ports that
+are to be exposed via the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the descriptive name of the port</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>portPolicy</code></br>
+<em>
+<a href="#agones.dev/v1.PortPolicy">
+PortPolicy
+</a>
+</em>
+</td>
+<td>
+<p>PortPolicy defines the policy for how the HostPort is populated.
+Dynamic port will allocate a HostPort within the selected MIN_PORT and MAX_PORT range passed to the controller
+at installation time.
+When <code>Static</code> portPolicy is specified, <code>HostPort</code> is required, to specify the port that game clients will
+connect to</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Container is the name of the container on which to open the port. Defaults to the game server container.
+This field is beta-level and is enabled by default, could be disabled by the &ldquo;ContainerPortAllocation&rdquo; feature.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ContainerPort is the port that is being opened on the specified container&rsquo;s process</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HostPort the port exposed on the host for clients to connect to</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#protocol-v1-core">
+Kubernetes core/v1.Protocol
+</a>
+</em>
+</td>
+<td>
+<p>Protocol is the network protocol being used. Defaults to UDP. TCP and TCPUDP are other options.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSetSpec">GameServerSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetSpec the specification for GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSetStatus">GameServerSetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetStatus is the status of a GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas is the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas is the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas is the number of Reserved GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas is the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shutdownReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ShutdownReplicas is the number of Shutdown GameServers replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code></br>
+<em>
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
+AggregatedPlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]
+Players is the current total player capacity and count for this GameServerSet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSpec">GameServerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServer">GameServer</a>, 
+<a href="#agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec</a>)
+</p>
+<p>
+<p>GameServerSpec is the spec for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code></br>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code></br>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code></br>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerState">GameServerState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>GameServerState is the state for the GameServer</p>
+</p>
+<h3 id="agones.dev/v1.GameServerStatus">GameServerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServer">GameServer</a>)
+</p>
+<p>
+<p>GameServerStatus is the status for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerState">
+GameServerState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of a GameServer, e.g. Creating, Starting, Ready, etc</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedUntil</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code></br>
+<em>
+<a href="#agones.dev/v1.PlayerStatus">
+PlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerStatusPort">GameServerStatusPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>GameServerStatusPort shows the port that was allocated to a
+GameServer.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
+</p>
+<p>
+<p>GameServerTemplateSpec is a template for GameServers</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code></br>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code></br>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code></br>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.Health">Health
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>Health configures health checking on the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>disabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Disabled is whether health checking is disabled or not</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>periodSeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>PeriodSeconds is the number of seconds each health ping has to occur in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failureThreshold</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>FailureThreshold how many failures in a row constitutes unhealthy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>initialDelaySeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>InitialDelaySeconds initial delay before checking health</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PlayerStatus">PlayerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>PlayerStatus stores the current player capacity values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ids</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PlayersSpec">PlayersSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>PlayersSpec tracks the initial player capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initialCapacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PortPolicy">PortPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerPort">GameServerPort</a>)
+</p>
+<p>
+<p>PortPolicy is the port policy for the GameServer</p>
+</p>
+<h3 id="agones.dev/v1.SdkServer">SdkServer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>logLevel</code></br>
+<em>
+<a href="#agones.dev/v1.SdkServerLogLevel">
+SdkServerLogLevel
+</a>
+</em>
+</td>
+<td>
+<p>LogLevel for SDK server (sidecar) logs. Defaults to &ldquo;Info&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>grpcPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>GRPCPort is the port on which the SDK Server binds the gRPC server to accept incoming connections</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HTTPPort is the port on which the SDK Server binds the HTTP gRPC gateway server to accept incoming connections</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.SdkServerLogLevel">SdkServerLogLevel
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.SdkServer">SdkServer</a>)
+</p>
+<p>
+<p>SdkServerLogLevel is the log level for SDK server (sidecar) logs</p>
+</p>
+<hr/>
+<h2 id="allocation.agones.dev/v1">allocation.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>
+</li></ul>
+<h3 id="allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation
+</h3>
+<p>
+<p>GameServerAllocation is the data structure for allocating against a set of
+GameServers, defined <code>required</code> and <code>preferred</code> selectors</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+allocation.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerAllocation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">
+GameServerAllocationSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>multiClusterSetting</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Required The required allocation. Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#labelselector-v1-meta">
+[]Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Preferred ordered list of preferred allocations out of the <code>required</code> set.
+If the first selector is not matched,
+the selection attempts the second selector, and so on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">
+GameServerAllocationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>multiClusterSetting</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Required The required allocation. Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#labelselector-v1-meta">
+[]Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Preferred ordered list of preferred allocations out of the <code>required</code> set.
+If the first selector is not matched,
+the selection attempts the second selector, and so on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationState">GameServerAllocationState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerAllocationState is the Allocation state</p>
+</p>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code></br>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationState">
+GameServerAllocationState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of an GameServerAllocation, e.g. Allocated, or UnAllocated</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gameServerName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#agones.dev/v1.GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.MetaPatch">MetaPatch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.MultiClusterSetting">MultiClusterSetting
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policySelector</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
+</li></ul>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
+</h3>
+<p>
+<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+autoscaling.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>FleetAutoscaler</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
+FleetAutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
+FleetAutoscalerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
+It must be bigger than both MinReplicas and BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MinReplicas is the minimum amount of replicas that the fleet must have
+If zero, it is ignored.
+If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code></br>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
+Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
+Absolute number is calculated from percentage by rounding up.
+Example: when this is set to 20%, the autoscaler will make sure that 20%
+of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
+the autoscaler will make sure that there are 20 available game servers
+Must be bigger than 0
+Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
+and computation stability in different edge case (fleet just created, not enough
+capacity in the cluster etc)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
+It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the Fleet being scaled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace associated with the request (if any).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+<p>The Fleet&rsquo;s status values</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response.
+This should be copied over from the corresponding FleetAutoscaleRequest.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scale</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Set to false if no scaling should occur to the Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>The targeted replica count</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
+</h3>
+<p>
+<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
+and then returned with a populated Response.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>request</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
+FleetAutoscaleRequest
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>response</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
+FleetAutoscaleResponse
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buffer</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.BufferPolicy">
+BufferPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhook</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.WebhookPolicy">
+WebhookPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicyType is the policy for autoscaling
+for a given Fleet</p>
+</p>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>CurrentReplicas is the current number of gameserver replicas
+of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>desiredReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredReplicas is the desired number of gameserver replicas
+of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScaleTime</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ableToScale</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>AbleToScale indicates that we can access the target fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scalingLimited</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ScalingLimited indicates that the calculated scale would be above or below the range
+defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.WebhookPolicy">WebhookPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>WebhookPolicy controls the desired behavior of the webhook policy.
+It contains the description of the webhook autoscaler service
+used to form url which is accessible inside the cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>url</code> gives the location of the webhook, in standard URL form
+(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
+must be specified.</p>
+<p>The <code>host</code> should not refer to a service running in the cluster; use
+the <code>service</code> field instead. The host might be resolved via external
+DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
+in-cluster DNS as that would be a layering violation). <code>host</code> may
+also be an IP address.</p>
+<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
+risky unless you take great care to run this webhook on all hosts
+which run an apiserver which might need to make calls to this
+webhook. Such installs are likely to be non-portable, i.e., not easy
+to turn up in a new cluster.</p>
+<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
+<p>A path is optional, and if present may be any string permissible in
+a URL. You may use the path to pass an arbitrary string to the
+webhook, for example, a cluster identifier.</p>
+<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
+allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
+allowed, either.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>service</code></br>
+<em>
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#servicereference-v1-admissionregistration">
+Kubernetes admissionregistration/v1.ServiceReference
 </a>
 </em>
 </td>

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	admregv1b "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -390,7 +390,7 @@ func TestAutoscalerWebhook(t *testing.T) {
 	fas.Spec.Policy.Buffer = nil
 	path := "scale"
 	fas.Spec.Policy.Webhook = &autoscalingv1.WebhookPolicy{
-		Service: &admregv1b.ServiceReference{
+		Service: &admregv1.ServiceReference{
 			Name:      svc.ObjectMeta.Name,
 			Namespace: framework.Namespace,
 			Path:      &path,
@@ -618,7 +618,7 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 	path := "scale"
 
 	fas.Spec.Policy.Webhook = &autoscalingv1.WebhookPolicy{
-		Service: &admregv1b.ServiceReference{
+		Service: &admregv1.ServiceReference{
 			Name:      svc.ObjectMeta.Name,
 			Namespace: defaultNS,
 			Path:      &path,


### PR DESCRIPTION
Updates the webhook configuration to use the v1 version of WebhookClientConfig.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #1799

**Special notes for your reviewer**:

There are no changes in configuration, so it's no change to the end user experience.

