### PR TITLE
Bump the y18n nodejs dependency to 4.0.1 to fix CVE-2020-7774

### DIFF
--- a/examples/nodejs-simple/README.md
+++ b/examples/nodejs-simple/README.md
@@ -29,9 +29,9 @@ tools need to be installed on your system.
 ## Testing locally with Docker
 
 If you want to run the example locally, you need to start an instance of the SDK-server. To run an SDK-server for
-120 seconds, run
+240 seconds, run
 ```bash
-$ cd ../../build; make run-sdk-conformance-local TIMEOUT=120 TESTS=ready,watch,health,gameserver
+$ cd ../../build; make run-sdk-conformance-local TIMEOUT=240 TESTS=ready,watch,health,gameserver
 ```
 
 In a separate terminal, while the SDK-server is still running, build and start a container with the example gameserver:
@@ -68,11 +68,11 @@ $ npm start -- --help
 ```
 
 You can optionally specify how long the server will stay up once the basic tests are complete with the `--timeout` option.
-To do this pass arguments through, e.g. to increase the shutdown duration to 120 seconds:
+To do this pass arguments through, e.g. to increase the shutdown duration to 90 seconds:
 ```
-$ make args="--timeout=120" run
-$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5 --timeout=120
-$ npm start -- --timeout=120
+$ make args="--timeout=90" run
+$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5 --timeout=90
+$ npm start -- --timeout=90
 ```
 
 To make run indefinitely use the special timeout value of 0:
@@ -84,7 +84,7 @@ $ npm start -- --timeout=0
 
 To enable alpha features ensure the feature gate is enabled:
 ```bash
-$ cd ../../build; make run-sdk-conformance-local TIMEOUT=120 FEATURE_GATES="PlayerTracking=true" TESTS=ready,watch,health,gameserver
+$ cd ../../build; make run-sdk-conformance-local TIMEOUT=240 FEATURE_GATES="PlayerTracking=true" TESTS=ready,watch,health,gameserver
 ```
 
 Then enable the alpha suite:

--- a/sdks/nodejs/package-lock.json
+++ b/sdks/nodejs/package-lock.json
@@ -2159,7 +2159,7 @@
       }
     },
     "y18n": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },


### PR DESCRIPTION
Also added some minor updates to the nodejs example README.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Address a security issue in the nodejs SDK. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


