### PR TITLE
Add a flag to the simple game server so that it can have a delay before marking itself ready

### DIFF
--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -35,7 +35,7 @@ WITH_WINDOWS=1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REGISTRY)/simple-game-server:0.4
+server_tag = $(REGISTRY)/simple-game-server:0.5
 ifeq ($(WITH_WINDOWS), 1)
 server_tag_linux_amd64 = $(server_tag)-linux_amd64
 else

--- a/examples/simple-game-server/README.md
+++ b/examples/simple-game-server/README.md
@@ -1,18 +1,51 @@
 # Simple Game Server
 
-A very simple logging server, for the purposes of demoing and testing
-running UDP and/or TCP based server on Agones.
+A very simple "toy" game server created to demo and test running a UDP and/or
+TCP game server on Agones.
 
-## Server
-Starts a server on port `7654` by default. Can be overwritten by `PORT` env var or `port` flag.
-
-By default listens on UDP. Set `UDP=FALSE` env var or `-udp=false` flag to turn UDP off.
-
-To enable TCP, set `TCP=TRUE` env var or `-tcp` flag. Must have at least TCP or UDP enabled.
-
-When it receives a text packet, it will send back "ACK:<text content>" for UDP as an echo or "ACK TCP:<text content>" for TCP. 
-
-If it receives the text "EXIT", then it will `sys.Exit(0)`
-
-To learn how to deploy your edited version of go server to gcp, please check out this link: [Edit Your First Game Server (Go)](https://agones.dev/site/docs/getting-started/edit-first-gameserver-go/),
+To learn how to deploy your edited version of go server to gcp, please check
+out this link: [Edit Your First Game Server (Go)](https://agones.dev/site/docs/getting-started/edit-first-gameserver-go/),
 or also look at the [`Makefile`](./Makefile).
+
+## Interacting with the Server
+
+When the server receives a text packet, it will send back "ACK:<text content>"
+for UDP as an echo or "ACK TCP:<text content>" for TCP.
+
+There are some text commands you can send the server to affect its behavior:
+
+| Command             | Behavior                                                                                 |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| "EXIT"              | Causes the game server to exit cleanly calling `os.Exit(0)`                              |
+| "UNHEATHY"          | Stopping sending health checks                                                           |
+| "GAMESERVER"        | Sends back the game server name                                                          |
+| "READY"             | Marks the server as Ready                                                                |
+| "ALLOCATE"          | Allocates the game server                                                                |
+| "RESERVE"           | Reserves the game server after the specified duration                                    |
+| "WATCH"             | Instructs the game server to log changes to the resource                                 |
+| "LABEL"             | Sets the specified label on the game server resource                                     |
+| "CRASH"             | Causes the game server to exit / crash immediately                                       |
+| "ANNOTATION"        | Sets the specified annotation on the game server resource                                |
+| "PLAYER_CAPACITY"   | With one argument, gets the player capacity; with two arguments sets the player capacity |
+| "PLAYER_CONNECT"    | Connects the specified player to the game server                                         |
+| "PLAYER_DISCONNECT" | Disconnects the specified player from the game server                                    |
+| "PLAYER_CONNECTED"  | Returns true/false depending on whether the specified player is connected                |
+| "GET_PLAYERS"       | Returns a list of the connected players                                                  |
+| "PLAYER_COUNT"      | Returns a count of the connected players                                                 |
+
+
+## Configuration
+
+The server has a few configuration options that can be set via command line
+flags. Some can also be set using environment variables.
+
+| Flag                      | Environment Variable | Default |
+| ------------------------- | -------------------- | ------- |
+| port                      | PORT                 | 7654    |
+| passthrough               | PASSTHROUGH          | false   |
+| ready                     | READY                | true    |
+| automaticShutdownDelayMin | _n/a_                | 0       |
+| readyDelaySec             | _n/a_                | 0       |
+| udp                       | UDP                  | true    |
+| tcp                       | TCP                  | false   |
+

--- a/examples/simple-game-server/dev-gameserver.yaml
+++ b/examples/simple-game-server/dev-gameserver.yaml
@@ -31,4 +31,4 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: gcr.io/agones-images/simple-game-server:0.4
+        image: gcr.io/agones-images/simple-game-server:0.5

--- a/examples/simple-game-server/fleet-distributed.yaml
+++ b/examples/simple-game-server/fleet-distributed.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: gcr.io/agones-images/simple-game-server:0.4
+            image: gcr.io/agones-images/simple-game-server:0.5
             resources:
               requests:
                 memory: "64Mi"

--- a/examples/simple-game-server/fleet-tcp.yaml
+++ b/examples/simple-game-server/fleet-tcp.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: gcr.io/agones-images/simple-game-server:0.4
+            image: gcr.io/agones-images/simple-game-server:0.5
             env:
             # Disables the UDP listener (Enabled by default)
             - name: "UDP"

--- a/examples/simple-game-server/fleet.yaml
+++ b/examples/simple-game-server/fleet.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: gcr.io/agones-images/simple-game-server:0.4
+            image: gcr.io/agones-images/simple-game-server:0.5
             resources:
               requests:
                 memory: "64Mi"

--- a/examples/simple-game-server/gameserver-passthrough.yaml
+++ b/examples/simple-game-server/gameserver-passthrough.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: gcr.io/agones-images/simple-game-server:0.4
+        image: gcr.io/agones-images/simple-game-server:0.5
         env:
           - name: "PASSTHROUGH"
             value: "TRUE"

--- a/examples/simple-game-server/gameserver-windows.yaml
+++ b/examples/simple-game-server/gameserver-windows.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: gcr.io/agones-images/simple-game-server:0.4
+        image: gcr.io/agones-images/simple-game-server:0.5
         resources:
           requests:
             memory: "64Mi"

--- a/examples/simple-game-server/gameserver.yaml
+++ b/examples/simple-game-server/gameserver.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: gcr.io/agones-images/simple-game-server:0.4
+        image: gcr.io/agones-images/simple-game-server:0.5
         resources:
           requests:
             memory: "64Mi"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**: Allows the simple game server to become ready more slowly, which makes it easier to verify percentage rollouts while testing fleet updates. Also update the documentation for the flags and add documentation for the commands that you can send to the game server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
_n/a_

**Special notes for your reviewer**:


