### PR TITLE
documentation - add godot-sdk to third-party libraries-tools page

### DIFF
--- a/site/content/en/docs/Third Party Content/libraries-tools.md
+++ b/site/content/en/docs/Third Party Content/libraries-tools.md
@@ -9,6 +9,7 @@ weight: 30
 ## Client SDKs
 
 - [Cubxity/AgonesKt](https://github.com/Cubxity/AgonesKt) - Agones Client SDK for **Kotlin**  
+- [AndreMicheletti/godot-agones-sdk](https://github.com/AndreMicheletti/godot-agones-sdk) - Agones Client SDK for **Godot Engine**
 
 ## Messaging
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / Why we need it**:

Adds a new third-party sdk option for [Godot Engine](https://github.com/godotengine/godot)

