### PR TITLE
Return HTTP 201 on GameServerAllocation

### DIFF
--- a/pkg/gameserverallocations/controller_test.go
+++ b/pkg/gameserverallocations/controller_test.go
@@ -103,6 +103,7 @@ func TestControllerAllocator(t *testing.T) {
 			rec := httptest.NewRecorder()
 			err = c.processAllocationRequest(ctx, rec, r, "default")
 			assert.NoError(t, err)
+			assert.Equal(t, http.StatusCreated, rec.Code)
 			ret := &allocationv1.GameServerAllocation{}
 			err = json.Unmarshal(rec.Body.Bytes(), ret)
 			assert.NoError(t, err)

--- a/test/e2e/gameserverallocation_test.go
+++ b/test/e2e/gameserverallocation_test.go
@@ -49,7 +49,7 @@ func TestCreateFleetAndGameServerAllocate(t *testing.T) {
 			fleet := defaultFleet(framework.Namespace)
 			fleet.Spec.Scheduling = strategy
 			flt, err := fleets.Create(ctx, fleet, metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 			}
 
@@ -62,7 +62,7 @@ func TestCreateFleetAndGameServerAllocate(t *testing.T) {
 				}}
 
 			gsa, err = framework.AgonesClient.AllocationV1().GameServerAllocations(fleet.ObjectMeta.Namespace).Create(ctx, gsa, metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, string(allocationv1.GameServerAllocationAllocated), string(gsa.Status.State))
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

The standard for CRD creation is to return a HTTP 201 response. The Go client is more flexible and was happy with a 200 response, but the C# client will error out if anything but a 201 response.

This fixes things so we send the correct HTTP response code when creating a GameServerAllocation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2108

**Special notes for your reviewer**:

N/A
