### PR TITLE
Update format of last-allocated to RFC 3339, set in Agones SDK as well

### DIFF
--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -72,13 +72,13 @@ const (
 	// timestamp of the most recent allocation.
 	LastAllocatedAnnotationKey = "agones.dev/last-allocated"
 
-	secretClientCertName       = "tls.crt"
-	secretClientKeyName        = "tls.key"
-	secretCACertName           = "ca.crt"
-	allocatorPort              = "443"
-	maxBatchQueue              = 100
-	maxBatchBeforeRefresh      = 100
-	batchWaitTime              = 500 * time.Millisecond
+	secretClientCertName  = "tls.crt"
+	secretClientKeyName   = "tls.key"
+	secretCACertName      = "ca.crt"
+	allocatorPort         = "443"
+	maxBatchQueue         = 100
+	maxBatchBeforeRefresh = 100
+	batchWaitTime         = 500 * time.Millisecond
 )
 
 var allocationRetry = wait.Backoff{

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -68,6 +68,10 @@ var (
 )
 
 const (
+	// LastAllocatedAnnotationKey is a GameServer annotation containing an RFC 3339 formatted
+	// timestamp of the most recent allocation.
+	LastAllocatedAnnotationKey = "agones.dev/last-allocated"
+
 	secretClientCertName       = "tls.crt"
 	secretClientKeyName        = "tls.key"
 	secretCACertName           = "ca.crt"
@@ -75,7 +79,6 @@ const (
 	maxBatchQueue              = 100
 	maxBatchBeforeRefresh      = 100
 	batchWaitTime              = 500 * time.Millisecond
-	lastAllocatedAnnotationKey = "agones.dev/last-allocated"
 )
 
 var allocationRetry = wait.Backoff{
@@ -593,7 +596,11 @@ func (c *Allocator) applyAllocationToGameServer(ctx context.Context, mp allocati
 	}
 
 	// add last allocated, so it always gets updated, even if it is already Allocated
-	gs.ObjectMeta.Annotations[lastAllocatedAnnotationKey] = time.Now().String()
+	ts, err := time.Now().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	gs.ObjectMeta.Annotations[LastAllocatedAnnotationKey] = string(ts)
 	gs.Status.State = agonesv1.GameServerStateAllocated
 
 	return c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(ctx, gs, metav1.UpdateOptions{})

--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -51,6 +51,8 @@ func TestAllocatorApplyAllocationToGameServer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 	assert.NotNil(t, gs.ObjectMeta.Annotations["agones.dev/last-allocated"])
+	var ts time.Time
+	assert.NoError(t, ts.UnmarshalText([]byte(gs.ObjectMeta.Annotations[LastAllocatedAnnotationKey])))
 
 	gs, err = allocator.applyAllocationToGameServer(ctx, allocationv1.MetaPatch{Labels: map[string]string{"foo": "bar"}}, &agonesv1.GameServer{})
 	assert.NoError(t, err)
@@ -65,5 +67,5 @@ func TestAllocatorApplyAllocationToGameServer(t *testing.T) {
 	assert.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 	assert.Equal(t, "bar", gs.ObjectMeta.Labels["foo"])
 	assert.Equal(t, "foo", gs.ObjectMeta.Annotations["bar"])
-	assert.NotNil(t, gs.ObjectMeta.Annotations[lastAllocatedAnnotationKey])
+	assert.NotNil(t, gs.ObjectMeta.Annotations[LastAllocatedAnnotationKey])
 }

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -56,6 +56,7 @@ func TestSidecarRun(t *testing.T) {
 
 	fixtures := map[string]struct {
 		f        func(*SDKServer, context.Context)
+		clock    clock.Clock
 		expected expected
 	}{
 		"ready": {
@@ -114,11 +115,10 @@ func TestSidecarRun(t *testing.T) {
 		},
 		"allocated": {
 			f: func(sc *SDKServer, ctx context.Context) {
-				fc := clock.NewFakeClock(now)
-				sc.clock = fc
 				_, err := sc.Allocate(ctx, &sdk.Empty{})
 				assert.NoError(t, err)
 			},
+			clock: clock.NewFakeClock(now),
 			expected: expected{
 				state:      agonesv1.GameServerStateAllocated,
 				recordings: []string{string(agonesv1.GameServerStateAllocated)},
@@ -186,6 +186,9 @@ func TestSidecarRun(t *testing.T) {
 
 			assert.Nil(t, err)
 			sc.recorder = m.FakeRecorder
+			if v.clock != nil {
+				sc.clock = v.clock
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -117,6 +117,12 @@ For those scenarios, this SDK functionality exists.
 
 There is a chance that GameServer does not actually become `Allocated` after this call. Please refer to the general note in [Function Reference](#function-reference) above.
 
+{{% feature publishVersion="1.19.0" %}}
+The `agones.dev/last-allocated` annotation will be set on the GameServer to an RFC3339 formatted timestamp of the time of allocation, even if the GameServer was already in an `Allocated` state.
+
+Note that if using `SDK.Allocate()` in combination with [GameServerAllocation]({{< ref "/docs/Reference/gameserverallocation.md" >}})s, it's possible for the `agones.dev/last-allocated` timestamp to move backwards if clocks are not synchronized between the Agones controller and the GameServer pod.
+{{% /feature %}}
+
 {{< alert title="Note" color="info">}}
 Using a [GameServerAllocation]({{< ref "/docs/Reference/gameserverallocation.md" >}}) is preferred in all other scenarios, 
 as it gives Agones control over how packed `GameServers` are scheduled within a cluster, whereas with `Allocate()` you


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Updates the format of the timestamp in the `agones.dev/last-allocated` annotation to a parsable format (RFC 3339).

Additionally, now also sets the annotation whenever an allocation is made through the Agones SDK (please let me know if there are any concerns around this!)

For some context: this timestamp is useful to see how long a game server has been in an allocated state, e.g. for debugging, or for automatic cleanup of game servers stuck in this state for whatever reason. For that, having the timestamp in a machine-readable format is helpful, the original format `time.String()` wasn't really meant to be parsed back

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2331 

**Special notes for your reviewer**:


