### PR TITLE
ObjectMeta should use additionalProperties

### DIFF
--- a/install/helm/agones/templates/crds/_gameserverspecschema.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecschema.yaml
@@ -24,10 +24,12 @@ properties:
     properties:
       labels:
         type: object
-        x-kubernetes-preserve-unknown-fields: true
+        additionalProperties:
+          type: string
       annotations:
         type: object
-        x-kubernetes-preserve-unknown-fields: true
+        additionalProperties:
+          type: string
   {{- end}}
   spec:
     type: object

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -231,10 +231,12 @@ spec:
                      properties:
                        labels:
                          type: object
-                         x-kubernetes-preserve-unknown-fields: true
+                         additionalProperties:
+                           type: string
                        annotations:
                          type: object
-                         x-kubernetes-preserve-unknown-fields: true
+                         additionalProperties:
+                           type: string
                    spec:
                      type: object
                      required:
@@ -970,10 +972,12 @@ spec:
                       properties:
                         labels:
                           type: object
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                         annotations:
                           type: object
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                     spec:
                       type: object
                       required:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Rather than using `x-kubernetes-preserve-unknown-fields` which allows both keys and values of any type, we should use `additionalProperties` which only allows a specified type (in this case "string") for keys and values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Better validation!

Also matches ObjectMeta's actual OpenAPI v2 spec.