### PR TITLE
Separate the Helm value for the allocator service name from its service account name

### DIFF
--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.agones.serviceaccount.allocator.name }}
+  name: {{ $.Values.agones.allocator.serviceName }}
   namespace: {{ .Release.Namespace }}
   labels:
     component: allocator

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.agones.allocator.serviceName }}
+  name: {{ $.Values.agones.allocator.service.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     component: allocator

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -159,7 +159,8 @@ agones:
     disableMTLS: false
     disableTLS: false
     remoteAllocationTimeout: 10s
-    serviceName: agones-allocator
+    service:
+      name: agones-allocator
     totalRemoteAllocationTimeout: 30s
   image:
     registry: gcr.io/agones-images

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -159,6 +159,7 @@ agones:
     disableMTLS: false
     disableTLS: false
     remoteAllocationTimeout: 10s
+    serviceName: agones-allocator
     totalRemoteAllocationTimeout: 30s
   image:
     registry: gcr.io/agones-images

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -174,9 +174,10 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.allocator.annotations`                      | [Annotations][annotations] added to the Agones allocator pods                                   | `{}`                   |
 | `agones.allocator.resources`                        | Allocator pods [resource requests/limit][resources]                                             | `{}`                   |
 | `agones.allocator.nodeSelector`                     | Allocator [node labels][nodeSelector] for pod assignment                                        | `{}`                   |
+| `agones.allocator.serviceName         `             | Service name for the allocator                                                                  | `agones-allocator`     |
 | `agones.serviceaccount.controller.name`             | Service account name for the controller                                                         | `agones-controller`    |
 | `agones.serviceaccount.sdk.name`                    | Service account name for the sdk                                                                | `agones-sdk`           |
-| `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`    |
+| `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`     |
 | `agones.serviceaccount.allocator.annotations`       | [Annotations][annotations] added to the Agones allocator service account                        | `{}`                   |
 | `agones.serviceaccount.controller.annotations`      | [Annotations][annotations] added to the Agones controller service account                       | `{}`                   |
 | `gameservers.namespaces`                            | a list of namespaces you are planning to use to deploy game servers                             | `["default"]`          |

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -174,7 +174,6 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.allocator.annotations`                      | [Annotations][annotations] added to the Agones allocator pods                                   | `{}`                   |
 | `agones.allocator.resources`                        | Allocator pods [resource requests/limit][resources]                                             | `{}`                   |
 | `agones.allocator.nodeSelector`                     | Allocator [node labels][nodeSelector] for pod assignment                                        | `{}`                   |
-| `agones.allocator.service.name`                     | Service name for the allocator                                                                  | `agones-allocator`     |
 | `agones.serviceaccount.controller.name`             | Service account name for the controller                                                         | `agones-controller`    |
 | `agones.serviceaccount.sdk.name`                    | Service account name for the sdk                                                                | `agones-sdk`           |
 | `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`     |
@@ -191,6 +190,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
+| `agones.allocator.service.name`                     | Service name for the allocator                                                                  | `agones-allocator`     |
 |                                                     |                                                                                                 |         |
 |                       |                           |                            |
 {{% /feature %}}

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -174,7 +174,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.allocator.annotations`                      | [Annotations][annotations] added to the Agones allocator pods                                   | `{}`                   |
 | `agones.allocator.resources`                        | Allocator pods [resource requests/limit][resources]                                             | `{}`                   |
 | `agones.allocator.nodeSelector`                     | Allocator [node labels][nodeSelector] for pod assignment                                        | `{}`                   |
-| `agones.allocator.serviceName         `             | Service name for the allocator                                                                  | `agones-allocator`     |
+| `agones.allocator.service.name`                     | Service name for the allocator                                                                  | `agones-allocator`     |
 | `agones.serviceaccount.controller.name`             | Service account name for the controller                                                         | `agones-controller`    |
 | `agones.serviceaccount.sdk.name`                    | Service account name for the sdk                                                                | `agones-sdk`           |
 | `agones.serviceaccount.allocator.name`              | Service account name for the allocator                                                          | `agones-allocator`     |


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
Separates the allocation service name from allocation service account name during a helm installation.  There are instances where I want to use the default `agones-allocator` service account name, yet customize the actual service name.  Additionally, should the service account name require updates, this will also impact the allocation service name (which could cause breaking changes to workloads depending on that fqdn).

