### PR TITLE
[docs] fix create gameserver args

### DIFF
--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -57,6 +57,7 @@ package main
 
 import (
 	"fmt"
+	"context"
 
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
@@ -107,7 +108,7 @@ func main() {
 			},
 		},
 	}
-	newGS, err := agonesClient.AgonesV1().GameServers("default").Create(gs)
+	newGS, err := agonesClient.AgonesV1().GameServers("default").Create(context.TODO(), gs, metav1.CreateOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one /kind <> line, press enter to put that in a new line, and remove leading whitespace from that line:
> /kind breaking
>  /kind bug
> /kind cleanup

/kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Now, `GameServerInterface#Create` needs three args (`context.Context / *v1.GameServer / metav1.CreateOptions)`). [code](https://github.com/googleforgames/agones/blob/main/pkg/client/clientset/versioned/typed/agones/v1/gameserver.go#L41)
Although, docs write only one arg (`*v1.GameServer`). So I fix it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

