### PR TITLE
Explanation for SetLabel/Annotation prefixes

### DIFF
--- a/site/content/en/docs/FAQ/_index.md
+++ b/site/content/en/docs/FAQ/_index.md
@@ -79,6 +79,11 @@ through [SDK.WatchGameServer()]({{< ref "/docs/Guides/Client SDKs/_index.md#watc
 Combining these two features allows you to pass information such as map data, gameplay metadata and more to a game
 server binary at Allocation time, through Agones functionality.
 
+Do note, that if you wish to have either the labels or annotations that are set via `GameServerAllocation` to be 
+editable by the game server via the Agones SDK, the label key will need to be prefixed with `agones.dev/sdk-`. See
+[SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabelkey-value" >}})
+and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/_index.md#setannotationkey-value" >}}) for more information.
+
 ### How can I expose information from my game server binary to an external service?
 
 The Agones game server SDK allows you to set custom 

--- a/site/content/en/docs/FAQ/_index.md
+++ b/site/content/en/docs/FAQ/_index.md
@@ -79,9 +79,10 @@ through [SDK.WatchGameServer()]({{< ref "/docs/Guides/Client SDKs/_index.md#watc
 Combining these two features allows you to pass information such as map data, gameplay metadata and more to a game
 server binary at Allocation time, through Agones functionality.
 
-Do note, that if you wish to have either the labels or annotations that are set via `GameServerAllocation` to be 
-editable by the game server via the Agones SDK, the label key will need to be prefixed with `agones.dev/sdk-`. See
-[SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabelkey-value" >}})
+Do note, that if you wish to have either the labels or annotations on the `GameServer` that are set via a  
+`GameServerAllocation` to be editable by the game server binary with the Agones SDK, the label key will need to 
+be prefixed with `agones.dev/sdk-`.
+See [SDK.SetLabel()]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabelkey-value" >}})
 and [SDK.SetAnnotation()]({{< ref "/docs/Guides/Client SDKs/_index.md#setannotationkey-value" >}}) for more information.
 
 ### How can I expose information from my game server binary to an external service?

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -192,7 +192,7 @@ two main reasons:
    SDK only gives you access to write to part of the set of labels and annotations that exist on a GameServer.
 *  The prefix allows for a smaller attack surface if the GameServer container gets compromised. Since the 
    game container is generally externally exposed, and the Agones project doesn't control the binary that is 
-   run within it, limiting exposure if something goes horribly wrong, and it becomes compromised is worth the extra 
+   run within it, limiting exposure if the game server becomes compromised is worth the extra 
    development friction that comes with having this prefix in place.
 
 {{< alert title="Warning" color="warning">}}

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -185,14 +185,14 @@ please [file an issue](https://github.com/googleforgames/agones/issues).
 This will set a [Label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) value on the backing `GameServer`
 record that is stored in Kubernetes. 
 
-To maintain isolation, the `key` value is automatically prefixed with value **"agones.dev/sdk-"**. This is done for two 
-main reasons:
+To maintain isolation, the `key` value is automatically prefixed with the value **"agones.dev/sdk-"**. This is done for 
+two main reasons:
 *  The prefix allows the developer to always know if they are accessing or reading a value that could have come, or 
-   may be changed by the client SDK. Much like `private` vs `public` scope in a programming language - The Agones SDK only 
-   gives you access to part of the set of labels and annotations that exist on a GameServer.
+   may be changed by the client SDK. Much like `private` vs `public` scope in a programming language, the Agones 
+   SDK only gives you access to write to part of the set of labels and annotations that exist on a GameServer.
 *  The prefix allows for a smaller attack surface if the GameServer container gets compromised. Since the 
    game container is generally externally exposed, and the Agones project doesn't control the binary that is 
-   run within it - limiting exposure if something goes horribly wrong, and it becomes compromised is worth the extra 
+   run within it, limiting exposure if something goes horribly wrong, and it becomes compromised is worth the extra 
    development friction that comes with having this prefix in place.
 
 {{< alert title="Warning" color="warning">}}
@@ -206,12 +206,12 @@ observable or searchable through the Kubernetes API.
 
 #### SetAnnotation(key, value)
 
-This will set a [Annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) value on the backing
-`GameServer` record that is stored in Kubernetes. 
+This will set an [Annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) value 
+on the backing `GameServer` record that is stored in Kubernetes. 
 
-To maintain isolation, the `key` value is automatically prefixed with **"agones.dev/sdk-"**. Since Agones also uses 
-annotations on the `GameServer` as part of its internal processes, the prefix is also in place for the same reasons 
-as in [SetLabel(...)](#setlabelkey-value) above.
+To maintain isolation, the `key` value is automatically prefixed with **"agones.dev/sdk-"** for the same reasons as 
+in [SetLabel(...)](#setlabelkey-value) above. The isolation is also important as Agones uses annotations on the 
+`GameServer` as part of its internal processing.
 
 Setting `GameServer` annotations can be useful if you want information from your running game server process to be 
 observable through the Kubernetes API.

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -183,21 +183,38 @@ please [file an issue](https://github.com/googleforgames/agones/issues).
 #### SetLabel(key, value)
 
 This will set a [Label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) value on the backing `GameServer`
-record that is stored in Kubernetes. To maintain isolation, the `key` value is automatically prefixed with "agones.dev/sdk-".
+record that is stored in Kubernetes. 
+
+To maintain isolation, the `key` value is automatically prefixed with value **"agones.dev/sdk-"**. This is done for two 
+main reasons:
+*  The prefix allows the developer to always know if they are accessing or reading a value that could have come, or 
+   may be changed by the client SDK. Much like `private` vs `public` scope in a programming language - The Agones SDK only 
+   gives you access to part of the set of labels and annotations that exist on a GameServer.
+*  The prefix allows for a smaller attack surface if the GameServer container gets compromised. Since the 
+   game container is generally externally exposed, and the Agones project doesn't control the binary that is 
+   run within it - limiting exposure if something goes horribly wrong, and it becomes compromised is worth the extra 
+   development friction that comes with having this prefix in place.
 
 {{< alert title="Warning" color="warning">}}
 There are limits on the characters that be used for label keys and values. Details are [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).
+
+You will need to take them into account when combined with the label prefix above. 
 {{< /alert >}}
 
-This can be useful if you want information from your running game server process to be observable or searchable through the Kubernetes API.  
+Setting `GameServer` labels can be useful if you want information from your running game server process to be 
+observable or searchable through the Kubernetes API.  
 
 #### SetAnnotation(key, value)
 
 This will set a [Annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) value on the backing
-`GameServer` record that is stored in Kubernetes. To maintain isolation, the `key` value is automatically prefixed with "agones.dev/sdk-".
+`GameServer` record that is stored in Kubernetes. 
 
-This can be useful if you want information from your running game server process to be observable through the Kubernetes API.
+To maintain isolation, the `key` value is automatically prefixed with **"agones.dev/sdk-"**. Since Agones also uses 
+annotations on the `GameServer` as part of its internal processes, the prefix is also in place for the same reasons 
+as in [SetLabel(...)](#setlabelkey-value) above.
 
+Setting `GameServer` annotations can be useful if you want information from your running game server process to be 
+observable through the Kubernetes API.
 
 ### Player Tracking
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Better explantations for the reasons why both `SetLabel(...)` and `SetAnnotation(...)` on the game server SDK are prefixed with values when being set on the GameServer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2053

**Special notes for your reviewer**:

N/A