### PR TITLE
Reduce e2e test parrallelism from 64 to 32

### DIFF
--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -20,5 +20,5 @@ set -e
 echo "installing current release"
 DOCKER_RUN= make install FEATURE_GATES='"'$FEATURES'"'
 echo "starting e2e test"
-DOCKER_RUN= make test-e2e ARGS=-parallel=64 FEATURE_GATES='"'$FEATURES'"'
+DOCKER_RUN= make test-e2e ARGS=-parallel=32 FEATURE_GATES='"'$FEATURES'"'
 echo "completed e2e test"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

One theory is that we're running too many tests  for the controller/control plane to manage at any given point and time, and things are timing out, and that's why we're getting so many flakes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2016 

**Special notes for your reviewer**:

N/A
