### PR TITLE
Update the machine type for GKE clusters in build scripts and terraform modules.

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -206,9 +206,9 @@ See the table below for available customizations :
 | `GCP_CLUSTER_NAME`                             | The name of the cluster                                                       | `test-cluster`  |
 | `GCP_CLUSTER_ZONE`                             | The name of the Google Compute Engine zone in which the cluster will resides. | `us-west1-c`    |
 | `GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT`        | The number of nodes to create in this cluster.                                | `4`             |
-| `GCP_CLUSTER_NODEPOOL_MACHINETYPE`             | The name of a Google Compute Engine machine type.                             | `n1-standard-4` |
+| `GCP_CLUSTER_NODEPOOL_MACHINETYPE`             | The name of a Google Compute Engine machine type.                             | `e2-standard-4` |
 | `GCP_CLUSTER_NODEPOOL_WINDOWSINITIALNODECOUNT` | The number of Windows nodes to create in this cluster.                        | `0`             |
-| `GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE`      | The name of a Google Compute Engine machine type for Windows nodes.           | `n1-standard-4` |
+| `GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE`      | The name of a Google Compute Engine machine type for Windows nodes.           | `e2-standard-4` |
 
 If you would like to change more settings, feel free to edit the [`cluster.yml.jinja`](./gke-test-cluster/cluster.yml.jinja) file before running this command.
 

--- a/build/includes/google-cloud.mk
+++ b/build/includes/google-cloud.mk
@@ -25,9 +25,9 @@ gcloud-init: ensure-build-config
 
 # Creates and authenticates a small, 6 node GKE cluster to work against (2 nodes are used for agones-metrics and agones-system)
 gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT ?= 4
-gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= n1-standard-4
+gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= e2-standard-4
 gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_WINDOWSINITIALNODECOUNT ?= 0
-gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE ?= n1-standard-4
+gcloud-test-cluster: GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE ?= e2-standard-4
 gcloud-test-cluster: $(ensure-build-image)
 	$(MAKE) gcloud-terraform-cluster GCP_TF_CLUSTER_NAME="$(GCP_CLUSTER_NAME)" GCP_CLUSTER_ZONE="$(GCP_CLUSTER_ZONE)" \
 		GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT="$(GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT)" \

--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -36,9 +36,9 @@ terraform-clean:
 # Version could be specified by AGONES_VERSION
 # Alpha Feature gates are disabled
 gcloud-terraform-cluster: GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT ?= 4
-gcloud-terraform-cluster: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= n1-standard-4
+gcloud-terraform-cluster: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= e2-standard-4
 gcloud-terraform-cluster: GCP_CLUSTER_NODEPOOL_WINDOWSINITIALNODECOUNT ?= 0
-gcloud-terraform-cluster: GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE ?= n1-standard-4
+gcloud-terraform-cluster: GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE ?= e2-standard-4
 gcloud-terraform-cluster: AGONES_VERSION ?= ''
 gcloud-terraform-cluster: GCP_TF_CLUSTER_NAME ?= agones-tf-cluster
 gcloud-terraform-cluster: LOG_LEVEL ?= debug
@@ -63,9 +63,9 @@ gcloud-terraform-cluster:
 # Set all necessary variables as `make install` does
 # Unifies previous `make gcloud-test-cluster` and `make install` targets
 gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_INITIALNODECOUNT ?= 4
-gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= n1-standard-4
+gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_MACHINETYPE ?= e2-standard-4
 gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_WINDOWSINITIALNODECOUNT ?= 0
-gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE ?= n1-standard-4
+gcloud-terraform-install: GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE ?= e2-standard-4
 gcloud-terraform-install: ALWAYS_PULL_SIDECAR := true
 gcloud-terraform-install: IMAGE_PULL_POLICY := "Always"
 gcloud-terraform-install: PING_SERVICE_TYPE := "LoadBalancer"

--- a/build/terraform/e2e/module.tf
+++ b/build/terraform/e2e/module.tf
@@ -30,7 +30,7 @@ module "gke_cluster" {
   cluster = {
     "name"             = "e2e-test-cluster"
     "zone"             = "us-west1-c"
-    "machineType"      = "n1-standard-4"
+    "machineType"      = "e2-standard-4"
     "initialNodeCount" = 8
     "project"          = var.project
   }

--- a/build/terraform/gke/module.tf
+++ b/build/terraform/gke/module.tf
@@ -34,11 +34,11 @@ variable "agones_version" {
 }
 
 variable "machine_type" {
-  default = "n1-standard-4"
+  default = "e2-standard-4"
 }
 
 variable "windows_machine_type" {
-  default = "n1-standard-4"
+  default = "e2-standard-4"
 }
 
 variable "name" {

--- a/build/terraform/prow/module.tf
+++ b/build/terraform/prow/module.tf
@@ -28,7 +28,7 @@ resource "google_container_cluster" "prow-build-cluster" {
   min_master_version = "1.18"
   initial_node_count = 8
   node_config {
-    machine_type = "n1-standard-4"
+    machine_type = "e2-standard-4"
     oauth_scopes = [
       "https://www.googleapis.com/auth/devstorage.read_only",
       "https://www.googleapis.com/auth/logging.write",

--- a/examples/terraform-submodules/gke/module.tf
+++ b/examples/terraform-submodules/gke/module.tf
@@ -38,7 +38,7 @@ variable "agones_version" {
 }
 
 variable "machine_type" {
-  default = "n1-standard-4"
+  default = "e2-standard-4"
 }
 
 // Note: This is the number of gameserver nodes. The Agones module will automatically create an additional
@@ -74,7 +74,7 @@ variable "windows_node_count" {
 }
 
 variable "windows_machine_type" {
-  default = "n1-standard-4"
+  default = "e2-standard-4"
 }
 
 module "gke_cluster" {

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -25,13 +25,13 @@ locals {
   project                 = lookup(var.cluster, "project", "agones")
   zone                    = lookup(var.cluster, "zone", "us-west1-c")
   name                    = lookup(var.cluster, "name", "test-cluster")
-  machineType             = lookup(var.cluster, "machineType", "n1-standard-4")
+  machineType             = lookup(var.cluster, "machineType", "e2-standard-4")
   initialNodeCount        = lookup(var.cluster, "initialNodeCount", "4")
   network                 = lookup(var.cluster, "network", "default")
   subnetwork              = lookup(var.cluster, "subnetwork", "")
   kubernetesVersion       = lookup(var.cluster, "kubernetesVersion", "1.18")
   windowsInitialNodeCount = lookup(var.cluster, "windowsInitialNodeCount", "0")
-  windowsMachineType      = lookup(var.cluster, "windowsMachineType", "n1-standard-4")
+  windowsMachineType      = lookup(var.cluster, "windowsMachineType", "e2-standard-4")
 }
 
 # echo command used for debugging purpose
@@ -96,7 +96,7 @@ resource "google_container_cluster" "primary" {
     }
 
     node_config {
-      machine_type = "n1-standard-4"
+      machine_type = "e2-standard-4"
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/devstorage.read_only",
@@ -128,7 +128,7 @@ resource "google_container_cluster" "primary" {
     }
 
     node_config {
-      machine_type = "n1-standard-4"
+      machine_type = "e2-standard-4"
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/devstorage.read_only",

--- a/install/terraform/modules/gke/variables.tf
+++ b/install/terraform/modules/gke/variables.tf
@@ -27,14 +27,14 @@ variable "cluster" {
   default = {
     "zone"                    = "us-west1-c"
     "name"                    = "test-cluster"
-    "machineType"             = "n1-standard-4"
+    "machineType"             = "e2-standard-4"
     "initialNodeCount"        = "4"
     "project"                 = "agones"
     "network"                 = "default"
     "subnetwork"              = ""
     "kubernetesVersion"       = "1.18"
     "windowsInitialNodeCount" = "0"
-    "windowsMachineType"      = "n1-standard-4"
+    "windowsMachineType"      = "e2-standard-4"
   }
 }
 

--- a/site/content/en/docs/Installation/Creating Cluster/gke.md
+++ b/site/content/en/docs/Installation/Creating Cluster/gke.md
@@ -98,7 +98,7 @@ Flag explanations:
 * scopes: Defines the Oauth scopes required by the nodes.
 * num-nodes: The number of nodes to be created in each of the cluster's zones. Default: 4. Depending on the needs of your game, this parameter should be adjusted.
 * no-enable-autoupgrade: Disable automatic upgrades for nodes to reduce the likelihood of in-use games being disrupted.
-* machine-type: The type of machine to use for nodes. Default: e2-medium. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
+* machine-type: The type of machine to use for nodes. Default: e2-standard-4. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
 
 _Optional_: Create a dedicated node pool for the Agones controllers. If you choose to skip this step, the Agones
 controllers will share the default node pool with your game servers which is fine for kicking the tires but is not

--- a/site/content/en/docs/Installation/Terraform/gke.md
+++ b/site/content/en/docs/Installation/Terraform/gke.md
@@ -80,6 +80,7 @@ The GKE cluster created from the example configuration will contain 3 Node Pools
 
 Configurable parameters:
 
+{{% feature expiryVersion="0.14.0" %}}
 - project - your Google Cloud Project ID (required)
 - name - the name of the GKE cluster (default is "agones-terraform-example")
 - agones_version - the version of agones to install (an empty string, which is the default, is the latest version from the [Helm repository](https://agones.dev/chart/stable))
@@ -95,6 +96,25 @@ Configurable parameters:
 - gameserver_maxPort - the upper bound of the port range which gameservers will listen on (default is "8000")
 - gameserver_namespaces - a list of namespaces which will be used to run gameservers (default is `["default"]`). For example `["default", "xbox-gameservers", "mobile-gameservers"]`
 - force_update - whether or not to force the replacement/update of resource (default is true, false may be required to prevent immutability errors when updating the configuration)
+{{% /feature %}}
+
+{{% feature publishVersion="0.14.0" %}}
+- project - your Google Cloud Project ID (required)
+- name - the name of the GKE cluster (default is "agones-terraform-example")
+- agones_version - the version of agones to install (an empty string, which is the default, is the latest version from the [Helm repository](https://agones.dev/chart/stable))
+- machine_type - machine type for hosting game servers (default is "e2-standard-4")
+- node_count - count of game server nodes for the default node pool (default is "4")
+- zone - the name of the [zone](https://cloud.google.com/compute/docs/regions-zones) you want your cluster to be
+  created in (default is "us-west1-c")
+- network - the name of the VPC network you want your cluster and firewall rules to be connected to (default is "default")
+- subnetwork - the name of the subnetwork in which the cluster's instances are launched. (required when using non default network)
+- log_level - possible values: Fatal, Error, Warn, Info, Debug (default is "info")
+- feature_gates - a list of alpha and beta version features to enable. For example, "PlayerTracking=true&ContainerPortAllocation=true"
+- gameserver_minPort - the lower bound of the port range which gameservers will listen on (default is "7000")
+- gameserver_maxPort - the upper bound of the port range which gameservers will listen on (default is "8000")
+- gameserver_namespaces - a list of namespaces which will be used to run gameservers (default is `["default"]`). For example `["default", "xbox-gameservers", "mobile-gameservers"]`
+- force_update - whether or not to force the replacement/update of resource (default is true, false may be required to prevent immutability errors when updating the configuration)
+{{% /feature %}}
 
 {{% alert title="Warning" color="warning"%}}
 On the lines that read `source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=main"`

--- a/test/load/allocation/grpc/README.md
+++ b/test/load/allocation/grpc/README.md
@@ -8,7 +8,7 @@ For the load test you can follow the regular Kubernetes and Agones setup. In ord
 the game servers to Ready state before starting a test.
 Here are the few important things:
 - If you are running in GCP, use a regional cluster instead of a zonal cluster to ensure high availability of the cluster control plane
-- Use a dedicated node pool for the Agones controllers with multiple CPUs per node, e.g. `n1-standard-4'
+- Use a dedicated node pool for the Agones controllers with multiple CPUs per node, e.g. `e2-standard-4'
 - In the default node pool (where the Game Server pods are created), 75 nodes are required to make sure there are enough nodes available for all game servers to move into the ready state. When using a regional cluster, with three zones with the region, that will require a configuration of 25 nodes per zone.
 
 ## Fleet Setting


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

 /kind breaking

> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Removes all remaining references to n1-standard machine type from the repository. 

I've marked this change as breaking since it changes the machine type in the terraform files. 

**Which issue(s) this PR fixes**:
Closes #2055

**Special notes for your reviewer**: This PR also addresses a comment from #2056 that was made after the PR was merged. 


