### PR TITLE
Set sidebar_menu_compact to true to make the side menu easier to navigate

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -104,7 +104,7 @@ prism_syntax_highlighting = true
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Makes the sidebar easier to navigate on the website.

See https://www.docsy.dev/docs/adding-content/navigation/#section-menu-options
for documentation about this setting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:

Check out the website preview. IMHO this is a huge usability improvement. 
