### PR TITLE
Utilize ExternalDNS as well as ExternalIP

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -63,7 +63,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 # Game Server image to use while doing end-to-end tests
 GS_TEST_IMAGE ?= gcr.io/agones-images/simple-game-server:0.1
 
-ALPHA_FEATURE_GATES ?= "PlayerTracking=true&RollingUpdateOnReady=true"
+ALPHA_FEATURE_GATES ?= "PlayerTracking=true&RollingUpdateOnReady=true&NodeExternalDNS=true"
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -232,7 +232,7 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&SDKWatchSendOnExecute=false&RollingUpdateOnReady=true', 'e2e-test-cluster']
+  args: ['PlayerTracking=true&SDKWatchSendOnExecute=false&RollingUpdateOnReady=true&NodeExternalDNS=true', 'e2e-test-cluster']
   id: e2e-feature-gates
   waitFor:
     - push-images

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -40,6 +40,9 @@ const (
 	// FeatureRollingUpdateOnReady is a feature flag to enable/disable rolling update fix of scale down, when ReadyReplicas
 	// count is taken into account
 	FeatureRollingUpdateOnReady Feature = "RollingUpdateOnReady"
+
+	// NodeExternalDNS is a feature flag to enable/disable node ExternalDNS and InternalDNS use as GameServer address
+	NodeExternalDNS Feature = "NodeExternalDNS"
 )
 
 var (
@@ -51,6 +54,7 @@ var (
 		FeaturePlayerTracking:        false,
 		FeatureSDKWatchSendOnExecute: true,
 		FeatureRollingUpdateOnReady:  false,
+		NodeExternalDNS:              false,
 	}
 
 	// featureGates is the storage of what features are enabled

--- a/site/content/en/docs/FAQ/_index.md
+++ b/site/content/en/docs/FAQ/_index.md
@@ -128,6 +128,16 @@ Each `GameServer` inherits the IP Address of the Node on which it resides. If it
 the Node (which it should if it's a publicly addressable Node), that it utilised, otherwise it falls back to using the
 `InternalIP` address. 
 
+{{% feature publishVersion="1.12.0" %}}
+### How do I use the DNS name of the Node?
+[You can make this available by using the feature flag.]({{< ref "/docs/Guides/feature-stages.md" >}})  
+Agones uses an IP address as the game server address by default.
+This works fine in most cases, but can be a problem if your game server and game client are running on different IP protocols.  
+e.g) The game server is connected only to the IPv4 network, and the game client is connected only to the IPv6 network.  
+When this feature is enabled, Agones will preferentially use the External DNS of the Node on which the GameServer Pod is running.
+Since the game client can get the domain name instead of the IP address, it will be able to communicate with the game server via DNS64 and NAT64.
+{{% /feature %}}
+
 ### How is traffic routed from the allocated Port to the GameServer container?
 
 Traffic is routed to the GameServer Container utilising the `hostPort` field on a 

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -41,6 +41,7 @@ The current set of `alpha` and `beta` feature gates are:
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}}) | `PlayerTracking` | Disabled | `Alpha` | 1.6.0 |
 | [SDK Send GameServer on Watch execution]({{< ref "/docs/Guides/Client SDKs/_index.md#watchgameserverfunctiongameserver" >}}) | `SDKWatchSendOnExecute` | Enabled | `Beta` | 1.12.0 |
 | Fix for RollingUpdate [Scale down](https://github.com/googleforgames/agones/issues/1625) and additional [details]({{< ref "/docs/Guides/fleet-updates.md#alpha-feature-rollingupdateonready" >}}) | `RollingUpdateOnReady` | Disabled | `Alpha` | 1.9.0 |
+| [Utilize Node ExternalDNS](https://github.com/googleforgames/agones/issues/1921) and additional [details]({{< ref "/docs/FAQ/_index.md" >}}) | `NodeExternalDNS` | Disabled | `Alpha` | 1.12.0 |
 {{% /feature %}}
 ## Description of Stages
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / Why we need it**:
In a situation where the game server is located in an IPv4 network and the game client is located in an IPv6 network, if you are able to use ExternalDNS, NAT64 will do the translation correctly and you will be able to communicate.

Currently, only ExternalIP is referenced, so you will get raw IPv4 addresses, and you will have to translate them manually.

The most typical case of a game client deployed in an IPv6 network is an Apple/iOS device.
They require the game application to work properly even on iOS devices deployed in IPv6 networks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1921

**Special notes for your reviewer**: