### PR TITLE
Hope to reduce e2e flakiness

### DIFF
--- a/test/e2e/controller/crash_test.go
+++ b/test/e2e/controller/crash_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
-	"github.com/sirupsen/logrus"
+	e2eframework "agones.dev/agones/test/e2e/framework"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,11 +29,11 @@ import (
 )
 
 func TestGameServerUnhealthyAfterDeletingPodWhileControllerDown(t *testing.T) {
-	logger := logrus.WithField("test", t.Name())
+	logger := e2eframework.TestLogger(t)
 	gs := framework.DefaultGameServer(defaultNs)
 	ctx := context.Background()
 
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, defaultNs, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestGameServerUnhealthyAfterDeletingPodWhileControllerDown(t *testing.T) {
 	err = podClient.Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
 	assert.NoError(t, err)
 
-	_, err = framework.WaitForGameServerState(readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
+	_, err = framework.WaitForGameServerState(t, readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
 	assert.NoError(t, err)
 	logger.Info("waiting for Agones controller to come back to running")
 	assert.NoError(t, waitForAgonesControllerRunning(ctx))

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -160,7 +160,7 @@ func TestFleetScaleUpEditAndScaleDown(t *testing.T) {
 			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(targetScale))
 			gsa := framework.CreateAndApplyAllocation(t, flt)
 
-			framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+			framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 				return fleet.Status.AllocatedReplicas == 1
 			})
 
@@ -210,7 +210,7 @@ func TestFleetScaleUpEditAndScaleDown(t *testing.T) {
 
 			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(1))
 
-			framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+			framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 				return fleet.Status.AllocatedReplicas == 0
 			})
 		})
@@ -334,7 +334,7 @@ func TestFleetRollingUpdate(t *testing.T) {
 
 				framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(1))
 
-				framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+				framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 					return fleet.Status.AllocatedReplicas == 0
 				})
 			})
@@ -432,7 +432,7 @@ func TestScaleFleetUpAndDownWithGameServerAllocation(t *testing.T) {
 			gsa, err = framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa, metav1.CreateOptions{})
 			assert.Nil(t, err)
 			assert.Equal(t, allocationv1.GameServerAllocationAllocated, gsa.Status.State)
-			framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+			framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 				return fleet.Status.AllocatedReplicas == 1
 			})
 
@@ -452,7 +452,7 @@ func TestScaleFleetUpAndDownWithGameServerAllocation(t *testing.T) {
 			assert.Nil(t, err)
 			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(1))
 
-			framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+			framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 				return fleet.Status.AllocatedReplicas == 0
 			})
 		})
@@ -553,7 +553,7 @@ func TestUpdateGameServerConfigurationInFleet(t *testing.T) {
 	gsa, err = framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa, metav1.CreateOptions{})
 	assert.Nil(t, err, "cloud not create gameserver allocation")
 	assert.Equal(t, allocationv1.GameServerAllocationAllocated, gsa.Status.State)
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.AllocatedReplicas == 1
 	})
 
@@ -604,7 +604,7 @@ func TestReservedGameServerInFleet(t *testing.T) {
 	assert.NoError(t, err)
 
 	// make sure counts are correct
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.ReadyReplicas == 2 && fleet.Status.ReservedReplicas == 1
 	})
 
@@ -613,9 +613,9 @@ func TestReservedGameServerInFleet(t *testing.T) {
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(0))
 
 	// one should be left behind
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		result := fleet.Status.ReservedReplicas == 1
-		logrus.WithField("reserved", fleet.Status.ReservedReplicas).WithField("result", result).Info("waiting for 1 reserved replica")
+		log.WithField("reserved", fleet.Status.ReservedReplicas).WithField("result", result).Info("waiting for 1 reserved replica")
 		return result
 	})
 
@@ -1114,7 +1114,7 @@ func TestFleetWithLongLabelsAnnotations(t *testing.T) {
 	assert.Error(t, err)
 	statusErr, ok = err.(*k8serrors.StatusError)
 	assert.True(t, ok)
-	assert.Len(t, statusErr.Status().Details.Causes, 1)
+	require.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, "annotations", statusErr.Status().Details.Causes[0].Field)
 	assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.Status().Details.Causes[0].Type)
 
@@ -1309,13 +1309,13 @@ func TestFleetAggregatedPlayerStatus(t *testing.T) {
 	flt, err := client.Fleets(framework.Namespace).Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		if fleet.Status.Players == nil {
-			logrus.WithField("status", fleet.Status).Info("No Players")
+			log.WithField("status", fleet.Status).Info("No Players")
 			return false
 		}
 
-		logrus.WithField("status", fleet.Status).Info("Checking Capacity")
+		log.WithField("status", fleet.Status).Info("Checking Capacity")
 		return fleet.Status.Players.Capacity == 30
 	})
 
@@ -1356,8 +1356,8 @@ func TestFleetAggregatedPlayerStatus(t *testing.T) {
 		}
 	}
 
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
-		logrus.WithField("players", fleet.Status.Players).WithField("totalCapacity", totalCapacity).
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
+		log.WithField("players", fleet.Status.Players).WithField("totalCapacity", totalCapacity).
 			WithField("totalPlayers", totalPlayers).Info("Checking Capacity")
 		// since UDP packets might fail, we might get an extra player, so we'll check for that.
 		return (fleet.Status.Players.Capacity == int64(totalCapacity)) && (fleet.Status.Players.Count >= int64(totalPlayers))

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -96,7 +96,7 @@ func TestAutoscalerBasicFunctions(t *testing.T) {
 
 	// do an allocation and watch the fleet scale up
 	gsa := framework.CreateAndApplyAllocation(t, flt)
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.AllocatedReplicas == 1
 	})
 
@@ -115,7 +115,7 @@ func TestAutoscalerBasicFunctions(t *testing.T) {
 	assert.True(t, fas.Status.AbleToScale, "Could not get AbleToScale status")
 
 	// check that we are able to scale
-	framework.WaitForFleetAutoScalerCondition(t, fas, func(fas *autoscalingv1.FleetAutoscaler) bool {
+	framework.WaitForFleetAutoScalerCondition(t, fas, func(log *logrus.Entry, fas *autoscalingv1.FleetAutoscaler) bool {
 		return !fas.Status.ScalingLimited
 	})
 
@@ -124,7 +124,7 @@ func TestAutoscalerBasicFunctions(t *testing.T) {
 	assert.Nil(t, err, "could not patch fleetautoscaler")
 
 	// check that we are not able to scale
-	framework.WaitForFleetAutoScalerCondition(t, fas, func(fas *autoscalingv1.FleetAutoscaler) bool {
+	framework.WaitForFleetAutoScalerCondition(t, fas, func(log *logrus.Entry, fas *autoscalingv1.FleetAutoscaler) bool {
 		return fas.Status.ScalingLimited
 	})
 
@@ -132,7 +132,7 @@ func TestAutoscalerBasicFunctions(t *testing.T) {
 	gp := int64(1)
 	err = stable.GameServers(framework.Namespace).Delete(ctx, gsa.Status.GameServerName, metav1.DeleteOptions{GracePeriodSeconds: &gp})
 	assert.Nil(t, err)
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.AllocatedReplicas == 0 &&
 			fleet.Status.ReadyReplicas == 1 &&
 			fleet.Status.Replicas == 1
@@ -236,7 +236,7 @@ func TestFleetAutoScalerRollingUpdate(t *testing.T) {
 	assert.True(t, fas.Status.AbleToScale, "Could not get AbleToScale status")
 
 	// check that we are able to scale
-	framework.WaitForFleetAutoScalerCondition(t, fas, func(fas *autoscalingv1.FleetAutoscaler) bool {
+	framework.WaitForFleetAutoScalerCondition(t, fas, func(log *logrus.Entry, fas *autoscalingv1.FleetAutoscaler) bool {
 		return !fas.Status.ScalingLimited
 	})
 
@@ -471,11 +471,11 @@ func TestAutoscalerWebhook(t *testing.T) {
 		assert.FailNow(t, "Failed creating autoscaler, aborting TestAutoscalerWebhook")
 	}
 	framework.CreateAndApplyAllocation(t, flt)
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.AllocatedReplicas == 1
 	})
 
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.Replicas > initialReplicasCount
 	})
 
@@ -701,11 +701,11 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 		assert.FailNow(t, "Failed creating autoscaler, aborting TestTlsWebhook")
 	}
 	framework.CreateAndApplyAllocation(t, flt)
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.AllocatedReplicas == 1
 	})
 
-	framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+	framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 		return fleet.Status.Replicas > initialReplicasCount
 	})
 }

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -47,7 +47,7 @@ const (
 func TestCreateConnect(t *testing.T) {
 	t.Parallel()
 	gs := framework.DefaultGameServer(framework.Namespace)
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
@@ -72,7 +72,7 @@ func TestSDKSetLabel(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	gs := framework.DefaultGameServer(framework.Namespace)
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestHealthCheckDisable(t *testing.T) {
 		InitialDelaySeconds: 1,
 		PeriodSeconds:       1,
 	}
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 	ctx := context.Background()
 	gs := framework.DefaultGameServer(framework.Namespace)
 	annotation := "agones.dev/sdk-timestamp"
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestUnhealthyGameServerAfterHealthCheckFail(t *testing.T) {
 	gs := framework.DefaultGameServer(framework.Namespace)
 	gs.Spec.Health.FailureThreshold = 1
 
-	gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		assert.FailNow(t, "Failed to create a gameserver", err.Error())
 	}
@@ -189,7 +189,7 @@ func TestUnhealthyGameServerAfterHealthCheckFail(t *testing.T) {
 	}
 	assert.Equal(t, "ACK: UNHEALTHY\n", reply)
 
-	_, err = framework.WaitForGameServerState(gs, agonesv1.GameServerStateUnhealthy, time.Minute)
+	_, err = framework.WaitForGameServerState(t, gs, agonesv1.GameServerStateUnhealthy, time.Minute)
 	assert.NoError(t, err)
 }
 
@@ -210,7 +210,7 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 
 	gameServers := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace)
 	// one successful static port GameServer
-	gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, template.DeepCopy())
+	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, template.DeepCopy())
 	require.NoError(t, err)
 
 	// now let's create the same one, but this time, require it be on the same node.
@@ -223,7 +223,7 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 	newGs, err = gameServers.Create(ctx, newGs, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_, err = framework.WaitForGameServerState(newGs, agonesv1.GameServerStateUnhealthy, 5*time.Minute)
+	_, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 5*time.Minute)
 	assert.NoError(t, err)
 }
 
@@ -231,7 +231,7 @@ func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	gs := framework.DefaultGameServer(framework.Namespace)
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -253,14 +253,14 @@ func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 	err = podClient.Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
 	assert.NoError(t, err)
 
-	_, err = framework.WaitForGameServerState(readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
+	_, err = framework.WaitForGameServerState(t, readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
 	assert.NoError(t, err)
 }
 
 func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := logrus.WithField("test", t.Name())
+	logger := e2eframework.TestLogger(t)
 
 	gs := framework.DefaultGameServer(framework.Namespace)
 	// give some buffer with gameservers crashing and coming back
@@ -274,7 +274,7 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	defer gsClient.Delete(ctx, newGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	logger.Info("Waiting for us to have an address to send things to")
-	newGs, err = framework.WaitForGameServerState(newGs, agonesv1.GameServerStateScheduled, time.Minute)
+	newGs, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateScheduled, time.Minute)
 	if err != nil {
 		assert.FailNow(t, "Failed schedule a pod", err.Error())
 	}
@@ -332,7 +332,7 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check that the GameServer is not in an unhealthy state. If it does happen, it should happen pretty quick
-	newGs, err = framework.WaitForGameServerState(newGs, agonesv1.GameServerStateUnhealthy, 5*time.Second)
+	newGs, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 5*time.Second)
 	// should be an error, as the state should not occur
 	if !assert.Error(t, err) {
 		assert.FailNow(t, "GameServer should not be Unhealthy")
@@ -374,7 +374,7 @@ func TestGameServerUnhealthyAfterReadyCrash(t *testing.T) {
 	l := logrus.WithField("test", "TestGameServerUnhealthyAfterReadyCrash")
 
 	gs := framework.DefaultGameServer(framework.Namespace)
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestGameServerUnhealthyAfterReadyCrash(t *testing.T) {
 			time.Sleep(5 * time.Second)
 		}
 	}()
-	_, err = framework.WaitForGameServerState(readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
+	_, err = framework.WaitForGameServerState(t, readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
 	assert.NoError(t, err)
 }
 
@@ -442,7 +442,7 @@ func TestDevelopmentGameServerLifecycle(t *testing.T) {
 			},
 		},
 	}
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -470,7 +470,7 @@ func TestGameServerSelfAllocate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	gs := framework.DefaultGameServer(framework.Namespace)
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -483,7 +483,7 @@ func TestGameServerSelfAllocate(t *testing.T) {
 	}
 
 	assert.Equal(t, "ACK: ALLOCATE\n", reply)
-	gs, err = framework.WaitForGameServerState(readyGs, agonesv1.GameServerStateAllocated, time.Minute)
+	gs, err = framework.WaitForGameServerState(t, readyGs, agonesv1.GameServerStateAllocated, time.Minute)
 	if assert.NoError(t, err) {
 		assert.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 	}
@@ -492,12 +492,12 @@ func TestGameServerSelfAllocate(t *testing.T) {
 func TestGameServerReadyAllocateReady(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := logrus.WithField("test", t.Name())
+	logger := e2eframework.TestLogger(t)
 
 	gs := framework.DefaultGameServer(framework.Namespace)
 
 	logger.Info("Moving to Ready")
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err, "Could not get a GameServer ready")
 	logger = logger.WithField("gs", readyGs.ObjectMeta.Name)
 
@@ -510,7 +510,7 @@ func TestGameServerReadyAllocateReady(t *testing.T) {
 	require.NoError(t, err, "Could not message GameServer")
 
 	require.Equal(t, "ACK: ALLOCATE\n", reply)
-	gs, err = framework.WaitForGameServerStateWithLogger(logger, readyGs, agonesv1.GameServerStateAllocated, time.Minute)
+	gs, err = framework.WaitForGameServerState(t, readyGs, agonesv1.GameServerStateAllocated, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 
@@ -518,9 +518,11 @@ func TestGameServerReadyAllocateReady(t *testing.T) {
 	reply, err = e2eframework.SendGameServerUDP(readyGs, "READY")
 	require.NoError(t, err, "Could not message GameServer")
 	require.Equal(t, "ACK: READY\n", reply)
-	gs, err = framework.WaitForGameServerStateWithLogger(logger, gs, agonesv1.GameServerStateReady, time.Minute)
+	gs, err = framework.WaitForGameServerState(t, gs, agonesv1.GameServerStateReady, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
+
+	framework.LogEvents(t, logrus.WithField("gs", gs.ObjectMeta.Name), gs)
 }
 
 func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
@@ -566,7 +568,7 @@ func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
 		},
 	}
 
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -614,7 +616,7 @@ func TestGameServerReserve(t *testing.T) {
 	// in a transitive state.
 
 	gs := framework.DefaultGameServer(framework.Namespace)
-	gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		assert.FailNow(t, "Could not get a GameServer ready", err.Error())
 	}
@@ -627,7 +629,7 @@ func TestGameServerReserve(t *testing.T) {
 	}
 	assert.Equal(t, "ACK: RESERVE 0\n", reply)
 
-	gs, err = framework.WaitForGameServerState(gs, agonesv1.GameServerStateReserved, 3*time.Minute)
+	gs, err = framework.WaitForGameServerState(t, gs, agonesv1.GameServerStateReserved, 3*time.Minute)
 	if err != nil {
 		assert.FailNow(t, "Time out on waiting for gs in a Reserved state", err.Error())
 	}
@@ -639,7 +641,7 @@ func TestGameServerReserve(t *testing.T) {
 	assert.Equal(t, "ACK: ALLOCATE\n", reply)
 
 	// put it in a totally different state, just to reset things.
-	gs, err = framework.WaitForGameServerState(gs, agonesv1.GameServerStateAllocated, 3*time.Minute)
+	gs, err = framework.WaitForGameServerState(t, gs, agonesv1.GameServerStateAllocated, 3*time.Minute)
 	if err != nil {
 		assert.FailNow(t, "Time out on waiting for gs in an Allocated state", err.Error())
 	}
@@ -652,7 +654,7 @@ func TestGameServerReserve(t *testing.T) {
 
 	// sleep, since we're going to wait for the Ready response.
 	time.Sleep(5 * time.Second)
-	_, err = framework.WaitForGameServerState(gs, agonesv1.GameServerStateReady, 3*time.Minute)
+	_, err = framework.WaitForGameServerState(t, gs, agonesv1.GameServerStateReady, 3*time.Minute)
 	assert.NoError(t, err)
 }
 
@@ -660,7 +662,7 @@ func TestGameServerShutdown(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	gs := framework.DefaultGameServer(framework.Namespace)
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
@@ -701,7 +703,7 @@ func TestGameServerEvicted(t *testing.T) {
 
 	logrus.WithField("name", newGs.ObjectMeta.Name).Info("GameServer created, waiting for being Evicted and Unhealthy")
 
-	_, err = framework.WaitForGameServerState(newGs, agonesv1.GameServerStateUnhealthy, 5*time.Minute)
+	_, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 5*time.Minute)
 
 	assert.Nil(t, err, fmt.Sprintf("waiting for %v GameServer Unhealthy state timed out (%v): %v", gs.Spec, gs.Name, err))
 }
@@ -715,7 +717,7 @@ func TestGameServerPassthroughPort(t *testing.T) {
 	_, valid := gs.Validate()
 	assert.True(t, valid)
 
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		assert.FailNow(t, "Could not get a GameServer ready", err.Error())
 	}
@@ -743,7 +745,7 @@ func TestGameServerTcpProtocol(t *testing.T) {
 	_, valid := gs.Validate()
 	require.True(t, valid)
 
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
 
 	replyTCP, err := e2eframework.SendGameServerTCP(readyGs, "Hello World !")
@@ -762,7 +764,7 @@ func TestGameServerTcpUdpProtocol(t *testing.T) {
 	_, valid := gs.Validate()
 	assert.True(t, valid)
 
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		assert.FailNow(t, "Could not get a GameServer ready", err.Error())
 	}
@@ -807,7 +809,7 @@ func TestGameServerWithoutPort(t *testing.T) {
 	_, valid := gs.Validate()
 	assert.True(t, valid)
 
-	readyGs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 
 	require.NoError(t, err, "Could not get a GameServer ready")
 	assert.Empty(t, readyGs.Spec.Ports)
@@ -914,7 +916,7 @@ func TestGameServerSetPlayerCapacity(t *testing.T) {
 
 	t.Run("no initial capacity set", func(t *testing.T) {
 		gs := framework.DefaultGameServer(framework.Namespace)
-		gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+		gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 		if err != nil {
 			t.Fatalf("Could not get a GameServer ready: %v", err)
 		}
@@ -952,7 +954,7 @@ func TestGameServerSetPlayerCapacity(t *testing.T) {
 	t.Run("initial capacity set", func(t *testing.T) {
 		gs := framework.DefaultGameServer(framework.Namespace)
 		gs.Spec.Players = &agonesv1.PlayersSpec{InitialCapacity: 10}
-		gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+		gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 		if err != nil {
 			t.Fatalf("Could not get a GameServer ready: %v", err)
 		}
@@ -1000,7 +1002,7 @@ func TestPlayerConnectAndDisconnect(t *testing.T) {
 	gs := framework.DefaultGameServer(framework.Namespace)
 	playerCount := int64(3)
 	gs.Spec.Players = &agonesv1.PlayersSpec{InitialCapacity: playerCount}
-	gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}

--- a/test/e2e/gameserverallocation_test.go
+++ b/test/e2e/gameserverallocation_test.go
@@ -360,7 +360,7 @@ func TestCreateFullFleetAndCantGameServerAllocate(t *testing.T) {
 				}
 			}
 
-			framework.AssertFleetCondition(t, flt, func(fleet *agonesv1.Fleet) bool {
+			framework.AssertFleetCondition(t, flt, func(log *logrus.Entry, fleet *agonesv1.Fleet) bool {
 				return fleet.Status.AllocatedReplicas == replicasCount
 			})
 
@@ -379,7 +379,7 @@ func TestGameServerAllocationMetaDataPatch(t *testing.T) {
 	gs := framework.DefaultGameServer(framework.Namespace)
 	gs.ObjectMeta.Labels = map[string]string{"test": t.Name()}
 
-	gs, err := framework.CreateGameServerAndWaitUntilReady(framework.Namespace, gs)
+	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if !assert.Nil(t, err) {
 		assert.FailNow(t, "could not create GameServer")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

A few things added to this PR to help combat/diagnose the e2e test flakines:

* Enhanced logging. Await for Fleet condition functions now log which test they are part of, and do dumps of gameserver state and events if a Fleet does not match the criteria.
* New logging methods, such as the ability to dump all an object's events.
* Retry on UDP message. Didn't seem to need this before (or only very rarely), but apparently do now.

**Which issue(s) this PR fixes**:

All of them.

**Special notes for your reviewer**:

🤞🏻 this makes a difference!
