### PR TITLE
Workaround for bullseye release CI blockage

### DIFF
--- a/build/build-sdk-images/cpp/Dockerfile
+++ b/build/build-sdk-images/cpp/Dockerfile
@@ -14,7 +14,7 @@
 ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && \
+RUN apt-get --allow-releaseinfo-change update && \
     apt-get install -y zip wget clang-format && \
     apt-get clean
 

--- a/build/build-sdk-images/csharp/Dockerfile
+++ b/build/build-sdk-images/csharp/Dockerfile
@@ -18,8 +18,8 @@ FROM $BASE_IMAGE
 # This should contains tooling required to generate GRPC code, build (if distribution is required) 
 # and test your integration.
 
-RUN  apt-get update \
-    && apt-get install -y wget
+RUN apt-get --allow-releaseinfo-change update && \
+    apt-get install -y wget
 
 RUN apt-get update \
     && apt-get install -y apt-transport-https 

--- a/build/build-sdk-images/go/Dockerfile
+++ b/build/build-sdk-images/go/Dockerfile
@@ -14,7 +14,7 @@
 ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && \
+RUN apt-get --allow-releaseinfo-change update && \
     apt-get install -y wget jq && \
     apt-get clean
 

--- a/build/build-sdk-images/node/Dockerfile
+++ b/build/build-sdk-images/node/Dockerfile
@@ -14,7 +14,9 @@
 ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+## --allow-releaseinfo-change is a workaround for the new debian release
+## Can be removed when upgrading to bullseye
+RUN apt-get --allow-releaseinfo-change update && curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
 # Installing request is to address a bug with node-pre-gyp

--- a/build/build-sdk-images/restapi/Dockerfile
+++ b/build/build-sdk-images/restapi/Dockerfile
@@ -14,7 +14,7 @@
 ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && \
+RUN apt-get --allow-releaseinfo-change update && \
     apt-get install -y wget jq && \
     apt-get clean
 

--- a/build/build-sdk-images/rust/Dockerfile
+++ b/build/build-sdk-images/rust/Dockerfile
@@ -14,7 +14,7 @@
 ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && \
+RUN apt-get --allow-releaseinfo-change update && \
     apt-get install -y wget && \
     apt-get clean
 

--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -59,7 +59,7 @@ for platform-independent game server metrics and monitoring dashboards
 		<a href="http://accelbyte.io/"><img alt="accelbyte" width="100" src="images/accelbyte.png" /></a>
 		<a href="https://space.game/"><img alt="Space Game" width="80" src="images/spacegame.png" /></a>
 		<a href="https://rolltable.app/"><img alt="rolltable" width="100" src="images/rolltable.png" /></a>
-		<a href="https://vela.games/"><img alt="Vela Games" width="100" src="images/velagames.png" /></a>
+		<a href="https://vela.games/" data-proofer-ignore><img alt="Vela Games" width="100" src="images/velagames.png" /></a>
 		<a href="https://netspeakgames.com//"><img alt="Netspeak Games" width="100" src="images/netspeakgames.png" /></a>
 		<a href="https://afterverse.com/"><img alt="Afterverse" width="100" src="images/afterverse.svg" /></a>
 	</p>

--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -21,4 +21,4 @@ ExternalTimeout: 60
 IgnoreURLs:
   - http://localhost
 HTTPHeaders:
-  User-Agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36"
+  User-Agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Switch out `apt-get update` commands that are run in CI to being `apt-get --allow-releaseinfo-change update` to ignore the error on new release change.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Workaround for #2224 until we can upgrade everything to bullseye.

**Special notes for your reviewer**:

🤞🏻 
