### PR TITLE
Allow disabling of all allocator secrets in helm chart

### DIFF
--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -250,6 +250,7 @@ roleRef:
 
 {{- end }}
 
+{{- if not .Values.agones.allocator.disableSecretCreation }}
 ---
 # Allocation CA
 {{- $selfSigned := genSelfSignedCert "" nil nil 3650 }}
@@ -334,5 +335,6 @@ metadata:
 data:
   tls.crt: {{ b64enc $selfSigned.Cert }}
   tls.key: {{ b64enc $selfSigned.Key }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -153,6 +153,7 @@ agones:
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
       annotations: {}
+    disableSecretCreation: false
     generateTLS: true
     generateClientTLS: true
     disableMTLS: false

--- a/site/content/en/docs/Advanced/allocator-service.md
+++ b/site/content/en/docs/Advanced/allocator-service.md
@@ -101,6 +101,12 @@ echo $TLS_CA_VALUE | base64 -d > ca.crt
 # echo $TLS_CA_VALUE | base64 -D > ca.crt
 ```
 
+{{% feature publishVersion="0.16.0" %}}
+### Bring Your Own Certificates (advanced)
+
+If you would like to completely manage the tls secrets outside of helm, you can create them in the namespace where agones is going to be installed, and then set the helm value `agones.allocator.disableSecretCreation` to `true`. This method will also work with the cert-manager method, as long as your certificate and secret are created ahead of time, and you populate the `allocator-tls-ca` and `allocator-client-ca` yourself.
+{{% /feature %}}
+
 ## Client Certificate
 
 Because agones-allocator uses an mTLS authentication mechanism, a client must provide a certificate that is accepted by the server.

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -189,6 +189,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`    |
 | `agones.serviceaccount.allocator.annotations`       | [Annotations][annotations] added to the Agones allocator service account                        | `{}`                   |
 | `agones.serviceaccount.controller.annotations`      | [Annotations][annotations] added to the Agones controller service account                       | `{}`                   |
+| `agones.allocator.disableSecretCreation`            | Disables the creation of any allocator secrets. If true, you MUST provide the `allocator-tls`, `allocator-tls-ca`, and `allocator-client-ca` secrets before installation. | `false` |
 |                       |                           |                            |
 {{% /feature %}}
 
@@ -252,7 +253,7 @@ Error: 1 test(s) failed
 That means that you skipped the `--cleanup` flag and you should either delete the `agones-test` pod manually or run with the same test `helm test my-release --cleanup` two more times.
 {{< /alert >}}
 
-## TLS Certificates
+## Controller TLS Certificates
 
 By default agones chart generates tls certificates used by the admission controller, while this is handy, it requires the agones controller to restart on each `helm upgrade` command.
 For most use cases the controller would have required a restart anyway (eg: controller image updated). However if you really need to avoid restarts we suggest that you turn off tls automatic generation (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -173,22 +173,22 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.allocator.annotations`                      | [Annotations][annotations] added to the Agones allocator pods                                   | `{}`                   |
 | `agones.allocator.resources`                        | Allocator pods [resource requests/limit][resources]                                             | `{}`                   |
 | `agones.allocator.nodeSelector`                     | Allocator [node labels][nodeSelector] for pod assignment                                        | `{}`                   |
+| `agones.serviceaccount.controller.name`             | Service account name for the controller                                                         | `agones-controller`    |
+| `agones.serviceaccount.sdk.name`                    | Service account name for the sdk                                                                | `agones-sdk`           |
+| `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`    |
+| `agones.serviceaccount.allocator.annotations`       | [Annotations][annotations] added to the Agones allocator service account                        | `{}`                   |
+| `agones.serviceaccount.controller.annotations`      | [Annotations][annotations] added to the Agones controller service account                       | `{}`                   |
 | `gameservers.namespaces`                            | a list of namespaces you are planning to use to deploy game servers                             | `["default"]`          |
 | `gameservers.minPort`                               | Minimum port to use for dynamic port allocation                                                 | `7000`                 |
 | `gameservers.maxPort`                               | Maximum port to use for dynamic port allocation                                                 | `8000`                 |
 | `gameservers.podPreserveUnknownFields`              | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition | `false`                |
 | `helm.installTests`                                 | Add an ability to run `helm test agones` to verify the installation                             | `8000`                 |
 
-{{% feature publishVersion="1.15.0" %}}
+{{% feature publishVersion="1.16.0" %}}
 **New Configuration Features:**
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
-| `agones.serviceaccount.controller.name`             | Service account name for the controller                                                         | `agones-controller`    |
-| `agones.serviceaccount.sdk.name`                    | Service account name for the sdk                                                                | `agones-sdk`           |
-| `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`    |
-| `agones.serviceaccount.allocator.annotations`       | [Annotations][annotations] added to the Agones allocator service account                        | `{}`                   |
-| `agones.serviceaccount.controller.annotations`      | [Annotations][annotations] added to the Agones controller service account                       | `{}`                   |
 | `agones.allocator.disableSecretCreation`            | Disables the creation of any allocator secrets. If true, you MUST provide the `allocator-tls`, `allocator-tls-ca`, and `allocator-client-ca` secrets before installation. | `false` |
 |                       |                           |                            |
 {{% /feature %}}


### PR DESCRIPTION
Signed-off-by: Andrew Suderman <andrew@sudermanjr.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind feature

**What this PR does / Why we need it**:
Provide a flag to completely disable allocator certificate generation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2175 

TODO:
- [x] Add documentation
