### PR TITLE
nullable lastScaleTime on FleetAutoScaler CRD

### DIFF
--- a/install/helm/agones/templates/crds/fleetautoscaler.yaml
+++ b/install/helm/agones/templates/crds/fleetautoscaler.yaml
@@ -112,6 +112,7 @@ spec:
                 lastScaleTime:
                   type: string
                   format: date-time
+                  nullable: true
                 ableToScale:
                   type: boolean
                 scalingLimited:

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -538,6 +538,7 @@ spec:
                 lastScaleTime:
                   type: string
                   format: date-time
+                  nullable: true
                 ableToScale:
                   type: boolean
                 scalingLimited:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

lastScaleTime can be null as it is a pointer in the CRD definition.

Needs to be nullable in the CRD spec, as kubectl will pass this value as "null", which causes the validation to fail in the error logs of the controller (no functionality differences though).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1951

**Special notes for your reviewer**:

Interestingly, creating a FleetAutoscaler from client-go code doesn't cause this error, just kubectl.
