### PR TITLE
Fix for failing export-openapi.sh on K8s 1.19

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -574,8 +574,10 @@ Compile the ping binary and then build the docker image
 #### `make gen-install`
 Generate the `/install/yaml/install.yaml` from the Helm template
 
-#### `gen-embedded-openapi`
-Generate the embedded OpenAPI specs for existing Kubernetes Objects, such as `PodTemplateSpec` and `ObjectMeta`
+#### `make gen-embedded-openapi`
+Generate the embedded OpenAPI specs for existing Kubernetes Objects, such as `PodTemplateSpec` and `ObjectMeta`.
+
+This should be run against a clean or brand new cluster, as external CRD's or schemas could cause errors to occur.
 
 #### `make gen-crd-client`
 Generate the Custom Resource Definition client(s)

--- a/build/export-openapi.sh
+++ b/build/export-openapi.sh
@@ -20,6 +20,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo
+echo "⚠ If you run into errors running this script, please remove anything you have installed in your cluster, or create a brand new cluster ⚠"
+echo
+
 do_expand() {
   echo "Processing $1"
   jq '.definitions."'"$1"'"' ./openapi.json >"$1.json"
@@ -53,7 +57,7 @@ chmod +x ./yq
 
 # cleanup and format
 curl http://127.0.0.1:8001/openapi/v2 | jq 'del(.. | .["x-kubernetes-patch-strategy"]?, .["x-kubernetes-patch-merge-key"]?, .["x-kubernetes-list-type"]?)' |
-  jq 'del(.. |  .["x-kubernetes-group-version-kind"]?, .["x-kubernetes-list-map-keys"]? )' >openapi.json
+  jq 'del(.. |  .["x-kubernetes-group-version-kind"]?, .["x-kubernetes-list-map-keys"]?, .["x-kubernetes-unions"]? )' >openapi.json
 do_expand "io.k8s.api.core.v1.PodTemplateSpec"
 
 # do any editing you need to do to any types here, before they are expanded.
@@ -61,6 +65,8 @@ do_expand "io.k8s.api.core.v1.PodTemplateSpec"
 jq '.properties.creationTimestamp.nullable = true' io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.json | sponge io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.json
 # Make IntOrString type have `x-kubernetes-int-or-string` member
 jq '.["x-kubernetes-int-or-string"] = true' io.k8s.apimachinery.pkg.util.intstr.IntOrString.json | jq 'del(.type)' | sponge io.k8s.apimachinery.pkg.util.intstr.IntOrString.json
+# This has a \\ in a description field that is being extra tricky to resolve, so let's just escape it here.
+sed -i 's/\\\\/\\\\\\\\/g' io.k8s.api.core.v1.PodSpec.json
 
 # easier debugging if something goes wrong, still have the original
 mkdir orig
@@ -74,7 +80,8 @@ for f in *.json; do
   # any "foo\nbar" values need their \n escaped
   # remove top and bottom line to get rid of first { and last } (we know all are formatted because jq)
   # then format for multiline - replace real multilines breaks with \n
-  contents=$(cat "$f" | jq 'del(.description)' | sed 's/\\n/\\\\n/g' | sed '$d' | sed '1d' | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/\$/\\$/g' | sed 's@\"@\\"@g')
+  # and escape bash and sed special characters, such as $ and &.
+  contents=$(cat "$f" | jq 'del(.description)' | sed 's/\\n/\\\\n/g' | sed '$d' | sed '1d' | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/\$/\\$/g' | sed 's/\&/\\&/g' | sed 's@\"@\\"@g')
   ref=$(basename "$f" .json)
 
   find -maxdepth 1 -name '*.json' | xargs sed -i 's@"$ref": "#/definitions/'"$ref"'"@'"$contents"'@g'

--- a/install/helm/agones/templates/crds/k8s/_io.k8s.api.core.v1.PodTemplateSpec.yaml
+++ b/install/helm/agones/templates/crds/k8s/_io.k8s.api.core.v1.PodTemplateSpec.yaml
@@ -101,7 +101,7 @@ properties:
         type: string
       namespace:
         description: |-
-          Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+          Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
 
           Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
         type: string
@@ -544,7 +544,7 @@ properties:
                             description: Specify whether the ConfigMap or its key must be defined
                             type: boolean
                       fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                         type: object
                         required:
                           - fieldPath
@@ -1003,6 +1003,21 @@ properties:
                     user:
                       description: User is a SELinux user label that applies to the container.
                       type: string
+                seccompProfile:
+                  description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    localhostProfile:
+                      description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                      type: string
+                    type:
+                      description: |-
+                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                      type: string
                 windowsOptions:
                   description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                   type: object
@@ -1239,7 +1254,7 @@ properties:
                             description: Specify whether the ConfigMap or its key must be defined
                             type: boolean
                       fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                         type: object
                         required:
                           - fieldPath
@@ -1698,6 +1713,21 @@ properties:
                     user:
                       description: User is a SELinux user label that applies to the container.
                       type: string
+                seccompProfile:
+                  description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    localhostProfile:
+                      description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                      type: string
+                    type:
+                      description: |-
+                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                      type: string
                 windowsOptions:
                   description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                   type: object
@@ -1941,7 +1971,7 @@ properties:
                             description: Specify whether the ConfigMap or its key must be defined
                             type: boolean
                       fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                         type: object
                         required:
                           - fieldPath
@@ -2400,6 +2430,21 @@ properties:
                     user:
                       description: User is a SELinux user label that applies to the container.
                       type: string
+                seccompProfile:
+                  description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    localhostProfile:
+                      description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                      type: string
+                    type:
+                      description: |-
+                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                      type: string
                 windowsOptions:
                   description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                   type: object
@@ -2567,7 +2612,7 @@ properties:
         additionalProperties:
           type: string
       preemptionPolicy:
-        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
         type: string
       priority:
         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -2639,6 +2684,21 @@ properties:
               user:
                 description: User is a SELinux user label that applies to the container.
                 type: string
+          seccompProfile:
+            description: The seccomp options to use by the containers in this pod.
+            type: object
+            required:
+              - type
+            properties:
+              localhostProfile:
+                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                type: string
+              type:
+                description: |-
+                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                type: string
           supplementalGroups:
             description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
             type: array
@@ -2679,6 +2739,9 @@ properties:
       serviceAccountName:
         description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
         type: string
+      setHostnameAsFQDN:
+        description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+        type: boolean
       shareProcessNamespace:
         description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
         type: boolean
@@ -2712,7 +2775,7 @@ properties:
               description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
               type: string
       topologySpreadConstraints:
-        description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
+        description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
         type: array
         items:
           type: object
@@ -2751,14 +2814,18 @@ properties:
                   additionalProperties:
                     type: string
             maxSkew:
-              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
               type: integer
               format: int32
             topologyKey:
               description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
               type: string
             whenUnsatisfiable:
-              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+              description: |-
+                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                  but giving higher precedence to topologies that would help reduce the
+                  skew.
+                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
               type: string
       volumes:
         description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -2885,7 +2952,7 @@ properties:
               type: object
               properties:
                 defaultMode:
-                  description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                   type: integer
                   format: int32
                 items:
@@ -2901,7 +2968,7 @@ properties:
                         description: The key to project.
                         type: string
                       mode:
-                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         type: integer
                         format: int32
                       path:
@@ -2914,7 +2981,7 @@ properties:
                   description: Specify whether the ConfigMap or its keys must be defined
                   type: boolean
             csi:
-              description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
+              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
               type: object
               required:
                 - driver
@@ -2945,7 +3012,7 @@ properties:
               type: object
               properties:
                 defaultMode:
-                  description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                  description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                   type: integer
                   format: int32
                 items:
@@ -2969,7 +3036,7 @@ properties:
                             description: Path of the field to select in the specified API version.
                             type: string
                       mode:
-                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                        description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         type: integer
                         format: int32
                       path:
@@ -3000,6 +3067,251 @@ properties:
                 sizeLimit:
                   description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                   type: string
+            ephemeral:
+              description: |-
+                Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                   tracking are needed,
+                c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                   information on the connection between this volume type
+                   and PersistentVolumeClaim).
+
+                Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+              type: object
+              properties:
+                readOnly:
+                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                  type: boolean
+                volumeClaimTemplate:
+                  description: |-
+                    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                    Required, must not be nil.
+                  type: object
+                  required:
+                    - spec
+                  properties:
+                    metadata:
+                      description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                      type: object
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                          additionalProperties:
+                            type: string
+                        clusterName:
+                          description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: |-
+                            CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+                            Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          type: string
+                          format: date-time
+                          nullable: true
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                          type: integer
+                          format: int64
+                        deletionTimestamp:
+                          description: |-
+                            DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+                            Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          type: string
+                          format: date-time
+                        finalizers:
+                          description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                          type: array
+                          items:
+                            type: string
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                          type: integer
+                          format: int64
+                        labels:
+                          description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                          additionalProperties:
+                            type: string
+                        managedFields:
+                          description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              apiVersion:
+                                description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                type: string
+                              fieldsType:
+                                description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                type: string
+                              fieldsV1:
+                                description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                type: object
+                              manager:
+                                description: Manager is an identifier of the workflow managing these fields.
+                                type: string
+                              operation:
+                                description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                type: string
+                              time:
+                                description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+                                type: string
+                                format: date-time
+                        name:
+                          description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - apiVersion
+                              - kind
+                              - name
+                              - uid
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: |-
+                            SelfLink is a URL representing this object. Populated by the system. Read-only.
+
+                            DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                      type: object
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          type: array
+                          items:
+                            type: string
+                        dataSource:
+                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                          type: object
+                          required:
+                            - kind
+                            - name
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                        resources:
+                          description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                          type: object
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                              additionalProperties:
+                                type: string
+                            requests:
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                              additionalProperties:
+                                type: string
+                        selector:
+                          description: A label query over volumes to consider for binding.
+                          type: object
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - key
+                                  - operator
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    type: array
+                                    items:
+                                      type: string
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                              additionalProperties:
+                                type: string
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                          type: string
             fc:
               description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
               type: object
@@ -3236,7 +3548,7 @@ properties:
                 - sources
               properties:
                 defaultMode:
-                  description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                   type: integer
                   format: int32
                 sources:
@@ -3262,7 +3574,7 @@ properties:
                                   description: The key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
@@ -3299,7 +3611,7 @@ properties:
                                       description: Path of the field to select in the specified API version.
                                       type: string
                                 mode:
-                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
@@ -3337,7 +3649,7 @@ properties:
                                   description: The key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
@@ -3474,7 +3786,7 @@ properties:
               type: object
               properties:
                 defaultMode:
-                  description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                   type: integer
                   format: int32
                 items:
@@ -3490,7 +3802,7 @@ properties:
                         description: The key to project.
                         type: string
                       mode:
-                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         type: integer
                         format: int32
                       path:

--- a/install/helm/agones/templates/crds/k8s/_io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.yaml
+++ b/install/helm/agones/templates/crds/k8s/_io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.yaml
@@ -97,7 +97,7 @@ properties:
     type: string
   namespace:
     description: |-
-      Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+      Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
 
       Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
     type: string

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -311,7 +311,7 @@ spec:
                          type: string
                        namespace:
                          description: |-
-                           Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                           Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
                      
                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                          type: string
@@ -454,7 +454,7 @@ spec:
                                  type: string
                                namespace:
                                  description: |-
-                                   Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                                   Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
                          
                                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                                  type: string
@@ -897,7 +897,7 @@ spec:
                                                      description: Specify whether the ConfigMap or its key must be defined
                                                      type: boolean
                                                fieldRef:
-                                                 description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                 description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                                  type: object
                                                  required:
                                                    - fieldPath
@@ -1356,6 +1356,21 @@ spec:
                                              user:
                                                description: User is a SELinux user label that applies to the container.
                                                type: string
+                                         seccompProfile:
+                                           description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                           type: object
+                                           required:
+                                             - type
+                                           properties:
+                                             localhostProfile:
+                                               description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                               type: string
+                                             type:
+                                               description: |-
+                                                 type indicates which kind of seccomp profile will be applied. Valid options are:
+                         
+                                                 Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                               type: string
                                          windowsOptions:
                                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                            type: object
@@ -1592,7 +1607,7 @@ spec:
                                                      description: Specify whether the ConfigMap or its key must be defined
                                                      type: boolean
                                                fieldRef:
-                                                 description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                 description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                                  type: object
                                                  required:
                                                    - fieldPath
@@ -2051,6 +2066,21 @@ spec:
                                              user:
                                                description: User is a SELinux user label that applies to the container.
                                                type: string
+                                         seccompProfile:
+                                           description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                           type: object
+                                           required:
+                                             - type
+                                           properties:
+                                             localhostProfile:
+                                               description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                               type: string
+                                             type:
+                                               description: |-
+                                                 type indicates which kind of seccomp profile will be applied. Valid options are:
+                         
+                                                 Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                               type: string
                                          windowsOptions:
                                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                            type: object
@@ -2294,7 +2324,7 @@ spec:
                                                      description: Specify whether the ConfigMap or its key must be defined
                                                      type: boolean
                                                fieldRef:
-                                                 description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                 description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                                  type: object
                                                  required:
                                                    - fieldPath
@@ -2753,6 +2783,21 @@ spec:
                                              user:
                                                description: User is a SELinux user label that applies to the container.
                                                type: string
+                                         seccompProfile:
+                                           description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                           type: object
+                                           required:
+                                             - type
+                                           properties:
+                                             localhostProfile:
+                                               description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                               type: string
+                                             type:
+                                               description: |-
+                                                 type indicates which kind of seccomp profile will be applied. Valid options are:
+                         
+                                                 Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                               type: string
                                          windowsOptions:
                                            description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                            type: object
@@ -2920,7 +2965,7 @@ spec:
                                  additionalProperties:
                                    type: string
                                preemptionPolicy:
-                                 description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+                                 description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
                                  type: string
                                priority:
                                  description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -2992,6 +3037,21 @@ spec:
                                        user:
                                          description: User is a SELinux user label that applies to the container.
                                          type: string
+                                   seccompProfile:
+                                     description: The seccomp options to use by the containers in this pod.
+                                     type: object
+                                     required:
+                                       - type
+                                     properties:
+                                       localhostProfile:
+                                         description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                         type: string
+                                       type:
+                                         description: |-
+                                           type indicates which kind of seccomp profile will be applied. Valid options are:
+                         
+                                           Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                         type: string
                                    supplementalGroups:
                                      description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                      type: array
@@ -3032,6 +3092,9 @@ spec:
                                serviceAccountName:
                                  description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                                  type: string
+                               setHostnameAsFQDN:
+                                 description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+                                 type: boolean
                                shareProcessNamespace:
                                  description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                                  type: boolean
@@ -3065,7 +3128,7 @@ spec:
                                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                        type: string
                                topologySpreadConstraints:
-                                 description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
+                                 description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
                                  type: array
                                  items:
                                    type: object
@@ -3104,14 +3167,18 @@ spec:
                                            additionalProperties:
                                              type: string
                                      maxSkew:
-                                       description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                       description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
                                        type: integer
                                        format: int32
                                      topologyKey:
                                        description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                        type: string
                                      whenUnsatisfiable:
-                                       description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                       description: |-
+                                         WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                           but giving higher precedence to topologies that would help reduce the
+                                           skew.
+                                         A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
                                        type: string
                                volumes:
                                  description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -3238,7 +3305,7 @@ spec:
                                        type: object
                                        properties:
                                          defaultMode:
-                                           description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                           description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                            type: integer
                                            format: int32
                                          items:
@@ -3254,7 +3321,7 @@ spec:
                                                  description: The key to project.
                                                  type: string
                                                mode:
-                                                 description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                 description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                  type: integer
                                                  format: int32
                                                path:
@@ -3267,7 +3334,7 @@ spec:
                                            description: Specify whether the ConfigMap or its keys must be defined
                                            type: boolean
                                      csi:
-                                       description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
+                                       description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                                        type: object
                                        required:
                                          - driver
@@ -3298,7 +3365,7 @@ spec:
                                        type: object
                                        properties:
                                          defaultMode:
-                                           description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                           description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                            type: integer
                                            format: int32
                                          items:
@@ -3322,7 +3389,7 @@ spec:
                                                      description: Path of the field to select in the specified API version.
                                                      type: string
                                                mode:
-                                                 description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                 description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                  type: integer
                                                  format: int32
                                                path:
@@ -3353,6 +3420,251 @@ spec:
                                          sizeLimit:
                                            description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                            type: string
+                                     ephemeral:
+                                       description: |-
+                                         Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+                         
+                                         Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                            tracking are needed,
+                                         c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                            a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                            information on the connection between this volume type
+                                            and PersistentVolumeClaim).
+                         
+                                         Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+                         
+                                         Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+                         
+                                         A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                                       type: object
+                                       properties:
+                                         readOnly:
+                                           description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                           type: boolean
+                                         volumeClaimTemplate:
+                                           description: |-
+                                             Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+                         
+                                             An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+                         
+                                             This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+                         
+                                             Required, must not be nil.
+                                           type: object
+                                           required:
+                                             - spec
+                                           properties:
+                                             metadata:
+                                               description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                               type: object
+                                               properties:
+                                                 annotations:
+                                                   description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                                   type: object
+                                                   additionalProperties:
+                                                     type: string
+                                                 clusterName:
+                                                   description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+                                                   type: string
+                                                 creationTimestamp:
+                                                   description: |-
+                                                     CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+                         
+                                                     Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                                   type: string
+                                                   format: date-time
+                                                   nullable: true
+                                                 deletionGracePeriodSeconds:
+                                                   description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                                   type: integer
+                                                   format: int64
+                                                 deletionTimestamp:
+                                                   description: |-
+                                                     DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+                         
+                                                     Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                                   type: string
+                                                   format: date-time
+                                                 finalizers:
+                                                   description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                                   type: array
+                                                   items:
+                                                     type: string
+                                                 generateName:
+                                                   description: |-
+                                                     GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                         
+                                                     If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                         
+                                                     Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                                   type: string
+                                                 generation:
+                                                   description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                                   type: integer
+                                                   format: int64
+                                                 labels:
+                                                   description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                                   type: object
+                                                   additionalProperties:
+                                                     type: string
+                                                 managedFields:
+                                                   description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                                   type: array
+                                                   items:
+                                                     type: object
+                                                     properties:
+                                                       apiVersion:
+                                                         description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                                         type: string
+                                                       fieldsType:
+                                                         description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                                         type: string
+                                                       fieldsV1:
+                                                         description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                                         type: object
+                                                       manager:
+                                                         description: Manager is an identifier of the workflow managing these fields.
+                                                         type: string
+                                                       operation:
+                                                         description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                                         type: string
+                                                       time:
+                                                         description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+                                                         type: string
+                                                         format: date-time
+                                                 name:
+                                                   description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                                   type: string
+                                                 namespace:
+                                                   description: |-
+                                                     Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                         
+                                                     Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                                   type: string
+                                                 ownerReferences:
+                                                   description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                                   type: array
+                                                   items:
+                                                     type: object
+                                                     required:
+                                                       - apiVersion
+                                                       - kind
+                                                       - name
+                                                       - uid
+                                                     properties:
+                                                       apiVersion:
+                                                         description: API version of the referent.
+                                                         type: string
+                                                       blockOwnerDeletion:
+                                                         description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                                         type: boolean
+                                                       controller:
+                                                         description: If true, this reference points to the managing controller.
+                                                         type: boolean
+                                                       kind:
+                                                         description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                                         type: string
+                                                       name:
+                                                         description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                                         type: string
+                                                       uid:
+                                                         description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                                         type: string
+                                                 resourceVersion:
+                                                   description: |-
+                                                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                         
+                                                     Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                                   type: string
+                                                 selfLink:
+                                                   description: |-
+                                                     SelfLink is a URL representing this object. Populated by the system. Read-only.
+                         
+                                                     DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                                                   type: string
+                                                 uid:
+                                                   description: |-
+                                                     UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                         
+                                                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                                   type: string
+                                             spec:
+                                               description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                               type: object
+                                               properties:
+                                                 accessModes:
+                                                   description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                   type: array
+                                                   items:
+                                                     type: string
+                                                 dataSource:
+                                                   description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                                                   type: object
+                                                   required:
+                                                     - kind
+                                                     - name
+                                                   properties:
+                                                     apiGroup:
+                                                       description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                       type: string
+                                                     kind:
+                                                       description: Kind is the type of resource being referenced
+                                                       type: string
+                                                     name:
+                                                       description: Name is the name of resource being referenced
+                                                       type: string
+                                                 resources:
+                                                   description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                   type: object
+                                                   properties:
+                                                     limits:
+                                                       description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                       type: object
+                                                       additionalProperties:
+                                                         type: string
+                                                     requests:
+                                                       description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                       type: object
+                                                       additionalProperties:
+                                                         type: string
+                                                 selector:
+                                                   description: A label query over volumes to consider for binding.
+                                                   type: object
+                                                   properties:
+                                                     matchExpressions:
+                                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                       type: array
+                                                       items:
+                                                         type: object
+                                                         required:
+                                                           - key
+                                                           - operator
+                                                         properties:
+                                                           key:
+                                                             description: key is the label key that the selector applies to.
+                                                             type: string
+                                                           operator:
+                                                             description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                             type: string
+                                                           values:
+                                                             description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                             type: array
+                                                             items:
+                                                               type: string
+                                                     matchLabels:
+                                                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                       type: object
+                                                       additionalProperties:
+                                                         type: string
+                                                 storageClassName:
+                                                   description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                   type: string
+                                                 volumeMode:
+                                                   description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                                   type: string
+                                                 volumeName:
+                                                   description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                                   type: string
                                      fc:
                                        description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                        type: object
@@ -3589,7 +3901,7 @@ spec:
                                          - sources
                                        properties:
                                          defaultMode:
-                                           description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                           description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                            type: integer
                                            format: int32
                                          sources:
@@ -3615,7 +3927,7 @@ spec:
                                                            description: The key to project.
                                                            type: string
                                                          mode:
-                                                           description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                           description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                            type: integer
                                                            format: int32
                                                          path:
@@ -3652,7 +3964,7 @@ spec:
                                                                description: Path of the field to select in the specified API version.
                                                                type: string
                                                          mode:
-                                                           description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                           description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                            type: integer
                                                            format: int32
                                                          path:
@@ -3690,7 +4002,7 @@ spec:
                                                            description: The key to project.
                                                            type: string
                                                          mode:
-                                                           description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                           description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                            type: integer
                                                            format: int32
                                                          path:
@@ -3827,7 +4139,7 @@ spec:
                                        type: object
                                        properties:
                                          defaultMode:
-                                           description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                           description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                            type: integer
                                            format: int32
                                          items:
@@ -3843,7 +4155,7 @@ spec:
                                                  description: The key to project.
                                                  type: string
                                                mode:
-                                                 description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                 description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                  type: integer
                                                  format: int32
                                                path:
@@ -4325,7 +4637,7 @@ spec:
                          type: string
                        namespace:
                          description: |-
-                           Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                           Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
                  
                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                          type: string
@@ -4768,7 +5080,7 @@ spec:
                                              description: Specify whether the ConfigMap or its key must be defined
                                              type: boolean
                                        fieldRef:
-                                         description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                         description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                          type: object
                                          required:
                                            - fieldPath
@@ -5227,6 +5539,21 @@ spec:
                                      user:
                                        description: User is a SELinux user label that applies to the container.
                                        type: string
+                                 seccompProfile:
+                                   description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                   type: object
+                                   required:
+                                     - type
+                                   properties:
+                                     localhostProfile:
+                                       description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                       type: string
+                                     type:
+                                       description: |-
+                                         type indicates which kind of seccomp profile will be applied. Valid options are:
+                 
+                                         Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                       type: string
                                  windowsOptions:
                                    description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                    type: object
@@ -5463,7 +5790,7 @@ spec:
                                              description: Specify whether the ConfigMap or its key must be defined
                                              type: boolean
                                        fieldRef:
-                                         description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                         description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                          type: object
                                          required:
                                            - fieldPath
@@ -5922,6 +6249,21 @@ spec:
                                      user:
                                        description: User is a SELinux user label that applies to the container.
                                        type: string
+                                 seccompProfile:
+                                   description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                   type: object
+                                   required:
+                                     - type
+                                   properties:
+                                     localhostProfile:
+                                       description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                       type: string
+                                     type:
+                                       description: |-
+                                         type indicates which kind of seccomp profile will be applied. Valid options are:
+                 
+                                         Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                       type: string
                                  windowsOptions:
                                    description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                    type: object
@@ -6165,7 +6507,7 @@ spec:
                                              description: Specify whether the ConfigMap or its key must be defined
                                              type: boolean
                                        fieldRef:
-                                         description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                         description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                          type: object
                                          required:
                                            - fieldPath
@@ -6624,6 +6966,21 @@ spec:
                                      user:
                                        description: User is a SELinux user label that applies to the container.
                                        type: string
+                                 seccompProfile:
+                                   description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                   type: object
+                                   required:
+                                     - type
+                                   properties:
+                                     localhostProfile:
+                                       description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                       type: string
+                                     type:
+                                       description: |-
+                                         type indicates which kind of seccomp profile will be applied. Valid options are:
+                 
+                                         Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                       type: string
                                  windowsOptions:
                                    description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                    type: object
@@ -6791,7 +7148,7 @@ spec:
                          additionalProperties:
                            type: string
                        preemptionPolicy:
-                         description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+                         description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
                          type: string
                        priority:
                          description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -6863,6 +7220,21 @@ spec:
                                user:
                                  description: User is a SELinux user label that applies to the container.
                                  type: string
+                           seccompProfile:
+                             description: The seccomp options to use by the containers in this pod.
+                             type: object
+                             required:
+                               - type
+                             properties:
+                               localhostProfile:
+                                 description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                 type: string
+                               type:
+                                 description: |-
+                                   type indicates which kind of seccomp profile will be applied. Valid options are:
+                 
+                                   Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                 type: string
                            supplementalGroups:
                              description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                              type: array
@@ -6903,6 +7275,9 @@ spec:
                        serviceAccountName:
                          description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                          type: string
+                       setHostnameAsFQDN:
+                         description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+                         type: boolean
                        shareProcessNamespace:
                          description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                          type: boolean
@@ -6936,7 +7311,7 @@ spec:
                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                type: string
                        topologySpreadConstraints:
-                         description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
+                         description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
                          type: array
                          items:
                            type: object
@@ -6975,14 +7350,18 @@ spec:
                                    additionalProperties:
                                      type: string
                              maxSkew:
-                               description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                               description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
                                type: integer
                                format: int32
                              topologyKey:
                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                type: string
                              whenUnsatisfiable:
-                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                               description: |-
+                                 WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                   but giving higher precedence to topologies that would help reduce the
+                                   skew.
+                                 A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
                                type: string
                        volumes:
                          description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -7109,7 +7488,7 @@ spec:
                                type: object
                                properties:
                                  defaultMode:
-                                   description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                   description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                    type: integer
                                    format: int32
                                  items:
@@ -7125,7 +7504,7 @@ spec:
                                          description: The key to project.
                                          type: string
                                        mode:
-                                         description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                         description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                          type: integer
                                          format: int32
                                        path:
@@ -7138,7 +7517,7 @@ spec:
                                    description: Specify whether the ConfigMap or its keys must be defined
                                    type: boolean
                              csi:
-                               description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
+                               description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                                type: object
                                required:
                                  - driver
@@ -7169,7 +7548,7 @@ spec:
                                type: object
                                properties:
                                  defaultMode:
-                                   description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                    type: integer
                                    format: int32
                                  items:
@@ -7193,7 +7572,7 @@ spec:
                                              description: Path of the field to select in the specified API version.
                                              type: string
                                        mode:
-                                         description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                         description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                          type: integer
                                          format: int32
                                        path:
@@ -7224,6 +7603,251 @@ spec:
                                  sizeLimit:
                                    description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                    type: string
+                             ephemeral:
+                               description: |-
+                                 Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+                 
+                                 Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                    tracking are needed,
+                                 c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                    a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                    information on the connection between this volume type
+                                    and PersistentVolumeClaim).
+                 
+                                 Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+                 
+                                 Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+                 
+                                 A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                               type: object
+                               properties:
+                                 readOnly:
+                                   description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                   type: boolean
+                                 volumeClaimTemplate:
+                                   description: |-
+                                     Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+                 
+                                     An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+                 
+                                     This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+                 
+                                     Required, must not be nil.
+                                   type: object
+                                   required:
+                                     - spec
+                                   properties:
+                                     metadata:
+                                       description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                       type: object
+                                       properties:
+                                         annotations:
+                                           description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                           type: object
+                                           additionalProperties:
+                                             type: string
+                                         clusterName:
+                                           description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+                                           type: string
+                                         creationTimestamp:
+                                           description: |-
+                                             CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+                 
+                                             Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                           type: string
+                                           format: date-time
+                                           nullable: true
+                                         deletionGracePeriodSeconds:
+                                           description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                           type: integer
+                                           format: int64
+                                         deletionTimestamp:
+                                           description: |-
+                                             DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+                 
+                                             Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                           type: string
+                                           format: date-time
+                                         finalizers:
+                                           description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                           type: array
+                                           items:
+                                             type: string
+                                         generateName:
+                                           description: |-
+                                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                 
+                                             If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                 
+                                             Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                           type: string
+                                         generation:
+                                           description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                           type: integer
+                                           format: int64
+                                         labels:
+                                           description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                           type: object
+                                           additionalProperties:
+                                             type: string
+                                         managedFields:
+                                           description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                           type: array
+                                           items:
+                                             type: object
+                                             properties:
+                                               apiVersion:
+                                                 description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                                 type: string
+                                               fieldsType:
+                                                 description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                                 type: string
+                                               fieldsV1:
+                                                 description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                                 type: object
+                                               manager:
+                                                 description: Manager is an identifier of the workflow managing these fields.
+                                                 type: string
+                                               operation:
+                                                 description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                                 type: string
+                                               time:
+                                                 description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+                                                 type: string
+                                                 format: date-time
+                                         name:
+                                           description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                           type: string
+                                         namespace:
+                                           description: |-
+                                             Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                 
+                                             Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                           type: string
+                                         ownerReferences:
+                                           description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                           type: array
+                                           items:
+                                             type: object
+                                             required:
+                                               - apiVersion
+                                               - kind
+                                               - name
+                                               - uid
+                                             properties:
+                                               apiVersion:
+                                                 description: API version of the referent.
+                                                 type: string
+                                               blockOwnerDeletion:
+                                                 description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                                 type: boolean
+                                               controller:
+                                                 description: If true, this reference points to the managing controller.
+                                                 type: boolean
+                                               kind:
+                                                 description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                                 type: string
+                                               name:
+                                                 description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                                 type: string
+                                               uid:
+                                                 description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                                 type: string
+                                         resourceVersion:
+                                           description: |-
+                                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                 
+                                             Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                           type: string
+                                         selfLink:
+                                           description: |-
+                                             SelfLink is a URL representing this object. Populated by the system. Read-only.
+                 
+                                             DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                                           type: string
+                                         uid:
+                                           description: |-
+                                             UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                 
+                                             Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                           type: string
+                                     spec:
+                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                       type: object
+                                       properties:
+                                         accessModes:
+                                           description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                           type: array
+                                           items:
+                                             type: string
+                                         dataSource:
+                                           description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                                           type: object
+                                           required:
+                                             - kind
+                                             - name
+                                           properties:
+                                             apiGroup:
+                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                               type: string
+                                             kind:
+                                               description: Kind is the type of resource being referenced
+                                               type: string
+                                             name:
+                                               description: Name is the name of resource being referenced
+                                               type: string
+                                         resources:
+                                           description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                           type: object
+                                           properties:
+                                             limits:
+                                               description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                               type: object
+                                               additionalProperties:
+                                                 type: string
+                                             requests:
+                                               description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                               type: object
+                                               additionalProperties:
+                                                 type: string
+                                         selector:
+                                           description: A label query over volumes to consider for binding.
+                                           type: object
+                                           properties:
+                                             matchExpressions:
+                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                               type: array
+                                               items:
+                                                 type: object
+                                                 required:
+                                                   - key
+                                                   - operator
+                                                 properties:
+                                                   key:
+                                                     description: key is the label key that the selector applies to.
+                                                     type: string
+                                                   operator:
+                                                     description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                     type: string
+                                                   values:
+                                                     description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                     type: array
+                                                     items:
+                                                       type: string
+                                             matchLabels:
+                                               description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                               type: object
+                                               additionalProperties:
+                                                 type: string
+                                         storageClassName:
+                                           description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                           type: string
+                                         volumeMode:
+                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                           type: string
+                                         volumeName:
+                                           description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                           type: string
                              fc:
                                description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                type: object
@@ -7460,7 +8084,7 @@ spec:
                                  - sources
                                properties:
                                  defaultMode:
-                                   description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                   description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                    type: integer
                                    format: int32
                                  sources:
@@ -7486,7 +8110,7 @@ spec:
                                                    description: The key to project.
                                                    type: string
                                                  mode:
-                                                   description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                   description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                    type: integer
                                                    format: int32
                                                  path:
@@ -7523,7 +8147,7 @@ spec:
                                                        description: Path of the field to select in the specified API version.
                                                        type: string
                                                  mode:
-                                                   description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                   description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                    type: integer
                                                    format: int32
                                                  path:
@@ -7561,7 +8185,7 @@ spec:
                                                    description: The key to project.
                                                    type: string
                                                  mode:
-                                                   description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                   description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                    type: integer
                                                    format: int32
                                                  path:
@@ -7698,7 +8322,7 @@ spec:
                                type: object
                                properties:
                                  defaultMode:
-                                   description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                   description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                    type: integer
                                    format: int32
                                  items:
@@ -7714,7 +8338,7 @@ spec:
                                          description: The key to project.
                                          type: string
                                        mode:
-                                         description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                         description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                          type: integer
                                          format: int32
                                        path:
@@ -8174,7 +8798,7 @@ spec:
                           type: string
                         namespace:
                           description: |-
-                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                            Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
                       
                             Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                           type: string
@@ -8317,7 +8941,7 @@ spec:
                                   type: string
                                 namespace:
                                   description: |-
-                                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                                    Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
                           
                                     Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                                   type: string
@@ -8760,7 +9384,7 @@ spec:
                                                       description: Specify whether the ConfigMap or its key must be defined
                                                       type: boolean
                                                 fieldRef:
-                                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                                   type: object
                                                   required:
                                                     - fieldPath
@@ -9219,6 +9843,21 @@ spec:
                                               user:
                                                 description: User is a SELinux user label that applies to the container.
                                                 type: string
+                                          seccompProfile:
+                                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                            type: object
+                                            required:
+                                              - type
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: |-
+                                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+                          
+                                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                                type: string
                                           windowsOptions:
                                             description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: object
@@ -9455,7 +10094,7 @@ spec:
                                                       description: Specify whether the ConfigMap or its key must be defined
                                                       type: boolean
                                                 fieldRef:
-                                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                                   type: object
                                                   required:
                                                     - fieldPath
@@ -9914,6 +10553,21 @@ spec:
                                               user:
                                                 description: User is a SELinux user label that applies to the container.
                                                 type: string
+                                          seccompProfile:
+                                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                            type: object
+                                            required:
+                                              - type
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: |-
+                                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+                          
+                                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                                type: string
                                           windowsOptions:
                                             description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: object
@@ -10157,7 +10811,7 @@ spec:
                                                       description: Specify whether the ConfigMap or its key must be defined
                                                       type: boolean
                                                 fieldRef:
-                                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                                   type: object
                                                   required:
                                                     - fieldPath
@@ -10616,6 +11270,21 @@ spec:
                                               user:
                                                 description: User is a SELinux user label that applies to the container.
                                                 type: string
+                                          seccompProfile:
+                                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                            type: object
+                                            required:
+                                              - type
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: |-
+                                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+                          
+                                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                                type: string
                                           windowsOptions:
                                             description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: object
@@ -10783,7 +11452,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                 preemptionPolicy:
-                                  description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+                                  description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
                                   type: string
                                 priority:
                                   description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -10855,6 +11524,21 @@ spec:
                                         user:
                                           description: User is a SELinux user label that applies to the container.
                                           type: string
+                                    seccompProfile:
+                                      description: The seccomp options to use by the containers in this pod.
+                                      type: object
+                                      required:
+                                        - type
+                                      properties:
+                                        localhostProfile:
+                                          description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied. Valid options are:
+                          
+                                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                          type: string
                                     supplementalGroups:
                                       description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                       type: array
@@ -10895,6 +11579,9 @@ spec:
                                 serviceAccountName:
                                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                                   type: string
+                                setHostnameAsFQDN:
+                                  description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+                                  type: boolean
                                 shareProcessNamespace:
                                   description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                                   type: boolean
@@ -10928,7 +11615,7 @@ spec:
                                         description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                         type: string
                                 topologySpreadConstraints:
-                                  description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
+                                  description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
                                   type: array
                                   items:
                                     type: object
@@ -10967,14 +11654,18 @@ spec:
                                             additionalProperties:
                                               type: string
                                       maxSkew:
-                                        description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                        description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
                                         type: integer
                                         format: int32
                                       topologyKey:
                                         description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                         type: string
                                       whenUnsatisfiable:
-                                        description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                        description: |-
+                                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                            but giving higher precedence to topologies that would help reduce the
+                                            skew.
+                                          A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
                                         type: string
                                 volumes:
                                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -11101,7 +11792,7 @@ spec:
                                         type: object
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           items:
@@ -11117,7 +11808,7 @@ spec:
                                                   description: The key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   type: integer
                                                   format: int32
                                                 path:
@@ -11130,7 +11821,7 @@ spec:
                                             description: Specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                       csi:
-                                        description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
+                                        description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                                         type: object
                                         required:
                                           - driver
@@ -11161,7 +11852,7 @@ spec:
                                         type: object
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           items:
@@ -11185,7 +11876,7 @@ spec:
                                                       description: Path of the field to select in the specified API version.
                                                       type: string
                                                 mode:
-                                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   type: integer
                                                   format: int32
                                                 path:
@@ -11216,6 +11907,251 @@ spec:
                                           sizeLimit:
                                             description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                             type: string
+                                      ephemeral:
+                                        description: |-
+                                          Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+                          
+                                          Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                             tracking are needed,
+                                          c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                             a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                             information on the connection between this volume type
+                                             and PersistentVolumeClaim).
+                          
+                                          Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+                          
+                                          Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+                          
+                                          A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                                        type: object
+                                        properties:
+                                          readOnly:
+                                            description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                            type: boolean
+                                          volumeClaimTemplate:
+                                            description: |-
+                                              Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+                          
+                                              An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+                          
+                                              This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+                          
+                                              Required, must not be nil.
+                                            type: object
+                                            required:
+                                              - spec
+                                            properties:
+                                              metadata:
+                                                description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                                    type: object
+                                                    additionalProperties:
+                                                      type: string
+                                                  clusterName:
+                                                    description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+                                                    type: string
+                                                  creationTimestamp:
+                                                    description: |-
+                                                      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+                          
+                                                      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                                    type: string
+                                                    format: date-time
+                                                    nullable: true
+                                                  deletionGracePeriodSeconds:
+                                                    description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                                    type: integer
+                                                    format: int64
+                                                  deletionTimestamp:
+                                                    description: |-
+                                                      DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+                          
+                                                      Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                                    type: string
+                                                    format: date-time
+                                                  finalizers:
+                                                    description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  generateName:
+                                                    description: |-
+                                                      GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                          
+                                                      If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                          
+                                                      Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                                    type: string
+                                                  generation:
+                                                    description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                                    type: integer
+                                                    format: int64
+                                                  labels:
+                                                    description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                                    type: object
+                                                    additionalProperties:
+                                                      type: string
+                                                  managedFields:
+                                                    description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      properties:
+                                                        apiVersion:
+                                                          description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                                          type: string
+                                                        fieldsType:
+                                                          description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                                          type: string
+                                                        fieldsV1:
+                                                          description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                                          type: object
+                                                        manager:
+                                                          description: Manager is an identifier of the workflow managing these fields.
+                                                          type: string
+                                                        operation:
+                                                          description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                                          type: string
+                                                        time:
+                                                          description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+                                                          type: string
+                                                          format: date-time
+                                                  name:
+                                                    description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                                    type: string
+                                                  namespace:
+                                                    description: |-
+                                                      Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                          
+                                                      Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                                    type: string
+                                                  ownerReferences:
+                                                    description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                        - apiVersion
+                                                        - kind
+                                                        - name
+                                                        - uid
+                                                      properties:
+                                                        apiVersion:
+                                                          description: API version of the referent.
+                                                          type: string
+                                                        blockOwnerDeletion:
+                                                          description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                                          type: boolean
+                                                        controller:
+                                                          description: If true, this reference points to the managing controller.
+                                                          type: boolean
+                                                        kind:
+                                                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                                          type: string
+                                                        uid:
+                                                          description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                                          type: string
+                                                  resourceVersion:
+                                                    description: |-
+                                                      An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                          
+                                                      Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                                    type: string
+                                                  selfLink:
+                                                    description: |-
+                                                      SelfLink is a URL representing this object. Populated by the system. Read-only.
+                          
+                                                      DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                                                    type: string
+                                                  uid:
+                                                    description: |-
+                                                      UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                          
+                                                      Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                                    type: string
+                                              spec:
+                                                description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                                type: object
+                                                properties:
+                                                  accessModes:
+                                                    description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  dataSource:
+                                                    description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                                                    type: object
+                                                    required:
+                                                      - kind
+                                                      - name
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name of resource being referenced
+                                                        type: string
+                                                  resources:
+                                                    description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                    type: object
+                                                    properties:
+                                                      limits:
+                                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                      requests:
+                                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  selector:
+                                                    description: A label query over volumes to consider for binding.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  storageClassName:
+                                                    description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                    type: string
+                                                  volumeMode:
+                                                    description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                                    type: string
+                                                  volumeName:
+                                                    description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                                    type: string
                                       fc:
                                         description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                         type: object
@@ -11452,7 +12388,7 @@ spec:
                                           - sources
                                         properties:
                                           defaultMode:
-                                            description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                            description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                             type: integer
                                             format: int32
                                           sources:
@@ -11478,7 +12414,7 @@ spec:
                                                             description: The key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                             type: integer
                                                             format: int32
                                                           path:
@@ -11515,7 +12451,7 @@ spec:
                                                                 description: Path of the field to select in the specified API version.
                                                                 type: string
                                                           mode:
-                                                            description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                             type: integer
                                                             format: int32
                                                           path:
@@ -11553,7 +12489,7 @@ spec:
                                                             description: The key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                             type: integer
                                                             format: int32
                                                           path:
@@ -11690,7 +12626,7 @@ spec:
                                         type: object
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           items:
@@ -11706,7 +12642,7 @@ spec:
                                                   description: The key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   type: integer
                                                   format: int32
                                                 path:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Some new documentation in 1.19 meant that there was some extra work to be done to escape certain strings properly.

This does that, and also provides the updated output for `PodTemplateSpec` and `ObjectMeta`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #2129
Fixes #2159

**Special notes for your reviewer**:


