### PR TITLE
Fix fleet autoscaler fleet name CRD validation issue

### DIFF
--- a/install/helm/agones/templates/crds/fleetautoscaler.yaml
+++ b/install/helm/agones/templates/crds/fleetautoscaler.yaml
@@ -51,7 +51,7 @@ spec:
                   type: string
                   minLength: 1
                   maxLength: 63
-                  pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                  pattern: "^[a-z0-9]([-\\.a-z0-9]*[a-z0-9])?$"
                 policy:
                   type: object
                   required:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

Fixes CRD validation issue for Fleet Autoscalers that reference a Fleet that has periods `.` in it.

**Which issue(s) this PR fixes**:
Closes #1954

**Special notes for your reviewer**:

I tested it on a regex checker, see the following: https://regex101.com/r/SQzpHU/1

I'm not sure if I need to add a test for this. If yes, I'm open to adding it if someone shows me where it should go. 
