### PR TITLE
Adds the Missing TCP protocol spec to the example fleet

### DIFF
--- a/examples/simple-game-server/fleet-tcp.yaml
+++ b/examples/simple-game-server/fleet-tcp.yaml
@@ -23,6 +23,7 @@ spec:
       ports:
       - name: default
         containerPort: 7654
+        protocol: TCP
       template:
         spec:
           containers:


### PR DESCRIPTION
**What type of PR is this?**


> /kind bug


**What this PR does / Why we need it**:
Adds the missing spec of ports.protocol to leet-tcp.yaml  

**Which issue(s) this PR fixes**:

Closes #2113 

**Special notes for your reviewer**:


