### PR TITLE
Update documentation to note there is no GameServer update support

### DIFF
--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -123,6 +123,8 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `players` (Alpha, behind "PlayerTracking" feature gate), sets this GameServer's initial player capacity
 - `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
+Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
+
 ## GameServer State Diagram
 
 The following diagram shows the lifecycle of a `GameServer`. 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -123,9 +123,9 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `players` (Alpha, behind "PlayerTracking" feature gate), sets this GameServer's initial player capacity
 - `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
-{{% alert color="info" title="Note" %}}
+{{< alert title="Note" color="info">}}
 Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
-{{% /alert %}}
+{{< /alert >}}
 
 ## GameServer State Diagram
 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -123,7 +123,7 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `players` (Alpha, behind "PlayerTracking" feature gate), sets this GameServer's initial player capacity
 - `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
-Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
+Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< relref "../fleet.md" >}}).
 
 ## GameServer State Diagram
 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -123,7 +123,9 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `players` (Alpha, behind "PlayerTracking" feature gate), sets this GameServer's initial player capacity
 - `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
+{{% alert color="info" title="Note" %}}
 Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
+{{% /alert %}}
 
 ## GameServer State Diagram
 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -124,7 +124,7 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
 {{< alert title="Note" color="info">}}
-Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
+The GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
 {{< /alert >}}
 
 ## GameServer State Diagram

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -123,7 +123,7 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `players` (Alpha, behind "PlayerTracking" feature gate), sets this GameServer's initial player capacity
 - `template` the [pod spec template]({{% k8s-api href="#podtemplatespec-v1-core" %}}) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
 
-Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< relref "../fleet.md" >}}).
+Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
 
 ## GameServer State Diagram
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:

Updates the `GameServer` reference page to note the lack of update support.

This is the included message:
```txt
Please note that the GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
```

This change is due to people not being able to update GameServers and suspecting a bug.

**Which issue(s) this PR fixes**:
Closes #1724 

**Special notes for your reviewer**:
If there is a better place for this, let me know. The reference page is what made most sense to me.


