### PR TITLE
Remove K8s API reference links from yaml examples

### DIFF
--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -18,10 +18,12 @@
 # To allocate a GameServer from a Fleet, use a GameServerAllocation
 #
 
+#
+# For a full reference and details: https://agones.dev/site/docs/reference/fleet/
+#
+
 apiVersion: "agones.dev/v1"
 kind: Fleet
-# Fleet Metadata
-# https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta
 metadata:
   name: fleet-example
 spec:

--- a/examples/fleetautoscaler.yaml
+++ b/examples/fleetautoscaler.yaml
@@ -17,10 +17,12 @@
 # automatically depending on load
 #
 
+#
+# For a full reference and details: https://agones.dev/site/docs/reference/fleetautoscaler/
+#
+
 apiVersion: "autoscaling.agones.dev/v1"
 kind: FleetAutoscaler
-# FleetAutoscaler Metadata
-# https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta
 metadata:
   name: fleet-autoscaler-example
 spec:

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -21,10 +21,12 @@
 # and provides a sidecar for this game server that the SDK will connect with.
 #
 
+#
+# For a full reference and details: https://agones.dev/site/docs/reference/gameserver/
+#
+
 apiVersion: "agones.dev/v1"
 kind: GameServer
-# GameServer Metadata
-# https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta
 metadata:
   # generateName: "gds-example" # generate a unique name, with the given prefix
   name: "gds-example" # set a fixed name
@@ -85,8 +87,8 @@ spec:
   # players:
   #   # set this GameServer's initial player capacity
   #   initialCapacity: 10
+  #
   # Pod template configuration
-  # https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podtemplate-v1-core
   template:
     # pod metadata. Name & Namespace is overwritten
     metadata:

--- a/examples/gameserverallocation.yaml
+++ b/examples/gameserverallocation.yaml
@@ -18,6 +18,10 @@
 # multiple Fleets, or a self managed group of GameServers.
 #
 
+#
+# For a full reference and details: https://agones.dev/site/docs/reference/gameserverallocation/
+#
+
 apiVersion: "allocation.agones.dev/v1"
 kind: GameServerAllocation
 spec:

--- a/examples/webhookfleetautoscaler.yaml
+++ b/examples/webhookfleetautoscaler.yaml
@@ -16,6 +16,11 @@
 # Full example of a FleetAutoscaler - this is used to scale a Fleet
 # automatically depending on load
 #
+
+#
+# For a full reference and details: https://agones.dev/site/docs/reference/fleetautoscaler/
+#
+
 apiVersion: "autoscaling.agones.dev/v1"
 kind: FleetAutoscaler
 metadata:

--- a/examples/webhookfleetautoscalertls.yaml
+++ b/examples/webhookfleetautoscalertls.yaml
@@ -16,6 +16,11 @@
 # Full example of a FleetAutoscaler - this is used to scale a Fleet
 # automatically depending on load
 #
+
+#
+# For a full reference and details: https://agones.dev/site/docs/reference/fleetautoscaler/
+#
+
 apiVersion: "autoscaling.agones.dev/v1"
 kind: FleetAutoscaler
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This PR removes the K8s API reference from the yaml files and redirects users to look at the website reference, which has links to those API docs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #1824

**Special notes for your reviewer**:

This is to reduce toil as we increment supported Kubernetes version numbers, as it is now far easier to edit the supported K8s version throughout the entire website docs through config variables.
