### PR TITLE
Fix badly formatted feature tags in GameServer specification docs

### DIFF
--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -9,7 +9,7 @@ description: >
 
 A full GameServer specification is available below and in the {{< ghlink href="examples/gameserver.yaml" >}}example folder{{< /ghlink >}} for reference :
 
-{{< feature expiryVersion="1.12.0"  >}}
+{{% feature expiryVersion="1.12.0"  %}}
 ```yaml
 apiVersion: "agones.dev/v1"
 kind: GameServer
@@ -93,7 +93,7 @@ spec:
         image:  gcr.io/agones-images/udp-server:0.21
         imagePullPolicy: Always
 ```
-{{< /feature >}}
+{{% /feature %}}
 
 {{% feature publishVersion="1.12.0"  %}}
 ```yaml
@@ -177,7 +177,7 @@ spec:
         image:  gcr.io/agones-images/udp-server:0.21
         imagePullPolicy: Always
 ```
-{{< /feature >}}
+{{% /feature %}}
 
 Since Agones defines a new [Custom Resources Definition (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) we can define a new resource using the kind `GameServer` with the custom group `agones.dev` and API version `v1`.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/master/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/master/build/README.md#testing-and-building
-->

**What type of PR is this?**

/kind documentation


**What this PR does / Why we need it**:

Fixes some template syntax issues. Was reading the live documentation and came across the following rendering issue (see screenshot)

![image](https://user-images.githubusercontent.com/2623895/106519795-d920fb00-64a9-11eb-8475-2ca949541cd0.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


