### PR TITLE
Update the link to look for issues for the release.

### DIFF
--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -18,8 +18,8 @@ and copy it into a release issue. Fill in relevant values, found inside {}
 ## Steps
 
 - [ ] Run `make shell` and run `gcloud config configurations activate agones-images`.
-- [ ] Review [closed issues with no milestone](https://github.com/googleforgames/agones/issues?q=is%3Aissue+is%3Aclosed+no%3Amilestone) and add relevant ones to the current milestone.
-  - Issues tagged as `invalid`, `duplicate`, `question`, or `wontfix` can be ignored
+- [ ] Review [closed issues with no milestone](https://github.com/googleforgames/agones/issues?q=is%3Aissue+is%3Aclosed+no%3Amilestone++-label%3Ainvalid+-label%3Aduplicate+-label%3Aquestion+-label%3Awontfix++-label%3Aarea%2Fmeta) and add relevant ones to the current milestone.
+  - Issues tagged as `invalid`, `duplicate`, `question`, `wontfix`, or `area/meta` can be ignored
 - [ ] Review closed issues in the current milestone to ensure that they have appropriate tags.
 - [ ] Review [merged PRs that have no milestone](https://github.com/googleforgames/agones/pulls?q=is%3Apr+is%3Amerged+no%3Amilestone+) and add them to the current milestone.
 - [ ] Review merged PRs in the current milestone to ensure that they have appropriate tags.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

The query for closed issues was starting to return a large number (>130) issues. Scanning through some of the issues past the first page I noticed that while we generally caught recently opened (and closed) issues for a release, there were issues without a milestone for many old releases (1.17, 1.14, and even 1.1) that had been missed using the old link.

