### PR TITLE
Cleanup: Start ➡ Run for all components.

### DIFF
--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -252,7 +252,7 @@ func newServiceHandler(kubeClient kubernetes.Interface, agonesClient versioned.I
 
 	kubeInformerFactory.Start(ctx.Done())
 	agonesInformerFactory.Start(ctx.Done())
-	if err := allocator.Start(ctx); err != nil {
+	if err := allocator.Run(ctx); err != nil {
 		logger.WithError(err).Fatal("starting allocator failed.")
 	}
 

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -164,13 +164,13 @@ func NewAllocator(policyInformer multiclusterinformerv1.GameServerAllocationPoli
 	return ah
 }
 
-// Start initiates the listeners.
-func (c *Allocator) Start(ctx context.Context) error {
+// Run initiates the listeners.
+func (c *Allocator) Run(ctx context.Context) error {
 	if err := c.Sync(ctx); err != nil {
 		return err
 	}
 
-	if err := c.readyGameServerCache.Start(ctx); err != nil {
+	if err := c.readyGameServerCache.Run(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) registerAPIResource(ctx context.Context) {
 // Run runs this controller. Will block until stop is closed.
 // Ignores threadiness, as we only needs 1 worker for cache sync
 func (c *Controller) Run(ctx context.Context, _ int) error {
-	if err := c.allocator.Start(ctx); err != nil {
+	if err := c.allocator.Run(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/gameserverallocations/ready_cache.go
+++ b/pkg/gameserverallocations/ready_cache.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"sort"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"agones.dev/agones/pkg/apis/agones"
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	allocationv1 "agones.dev/agones/pkg/apis/allocation/v1"
@@ -33,6 +31,7 @@ import (
 	"github.com/heptiolabs/healthcheck"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -125,8 +124,8 @@ func (c *ReadyGameServerCache) Resync() {
 	c.workerqueue.EnqueueImmediately(&agonesv1.GameServer{})
 }
 
-// Start prepares cache to start
-func (c *ReadyGameServerCache) Start(ctx context.Context) error {
+// Run prepares cache to start
+func (c *ReadyGameServerCache) Run(ctx context.Context) error {
 	if err := c.Sync(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Minor cleanup that was irking me for a while. 😍

Almost all of the Agones component follow a pattern of `New*` for construction and call `Run` to start a process / background thread / etc.

Except for a couple of allocation components that have a `Start` instead of a `Run`.

This PR renames their `Start` functions to `Run` to make everything consistent.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A