### PR TITLE
Fix sidecar tag in different make targets

### DIFF
--- a/build/includes/build-image.mk
+++ b/build/includes/build-image.mk
@@ -66,4 +66,4 @@ pull-remote-build-image:
 	-docker pull $(REMOTE_TAG) && docker tag $(REMOTE_TAG) $(LOCAL_TAG)
 
 ensure-agones-sdk-image:
-	$(MAKE) ensure-image IMAGE_TAG=$(sidecar_tag) BUILD_TARGET=build-agones-sdk-server-image
+	$(MAKE) ensure-image IMAGE_TAG=$(sidecar_linux_amd64_tag) BUILD_TARGET=build-agones-sdk-server-image

--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -46,7 +46,7 @@ kind-install:
 
 # pushes the current dev version of agones to the kind single node cluster.
 kind-push:
-	kind load docker-image $(sidecar_tag) --name="$(KIND_PROFILE)"
+	kind load docker-image $(sidecar_linux_amd64_tag) --name="$(KIND_PROFILE)"
 	kind load docker-image $(controller_tag) --name="$(KIND_PROFILE)"
 	kind load docker-image $(ping_tag) --name="$(KIND_PROFILE)"
 	kind load docker-image $(allocator_tag) --name="$(KIND_PROFILE)"

--- a/build/includes/minikube.mk
+++ b/build/includes/minikube.mk
@@ -38,7 +38,7 @@ minikube-shell: $(ensure-build-image)
 # Push the local Agones Docker images that have already been built
 # via `make build` or `make build-images` into the "agones" minikube instance.
 minikube-push:
-	$(MINIKUBE) cache add $(sidecar_tag)
+	$(MINIKUBE) cache add $(sidecar_linux_amd64_tag)
 	$(MINIKUBE) cache add $(controller_tag)
 	$(MINIKUBE) cache add $(ping_tag)
 	$(MINIKUBE) cache add $(allocator_tag)

--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -129,7 +129,7 @@ run-sdk-conformance-local: TESTS ?= ready,allocate,setlabel,setannotation,gamese
 run-sdk-conformance-local: FEATURE_GATES ?=
 run-sdk-conformance-local: ensure-agones-sdk-image
 	docker run -e "ADDRESS=" -p 9357:9357 -p 9358:9358 \
-	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" -e "FEATURE_GATES=$(FEATURE_GATES)" $(sidecar_tag)
+	 -e "TEST=$(TESTS)" -e "TIMEOUT=$(TIMEOUT)" -e "FEATURE_GATES=$(FEATURE_GATES)" $(sidecar_linux_amd64_tag)
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
 # Sleeps the start of the sidecar to test that the SDK blocks on connection correctly
@@ -144,7 +144,7 @@ run-sdk-conformance-no-build: ensure-agones-sdk-image
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	DOCKER_RUN_ARGS="--net host -e AGONES_SDK_GRPC_PORT=$(GRPC_PORT) -e AGONES_SDK_HTTP_PORT=$(HTTP_PORT) -e FEATURE_GATES=$(FEATURE_GATES) $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \
 	docker run -p $(GRPC_PORT):$(GRPC_PORT) -p $(HTTP_PORT):$(HTTP_PORT) -e "FEATURE_GATES=$(FEATURE_GATES)" -e "ADDRESS=" -e "TEST=$(TESTS)" -e "SDK_NAME=$(SDK_FOLDER)" -e "TIMEOUT=$(TIMEOUT)" -e "DELAY=$(DELAY)" \
-	--net=host $(sidecar_tag) --grpc-port $(GRPC_PORT) --http-port $(HTTP_PORT)
+	--net=host $(sidecar_linux_amd64_tag) --grpc-port $(GRPC_PORT) --http-port $(HTTP_PORT)
 
 # Run SDK conformance test for a specific SDK_FOLDER
 run-sdk-conformance-test: ensure-agones-sdk-image


### PR DESCRIPTION
If WITH_WINDOWS set to 1, then next make targets will be broken.
 `make build-images && make kind-push` cannot find the tag on the main branch:
 ```bash
 make kind-push
kind load docker-image gcr.io/agones-images/agones-sdk:1.16.0-0624928 --name="agones"
ERROR: image: "gcr.io/agones-images/agones-sdk:1.16.0-0624928" not present locally
make: *** [includes/kind.mk:49: kind-push] Error 1
 ```
This PR is to reflect the change in `make build-images` namely sidecar image tag.

Well another way round would be to do `make WITH_WINDOWS=0 build-images` #2037 . But I think that ensure-sdk-image should be consistent with new tag used.