### PR TITLE
docs: remove --node-ami auto for managed nodegroups

### DIFF
--- a/site/content/en/docs/Installation/Creating Cluster/eks.md
+++ b/site/content/en/docs/Installation/Creating Cluster/eks.md
@@ -23,8 +23,7 @@ eksctl create cluster \
 --node-type t3.medium \
 --nodes 3 \
 --nodes-min 3 \
---nodes-max 4 \
---node-ami auto
+--nodes-max 4
 ```
 
 {{< alert title="Note" color="info">}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
`eksctl` doesn't need `--node-ami auto` for creating EKS cluster.

https://eksctl.io/usage/custom-ami-support/

https://github.com/weaveworks/eksctl/pull/3754

The option happens the error below.
`Error: invalid AMI "auto" (managedNodeGroups[0].ami)`

So, delete `--node-ami auto` options in this ducument.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:
N/A

