### PR TITLE
Update app labels to all use "agones.name" and not "agones.fullname"

### DIFF
--- a/install/helm/agones/templates/extensions.yaml
+++ b/install/helm/agones/templates/extensions.yaml
@@ -145,7 +145,7 @@ metadata:
   name: {{ template "agones.fullname" . }}-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "agones.fullname" . }}
+    app: {{ template "agones.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -257,7 +257,7 @@ metadata:
   name: allocator-client-ca
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "agones.fullname" . }}
+    app: {{ template "agones.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -281,7 +281,7 @@ metadata:
   name: allocator-tls
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "agones.fullname" . }}
+    app: {{ template "agones.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -302,7 +302,7 @@ metadata:
   name: allocator-tls-ca
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "agones.fullname" . }}
+    app: {{ template "agones.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -324,7 +324,7 @@ metadata:
   name: allocator-client.default
   namespace: {{ . }}
   labels:
-    app: {{ template "agones.fullname" $ }}
+    app: {{ template "agones.name" $ }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -69,7 +69,7 @@ metadata:
   name: agones-manual-cert
   namespace: agones-system
   labels:
-    app: agones-manual
+    app: agones
     chart: "agones-1.14.0-dev"
     release: "agones-manual"
     heritage: "Helm"
@@ -86,7 +86,7 @@ metadata:
   name: allocator-client-ca
   namespace: agones-system
   labels:
-    app: agones-manual
+    app: agones
     chart: "agones-1.14.0-dev"
     release: "agones-manual"
     heritage: "Helm"
@@ -102,7 +102,7 @@ metadata:
   name: allocator-tls
   namespace: agones-system
   labels:
-    app: agones-manual
+    app: agones
     chart: "agones-1.14.0-dev"
     release: "agones-manual"
     heritage: "Helm"
@@ -118,7 +118,7 @@ metadata:
   name: allocator-tls-ca
   namespace: agones-system
   labels:
-    app: agones-manual
+    app: agones
     chart: "agones-1.14.0-dev"
     release: "agones-manual"
     heritage: "Helm"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

 /kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: If you inspect the labels on the installed resources from helm, the `app` label is currently used inconsistently. In most places it is just the charge name (e.g. `agones`) but in some resources it is the "fullname", which prepends the chart name with the release name (e.g. `my-release-agones`). Since we have a separate label with the release name and most places just use the chart name, this brings everything in line to consistently use the chart name for all occurrences of the `app` label. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


