### PR TITLE
Update helm configuration to allow annotations to be added to service accounts

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -69,7 +69,7 @@ spec:
       {{- if .Values.agones.createPriorityClass }}
       priorityClassName: {{ .Values.agones.priorityClassName }}
       {{- end }}
-      serviceAccountName: {{ .Values.agones.serviceaccount.controller }}
+      serviceAccountName: {{ .Values.agones.serviceaccount.controller.name }}
       containers:
       - name: agones-controller
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ default .Values.agones.image.tag .Values.agones.image.controller.tag }}"
@@ -94,7 +94,7 @@ spec:
         - name: SIDECAR_MEMORY_LIMIT
           value: {{ .Values.agones.image.sdk.memoryLimit | quote }}
         - name: SDK_SERVICE_ACCOUNT
-          value: {{ .Values.agones.serviceaccount.sdk | quote }}
+          value: {{ .Values.agones.serviceaccount.sdk.name | quote }}
         - name: PROMETHEUS_EXPORTER
           value: {{ .Values.agones.metrics.prometheusEnabled | quote }}
         - name: STACKDRIVER_EXPORTER

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: agones-allocator
+  name: {{ $.Values.agones.serviceaccount.allocator.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     component: allocator
@@ -101,7 +101,7 @@ spec:
       tolerations:
 {{ toYaml .Values.agones.allocator.tolerations | indent 8 }}
       {{- end }}
-      serviceAccountName: agones-allocator
+      serviceAccountName: {{ $.Values.agones.serviceaccount.allocator.name }}
       volumes:
       - name: tls
         secret:
@@ -223,7 +223,10 @@ metadata:
     chart: {{ template "agones.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
-
+{{- if .Values.agones.serviceaccount.allocator.annotations }}
+  annotations:
+{{- toYaml .Values.agones.serviceaccount.allocator.annotations | nindent 4 }}
+{{- end }}
 ---
 # Bind the agones-allocator ServiceAccount to the agones-allocator ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -238,7 +241,7 @@ metadata:
     heritage: {{ $.Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: agones-allocator
+  name: {{ $.Values.agones.serviceaccount.allocator.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -16,20 +16,24 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.agones.serviceaccount.controller }}
+  name: {{ .Values.agones.serviceaccount.controller.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.agones.serviceaccount.controller.annotations }}
+  annotations:
+{{- toYaml .Values.agones.serviceaccount.controller.annotations | nindent 4 }}
+{{- end }}
 ---
 {{- end}}
 {{- if .Values.agones.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.agones.serviceaccount.controller }}
+  name: {{ .Values.agones.serviceaccount.controller.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
@@ -74,7 +78,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.agones.serviceaccount.controller }}-access
+  name: {{ .Values.agones.serviceaccount.controller.name }}-access
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
@@ -83,12 +87,12 @@ metadata:
     heritage: {{ .Release.Service }}
 subjects:
 - kind: User
-  name: system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.agones.serviceaccount.controller }}
+  name: system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.agones.serviceaccount.controller.name }}
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.agones.serviceaccount.controller }}
+  name: {{ .Values.agones.serviceaccount.controller.name }}
 ---
 #
 # RBACs for APIService
@@ -96,20 +100,20 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.agones.serviceaccount.controller }}:system:auth-delegator
+  name: {{ .Values.agones.serviceaccount.controller.name }}:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.agones.serviceaccount.controller }}
+    name: {{ .Values.agones.serviceaccount.controller.name }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.agones.serviceaccount.controller }}-auth-reader
+  name: {{ .Values.agones.serviceaccount.controller.name }}-auth-reader
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -117,6 +121,6 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.agones.serviceaccount.controller }}
+    name: {{ .Values.agones.serviceaccount.controller.name }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $.Values.agones.serviceaccount.sdk }}
+  name: {{ $.Values.agones.serviceaccount.sdk.name }}
   namespace: {{ . }}
   labels:
     app: {{ template "agones.name" $ }}
@@ -29,7 +29,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.agones.serviceaccount.sdk }}
+  name: {{ .Values.agones.serviceaccount.sdk.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
@@ -48,7 +48,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $.Values.agones.serviceaccount.sdk }}-access
+  name: {{ $.Values.agones.serviceaccount.sdk.name }}-access
   namespace: {{ . }}
   labels:
     app: {{ template "agones.name" $ }}
@@ -57,12 +57,12 @@ metadata:
     heritage: {{ $.Release.Service }}
 subjects:
 - kind: User
-  name: system:serviceaccount:{{ . }}:{{ $.Values.agones.serviceaccount.sdk }}
+  name: system:serviceaccount:{{ . }}:{{ $.Values.agones.serviceaccount.sdk.name }}
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ $.Values.agones.serviceaccount.sdk }}
+  name: {{ $.Values.agones.serviceaccount.sdk.name }}
 ---
   {{- end }}
 {{- end }}

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -30,8 +30,14 @@ agones:
     install: true
     cleanupOnDelete: true
   serviceaccount:
-    controller: agones-controller
-    sdk: agones-sdk
+    allocator:
+      name: agones-allocator
+      annotations: {}
+    controller:
+      name: agones-controller
+      annotations: {}
+    sdk:
+      name: agones-sdk
   createPriorityClass: true
   priorityClassName: agones-system
   controller:

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -94,8 +94,8 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.metrics.stackdriverEnabled`                 | Enables Stackdriver exporter of controller metrics                                              | `false`                |
 | `agones.metrics.stackdriverProjectID`               | This overrides the default gcp project id for use with stackdriver                              | \`\`                   |
 | `agones.metrics.stackdriverLabels`                  | A set of default labels to add to all stackdriver metrics generated in form of key value pair (`key=value,key2=value2`). By default metadata are automatically added using Kubernetes API and GCP metadata enpoint.                              | \`\` |
-| `agones.serviceaccount.controller`                  | Service account name for the controller                                                         | `agones-controller`    |
-| `agones.serviceaccount.sdk`                         | Service account name for the sdk                                                                | `agones-sdk`           |
+| `agones.serviceaccount.controller`                  | Service account name for the controller. **Note**: Will be replaced with `agones.serviceaccount.controller.name` in Agones 1.16 | `agones-controller`    |
+| `agones.serviceaccount.sdk`                         | Service account name for the sdk. **Note**: Will be replaced with `agones.serviceaccount.sdk.name` in Agones 1.16        | `agones-sdk`           |
 | `agones.image.registry`                             | Global image registry for all images                                                            | `gcr.io/agones-images` |
 | `agones.image.tag`                                  | Global image tag for all images                                                                 | `{{< release-version >}}` |
 | `agones.image.controller.name`                      | Image name for the controller                                                                   | `agones-controller`    |
@@ -184,6 +184,11 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
+| `agones.serviceaccount.controller.name`             | Service account name for the controller                                                         | `agones-controller`    |
+| `agones.serviceaccount.sdk.name`                    | Service account name for the sdk                                                                | `agones-sdk`           |
+| `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`    |
+| `agones.serviceaccount.allocator.annotations`       | [Annotations][annotations] added to the Agones allocator service account                        | `{}`                   |
+| `agones.serviceaccount.controller.annotations`      | [Annotations][annotations] added to the Agones controller service account                       | `{}`                   |
 |                       |                           |                            |
 {{% /feature %}}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>

/kind breaking

> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Adds helm configuration options and documentation to enable stackdriver on GKE clusters using workload identity. 

/cc @sisso

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2101

**Special notes for your reviewer**:

I moved around some of the helm parameters to what I thought made the most sense, but this is a breaking change for anyone that is relying on the old parameters that I've renamed. We should discuss whether we try to make this more backwards compatible. 

I also added a parameter for the allocator service account name, to make it consistent with the other service accounts that we create. 

I've tested this change with `helm install --namespace agones-system --create-namespace --set agones.image.tag=1.15.0 --set agones.serviceaccount.allocator.annotations."iam\.gke\.io/gcp-service-account"="workload-identity-test@robertbailey-agones\.iam\.gserviceaccount\.com" --set agones.serviceaccount.controller.annotations."iam\.gke\.io/gcp-service-account"="workload-identity-test@robertbailey-agones\.iam\.gserviceaccount\.com" --set agones.metrics.stackdriverEnabled=true --set agones.metrics.prometheusEnabled=false --set agones.metrics.prometheusServiceDiscovery=false agones ./install/helm/agones`
