### PR TITLE
Fix GameServerAllocation preferred documentation

### DIFF
--- a/site/content/en/docs/Reference/gameserverallocation.md
+++ b/site/content/en/docs/Reference/gameserverallocation.md
@@ -25,8 +25,10 @@ spec:
       game: my-game
     matchExpressions:
       - {key: tier, operator: In, values: [cache]}
-  # ordered list of preferred allocations out of the `required` set.
+  # An ordered list of preferred GameServer label selectors
+  # that are optional to be fulfilled, but will be searched before the `required` selector.
   # If the first selector is not matched, the selection attempts the second selector, and so on.
+  # If any of the preferred selectors are matched, the required selector is not considered.
   # This is useful for things like smoke testing of new game servers.
   # This also support `matchExpressions`
   preferred:
@@ -55,13 +57,15 @@ name for the `GameServerAllocation` is generated when the `GameServerAllocation`
 
 The `spec` field is the actual `GameServerAllocation` specification and it is composed as follow:
 
-- `required` is a [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) 
-   (matchLabels and/or matchExpressions) from which to choose GameServers from.
-   GameServers still have the hard requirement to be `Ready` to be allocated from
-- `preferred` is an order list of [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-   out of the `required` set.
-   If the first selector is not matched, the selection attempts the second selector, and so on.
-   This is useful for things like smoke testing of new game servers. 
+- `required` is a [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+  (matchLabels and/or matchExpressions) from which to choose GameServers from.
+  GameServers still have the hard requirement to be `Ready` to be allocated from
+- `preferred` is an ordered list of preferred
+  [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+  that are _optional_ to be fulfilled, but will be searched before the `required` selector.
+  If the first selector is not matched, the selection attempts the second selector, and so on.
+  If any of the `preferred` selectors are matched, the `required` selector is not considered.
+  This is useful for things like smoke testing of new game servers.
 - `scheduling` defines how GameServers are organised across the cluster, in this case specifically when allocating
   `GameServers` for usage.
    "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

There was a bug in the reference docs that read that the `required` check was applied to all queries, including the preferred check.

This is not the case - each label selector is independent.

Fixing this in the documentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A