### PR TITLE
Upgrade `terraform-aws-eks` to `v17.22.0`

### DIFF
--- a/install/terraform/modules/eks/eks.tf
+++ b/install/terraform/modules/eks/eks.tf
@@ -82,7 +82,7 @@ module "vpc" {
 }
 
 module "eks" {
-  source          = "git::github.com/terraform-aws-modules/terraform-aws-eks.git?ref=v12.2.0"
+  source          = "git::github.com/terraform-aws-modules/terraform-aws-eks.git?ref=v17.22.0"
   cluster_name    = var.cluster_name
   subnets         = module.vpc.public_subnets
   vpc_id          = module.vpc.vpc_id


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:

Without this change, validation of [the EKS example](https://github.com/googleforgames/agones/blob/fc6e7872e58ffbf7bf700d8e76e085ce4ce74e03/examples/terraform-submodules/eks/module.tf) fails on Terraform v1.0.9 with the following error:
```
╷
│ Error: Error in function call
│
│   on .terraform/modules/eks_cluster.eks/outputs.tf line 3, in output "cluster_id":
│    3:   value       = element(concat(aws_eks_cluster.this.*.id, list("")), 0)
│
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
╵
```
(there are 4 more instances of it)

I hope this upgrade doesn't introduce any breaking changes. So far, I've simply got the example to validate successfully.
