### PR TITLE
Metadata missing in xonotic example , fails to start without it

### DIFF
--- a/examples/xonotic/gameserverallocation.yaml
+++ b/examples/xonotic/gameserverallocation.yaml
@@ -14,6 +14,8 @@
 
 apiVersion: "allocation.agones.dev/v1"
 kind: GameServerAllocation
+metadata:
+  name: xonotic
 spec:
   # GameServer selector from which to choose GameServers from.
   # GameServers still have the hard requirement to be `Ready` to be allocated from


### PR DESCRIPTION
Gameserverallocation fails to start with the following error

`error: error when retrieving current configuration of:
Resource: "allocation.agones.dev/v1, Resource=gameserverallocations", GroupVersionKind: "allocation.agones.dev/v1, Kind=GameServerAllocation"
Name: "", Namespace: "default"
from server for: "gameserverallocation.yaml": resource name may not be empty`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
hotfix

**What this PR does / Why we need it**:
Running the xonotic example, allocation fails with the above error.



