### PR TITLE
Build Agones Windows images by default.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -49,8 +49,10 @@ MINIKUBE_PROFILE ?= agones
 GO_BUILD_TAGS ?= none
 BUILDX_WINDOWS_BUILDER = windows-builder
 WINDOWS_DOCKER_PUSH_ARGS =
-WINDOWS_VERSIONS = ltsc2019 # 1909 (For GKE WINDOWS_SAC support)
-BUILD_WINDOWS_IMAGE =
+# Versions of Windows Server to support, default is Windows Server 2019.
+# For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
+# GKE-Windows version map: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#version_mapping
+WINDOWS_VERSIONS = ltsc2019
 
 # Specify stress test level 1..100
 # STRESS_TEST_LEVEL=n requires capacity between 50*n up to 100*n simple-game-server Game Servers.
@@ -64,6 +66,9 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 GS_TEST_IMAGE ?= gcr.io/agones-images/simple-game-server:0.2
 
 ALPHA_FEATURE_GATES ?= "PlayerTracking=true&NodeExternalDNS=true"
+
+# Build with Windows support
+WITH_WINDOWS=1
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
@@ -94,7 +99,7 @@ build_tag = agones-build:$(build_version)
 controller_tag = $(REGISTRY)/agones-controller:$(VERSION)
 sidecar_tag = $(REGISTRY)/agones-sdk:$(VERSION)
 
-ifdef WITH_WINDOWS
+ifeq ($(WITH_WINDOWS), 1)
 sidecar_linux_amd64_tag = $(sidecar_tag)-linux_amd64
 else
 sidecar_linux_amd64_tag = $(sidecar_tag)
@@ -216,7 +221,7 @@ build: build-images build-sdks
 
 # build the docker images
 build-images: build-controller-image build-agones-sdk-image build-ping-image build-allocator-image
-ifdef WITH_WINDOWS
+ifeq ($(WITH_WINDOWS), 1)
 build-images: build-agones-sdk-image-windows
 endif
 
@@ -451,15 +456,17 @@ push-allocator-image: $(ensure-build-image)
 build-allocator-image: $(ensure-build-image) build-allocator-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/allocator/ --tag=$(allocator_tag) $(DOCKER_BUILD_ARGS)
 
-ifdef WITH_WINDOWS
+ifeq ($(WITH_WINDOWS), 1)
 # push the gameservers sidecar image
 push-agones-sdk-image: push-agones-sdk-linux-image
+	# Ensure that the sidecar manifest is removed before creating a new one.
+	-DOCKER_CLI_EXPERIMENTAL=enabled docker manifest rm $(sidecar_tag)
 	# Using docker buildx with foreign OSes is a bit awkward. Since the layers but not the tag
 	# was cached we have to rebuild the image (which should be fast since it's cached).
 	$(MAKE) WINDOWS_DOCKER_PUSH_ARGS=--push build-agones-sdk-image-windows
 	# Agones should start using the -linux_amd64 suffix for Linux images. This allows multi-arch support in the future.
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create $(sidecar_tag) $(sidecar_linux_amd64_tag) $(foreach windows_version, $(WINDOWS_VERSIONS), $(sidecar_tag)-windows_amd64-$(windows_version))
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(sidecar_tag) --purge
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(sidecar_tag)
 else
 push-agones-sdk-image: push-agones-sdk-linux-image
 endif

--- a/build/README.md
+++ b/build/README.md
@@ -392,7 +392,8 @@ and `default` (for pulling the sdk image) repositories.
 ### WITH_WINDOWS
 Build Windows container images for Agones.
 
-If set, `make WITH_WINDOWS=1 build-images` will build Windows images.
+This option is enabled by default via implicit `make WITH_WINDOWS=1 build-images`.
+To disable, use `make WITH_WINDOWS=0 build-images`.
 
 ### WINDOWS_VERSIONS
 List of Windows Server versions to build for. Defaults to `ltsc2019` for Windows Server 2019.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -314,8 +314,8 @@ substitutions:
   _RUST_SDK_BUILD_CACHE_KEY: rust-sdk-build
 
 tags: ['ci']
-timeout: "2h"
-images: ['gcr.io/$PROJECT_ID/agones-controller', 'gcr.io/$PROJECT_ID/agones-sdk', 'gcr.io/$PROJECT_ID/agones-ping']
+timeout: 7200s
+images: ['gcr.io/$PROJECT_ID/agones-controller', 'gcr.io/$PROJECT_ID/agones-ping']
 logsBucket: "gs://agones-build-logs"
 options:
  machineType: 'N1_HIGHCPU_32'

--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -25,13 +25,18 @@
 
 REGISTRY = gcr.io/agones-images
 BUILDX_WINDOWS_BUILDER = windows-builder
-WINDOWS_VERSIONS = ltsc2019 # 1909 (For GKE WINDOWS_SAC support)
+# Versions of Windows Server to support, default is Windows Server 2019.
+# For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
+# GKE-Windows version map: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#version_mapping
+WINDOWS_VERSIONS = ltsc2019
 WINDOWS_DOCKER_PUSH_ARGS = # When pushing set to --push.
+# Build with Windows support
+WITH_WINDOWS=1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
 server_tag = $(REGISTRY)/simple-game-server:0.2
-ifdef WITH_WINDOWS
+ifeq ($(WITH_WINDOWS), 1)
 server_tag_linux_amd64 = $(server_tag)-linux_amd64
 else
 server_tag_linux_amd64 = $(server_tag)
@@ -45,7 +50,7 @@ root_path = $(realpath $(project_path)/../..)
 #    |_|\__,_|_|  \__, |\___|\__|___/
 #                 |___/
 
-ifdef WITH_WINDOWS
+ifeq ($(WITH_WINDOWS), 1)
 push: push-multi-arch-image
 build: build-linux-image $(foreach winver, $(WINDOWS_VERSIONS), build-windows-image-$(winver))
 else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind feature
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Builds Windows container images by default so that they are easier to use out of the box.
This is done by turning on the `WITH_WINDOWS=1` flag in the Makefile.

**Which issue(s) this PR fixes**:
Issue #54 is mostly complete.

**Special notes for your reviewer**:
This will add some latency to the Agones build.

