### PR TITLE
Allow the ports for gRPC and REST to be configured for the allocator service

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -328,11 +328,11 @@ install: $(ensure-build-image) install-custom-pull-secret
 		--set agones.image.controller.pullPolicy=$(IMAGE_PULL_POLICY),agones.image.sdk.alwaysPull=$(ALWAYS_PULL_SIDECAR) \
 		--set agones.image.controller.pullSecret=$(IMAGE_PULL_SECRET) \
 		--set agones.ping.http.serviceType=$(PING_SERVICE_TYPE),agones.ping.udp.serviceType=$(PING_SERVICE_TYPE) \
-		--set agones.allocator.http.serviceType=$(ALLOCATOR_SERVICE_TYPE) \
+		--set agones.allocator.service.serviceType=$(ALLOCATOR_SERVICE_TYPE) \
 		--set agones.controller.logLevel=$(LOG_LEVEL) \
 		--set agones.crds.cleanupOnDelete=$(CRD_CLEANUP) \
 		--set agones.featureGates=$(FEATURE_GATES) \
-		--set agones.allocator.http.loadBalancerIP=$(EXTERNAL_IP) \
+		--set agones.allocator.service.loadBalancerIP=$(EXTERNAL_IP) \
 		$(HELM_ARGS) \
 		agones $(mount_path)/install/helm/agones/
 

--- a/cmd/allocator/metrics.go
+++ b/cmd/allocator/metrics.go
@@ -29,6 +29,8 @@ import (
 )
 
 const (
+	httpPortFlag                     = "http-port"
+	grpcPortFlag                     = "grpc-port"
 	enableStackdriverMetricsFlag     = "stackdriver-exporter"
 	enablePrometheusMetricsFlag      = "prometheus-exporter"
 	projectIDFlag                    = "gcp-project-id"
@@ -47,6 +49,8 @@ func init() {
 }
 
 type config struct {
+	GRPCPort                     int
+	HTTPPort                     int
 	APIServerSustainedQPS        int
 	APIServerBurstQPS            int
 	TLSDisabled                  bool
@@ -62,6 +66,8 @@ type config struct {
 
 func parseEnvFlags() config {
 
+	viper.SetDefault(httpPortFlag, -1)
+	viper.SetDefault(grpcPortFlag, -1)
 	viper.SetDefault(apiServerSustainedQPSFlag, 400)
 	viper.SetDefault(apiServerBurstQPSFlag, 500)
 	viper.SetDefault(enablePrometheusMetricsFlag, true)
@@ -74,6 +80,8 @@ func parseEnvFlags() config {
 	viper.SetDefault(totalRemoteAllocationTimeoutFlag, 30*time.Second)
 	viper.SetDefault(logLevelFlag, "Info")
 
+	pflag.Int32(httpPortFlag, viper.GetInt32(httpPortFlag), "Port to listen on for REST requests")
+	pflag.Int32(grpcPortFlag, viper.GetInt32(grpcPortFlag), "Port to listen on for gRPC requests")
 	pflag.Int32(apiServerSustainedQPSFlag, viper.GetInt32(apiServerSustainedQPSFlag), "Maximum sustained queries per second to send to the API server")
 	pflag.Int32(apiServerBurstQPSFlag, viper.GetInt32(apiServerBurstQPSFlag), "Maximum burst queries per second to send to the API server")
 	pflag.Bool(enablePrometheusMetricsFlag, viper.GetBool(enablePrometheusMetricsFlag), "Flag to activate metrics of Agones. Can also use PROMETHEUS_EXPORTER env variable.")
@@ -89,6 +97,8 @@ func parseEnvFlags() config {
 	pflag.Parse()
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	runtime.Must(viper.BindEnv(httpPortFlag))
+	runtime.Must(viper.BindEnv(grpcPortFlag))
 	runtime.Must(viper.BindEnv(apiServerSustainedQPSFlag))
 	runtime.Must(viper.BindEnv(apiServerBurstQPSFlag))
 	runtime.Must(viper.BindEnv(enablePrometheusMetricsFlag))
@@ -104,6 +114,8 @@ func parseEnvFlags() config {
 	runtime.Must(runtime.ParseFeaturesFromEnv())
 
 	return config{
+		HTTPPort:                     int(viper.GetInt32(httpPortFlag)),
+		GRPCPort:                     int(viper.GetInt32(grpcPortFlag)),
 		APIServerSustainedQPS:        int(viper.GetInt32(apiServerSustainedQPSFlag)),
 		APIServerBurstQPS:            int(viper.GetInt32(apiServerBurstQPSFlag)),
 		PrometheusMetrics:            viper.GetBool(enablePrometheusMetricsFlag),

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -36,20 +36,20 @@ spec:
   ports:
 {{- if .Values.agones.allocator.service.http.enabled }}
     - port: {{ .Values.agones.allocator.service.http.port }}
-      name: https
+      name: {{ .Values.agones.allocator.service.http.portName }}
       targetPort: {{ .Values.agones.allocator.service.http.targetPort }}
       protocol: TCP
 {{- if .Values.agones.allocator.service.grpc.enabled }}
 {{- if ne .Values.agones.allocator.service.grpc.port .Values.agones.allocator.service.http.port }}
     - port: {{ .Values.agones.allocator.service.grpc.port }}
-      name: grpc
+      name: {{ .Values.agones.allocator.service.grpc.portName }}
       targetPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
       protocol: TCP
 {{- end }}
 {{- end }}
 {{- else if .Values.agones.allocator.service.grpc.enabled }}
     - port: {{ .Values.agones.allocator.service.grpc.port }}
-      name: grpc
+      name: {{ .Values.agones.allocator.service.grpc.portName }}
       targetPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
       protocol: TCP
 {{- end }}
@@ -185,16 +185,16 @@ spec:
           value: {{ .Values.agones.featureGates | quote }}
         ports:
         {{- if .Values.agones.allocator.service.http.enabled }}
-        - name: https
+        - name: {{ .Values.agones.allocator.service.http.portName }}
           containerPort: {{ .Values.agones.allocator.service.http.targetPort }}
         {{- if .Values.agones.allocator.service.grpc.enabled }}
         {{- if ne .Values.agones.allocator.service.grpc.port .Values.agones.allocator.service.http.port }}
-        - name: grpc
+        - name: {{ .Values.agones.allocator.service.grpc.portName }}
           containerPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
         {{- end }}
         {{- end }}
         {{- else if .Values.agones.allocator.service.grpc.enabled }}
-        - name: grpc
+        - name: {{ .Values.agones.allocator.service.grpc.portName }}
           containerPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
         {{- end }}
         volumeMounts:

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- $useLoadBalancerIP := and (ne .Values.agones.allocator.http.loadBalancerIP "") (eq .Values.agones.allocator.http.serviceType "LoadBalancer") }}
+{{- $useLoadBalancerIP := and (ne .Values.agones.allocator.service.loadBalancerIP "") (eq .Values.agones.allocator.service.serviceType "LoadBalancer") }}
 {{- if .Values.agones.allocator.install }}
 # Define a Service for the agones-allocator
 apiVersion: v1
@@ -26,31 +26,46 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.agones.allocator.http.annotations }}
+{{- if .Values.agones.allocator.service.annotations }}
   annotations:
-{{ toYaml .Values.agones.allocator.http.annotations | indent 4 }}
+{{ toYaml .Values.agones.allocator.service.annotations | indent 4 }}
 {{- end }}
 spec:
   selector:
     multicluster.agones.dev/role: allocator
   ports:
-    - port: {{ .Values.agones.allocator.http.port }}
+{{- if .Values.agones.allocator.service.http.enabled }}
+    - port: {{ .Values.agones.allocator.service.http.port }}
       name: https
-      targetPort: 8443
+      targetPort: {{ .Values.agones.allocator.service.http.targetPort }}
       protocol: TCP
-  type: {{ .Values.agones.allocator.http.serviceType }}
-{{- if $useLoadBalancerIP }}
-  loadBalancerIP: {{ .Values.agones.allocator.http.loadBalancerIP }}
+{{- if .Values.agones.allocator.service.grpc.enabled }}
+{{- if ne .Values.agones.allocator.service.grpc.port .Values.agones.allocator.service.http.port }}
+    - port: {{ .Values.agones.allocator.service.grpc.port }}
+      name: grpc
+      targetPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
+      protocol: TCP
 {{- end }}
-{{- if eq .Values.agones.allocator.http.serviceType "LoadBalancer" }}
-  {{- if .Values.agones.allocator.http.loadBalancerSourceRanges }}
+{{- end }}
+{{- else if .Values.agones.allocator.service.grpc.enabled }}
+    - port: {{ .Values.agones.allocator.service.grpc.port }}
+      name: grpc
+      targetPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
+      protocol: TCP
+{{- end }}
+  type: {{ .Values.agones.allocator.service.serviceType }}
+{{- if $useLoadBalancerIP }}
+  loadBalancerIP: {{ .Values.agones.allocator.service.loadBalancerIP }}
+{{- end }}
+{{- if eq .Values.agones.allocator.service.serviceType "LoadBalancer" }}
+  {{- if .Values.agones.allocator.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.agones.allocator.http.loadBalancerSourceRanges | indent 4 }}
+{{ toYaml .Values.agones.allocator.service.loadBalancerSourceRanges | indent 4 }}
   {{- end }}
 {{- end }}
 
 ---
-# Deploy a pod to run the agones-allocator code
+# Deploy pods to run the agones-allocator code
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,6 +141,14 @@ spec:
             path: /ready
             port: 8080
         env:
+        {{- if .Values.agones.allocator.service.http.enabled }}
+        - name: HTTP_PORT
+          value: {{ .Values.agones.allocator.service.http.targetPort | quote }}
+        {{- end }}
+        {{- if .Values.agones.allocator.service.grpc.enabled }}
+        - name: GRPC_PORT
+          value: {{ .Values.agones.allocator.service.grpc.targetPort | quote }}
+        {{- end }}
         - name: API_SERVER_QPS
           value: {{ .Values.agones.allocator.apiServerQPS | quote }}
         - name: API_SERVER_QPS_BURST
@@ -161,8 +184,19 @@ spec:
         - name: FEATURE_GATES
           value: {{ .Values.agones.featureGates | quote }}
         ports:
+        {{- if .Values.agones.allocator.service.http.enabled }}
         - name: https
-          containerPort: 8443
+          containerPort: {{ .Values.agones.allocator.service.http.targetPort }}
+        {{- if .Values.agones.allocator.service.grpc.enabled }}
+        {{- if ne .Values.agones.allocator.service.grpc.port .Values.agones.allocator.service.http.port }}
+        - name: grpc
+          containerPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
+        {{- end }}
+        {{- end }}
+        {{- else if .Values.agones.allocator.service.grpc.enabled }}
+        - name: grpc
+          containerPort: {{ .Values.agones.allocator.service.grpc.targetPort }}
+        {{- end }}
         volumeMounts:
         - mountPath: /home/allocator/tls
           name: tls
@@ -277,7 +311,7 @@ data:
 
 ---
 # Allocation TLS certs
-{{- $cert := genSignedCert "" ($useLoadBalancerIP | ternary (list .Values.agones.allocator.http.loadBalancerIP) nil) nil 3650 $ca }}
+{{- $cert := genSignedCert "" ($useLoadBalancerIP | ternary (list .Values.agones.allocator.service.loadBalancerIP) nil) nil 3650 $ca }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -156,10 +156,12 @@ agones:
       http:
         enabled: true
         port: 443
+        portName: https
         targetPort: 8443
       grpc:
         enabled: true
         port: 443
+        portName: grpc
         targetPort: 8443
     disableSecretCreation: false
     generateTLS: true

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -147,20 +147,26 @@ agones:
               - key: agones.dev/agones-system
                 operator: Exists
     replicas: 3
-    http:
-      port: 443
+    service:
+      name: agones-allocator
       serviceType: LoadBalancer
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
       annotations: {}
+      http:
+        enabled: true
+        port: 443
+        targetPort: 8443
+      grpc:
+        enabled: true
+        port: 443
+        targetPort: 8443
     disableSecretCreation: false
     generateTLS: true
     generateClientTLS: true
     disableMTLS: false
     disableTLS: false
     remoteAllocationTimeout: 10s
-    service:
-      name: agones-allocator
     totalRemoteAllocationTimeout: 30s
   image:
     registry: gcr.io/agones-images

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -13409,7 +13409,7 @@ spec:
             value: ""
 ---
 # Source: agones/templates/service/allocation.yaml
-# Deploy a pod to run the agones-allocator code
+# Deploy pods to run the agones-allocator code
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13478,6 +13478,10 @@ spec:
             path: /ready
             port: 8080
         env:
+        - name: HTTP_PORT
+          value: "8443"
+        - name: GRPC_PORT
+          value: "8443"
         - name: API_SERVER_QPS
           value: "400"
         - name: API_SERVER_QPS_BURST

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -191,7 +191,16 @@ The following tables lists the configurable parameters of the Agones chart and t
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
 | `agones.allocator.service.name`                     | Service name for the allocator                                                                  | `agones-allocator`     |
-|                                                     |                                                                                                 |         |
+| `agones.allocator.service.serviceType`                 | The [Service Type][service] of the HTTP Service                                                 | `LoadBalancer`         |
+| `agones.allocator.service.loadBalancerIP`              | The [Load Balancer IP][loadBalancer] of the Agones allocator load balancer. Only works if the Kubernetes provider supports this option. | \`\`                     |
+| `agones.allocator.service.loadBalancerSourceRanges`    | The [Load Balancer SourceRanges][loadBalancer] of the Agones allocator load balancer. Only works if the Kubernetes provider supports this option. | `[]`         |
+| `agones.allocator.service.annotations`                      | [Annotations][annotations] added to the Agones allocator service                                | `{}`                   |
+| `agones.allocator.service.http.enabled`                        | If true the [allocator service][allocator] will respond to [REST requests][rest-requests] | `true`                  |
+| `agones.allocator.service.http.port`                        | The port that is exposed externally by the [allocator service][allocator] for [REST requests][rest-requests] | `443`                  |
+| `agones.allocator.service.http.targetPort`                        | The port that is used by the allocator pod to listen for [REST requests][rest-requests]. Note that the allocator server cannot bind to low numbered ports. | `8443`                  |
+| `agones.allocator.service.grpc.enabled`                        | If true the [allocator service][allocator] will respond to [gRPC requests][grpc-requests] | `true`                  |
+| `agones.allocator.service.grpc.port`                        | The port that is exposed externally by the [allocator service][allocator] for [gRPC requests][grpc-requests] | `443`                  |
+| `agones.allocator.service.grpc.targetPort`                        | The port that is used by the allocator pod to listen for [gRPC requests][grpc-requests]. Note that the allocator server cannot bind to low numbered ports. | `8443`                  |
 |                       |                           |                            |
 {{% /feature %}}
 
@@ -208,6 +217,8 @@ The following tables lists the configurable parameters of the Agones chart and t
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 [pruning]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning
 [gameserver]: {{< ref "/docs/Reference/gameserver.md" >}}
+[rest-requests]: {{< ref "/docs/Advanced/allocator-service.md#using-rest" >}}
+[grpc-requests]: {{< ref "/docs/Advanced/allocator-service.md#using-grpc" >}}
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>

/kind breaking

> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Makes it possible to disable the REST endpoint in the allocator service or to run gRPC and REST on different ports. This allows using the non-experimental gRPC server code.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2263

**Special notes for your reviewer**:

~~This is currently a work-in-progress. I still need to update the documentation before this can be merged.~~

I've added documentation. 

This is a breaking change because I'm renaming some helm parameters (which can be seen in the updates to the Makefile and the allocator service documentation). In the 1.18.0 release we should notify folks that if they rely on these helm parameters that they now have different names. 