### PR TITLE
Fix for health check race condition

### DIFF
--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -20,5 +20,5 @@ set -e
 echo "installing current release"
 DOCKER_RUN= make install FEATURE_GATES='"'$FEATURES'"'
 echo "starting e2e test"
-DOCKER_RUN= make test-e2e ARGS=-parallel=32 FEATURE_GATES='"'$FEATURES'"'
+DOCKER_RUN= make test-e2e ARGS=-parallel=16 FEATURE_GATES='"'$FEATURES'"'
 echo "completed e2e test"

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -46,7 +46,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["create", "delete", "list", "watch"]
+  verbs: ["create", "update", "delete", "list", "watch"]
 - apiGroups: [""]
   resources: ["nodes", "secrets"]
   verbs: ["list", "watch"]

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -13398,7 +13398,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["create", "delete", "list", "watch"]
+  verbs: ["create", "update", "delete", "list", "watch"]
 - apiGroups: [""]
   resources: ["nodes", "secrets"]
   verbs: ["list", "watch"]

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -237,8 +237,20 @@ func (hc *HealthController) skipUnhealthy(gs *agonesv1.GameServer) (bool, error)
 		// This is not the Pod we are looking for 🤖
 		return false, nil
 	}
+
+	// If the GameServer is before Ready, both annotation values should be ""
+	// If the GameServer is past Ready, both the annotations should be exactly the same.
+	// If they are annotations are different, then the data between the GameServer and the Pod is out of sync,
+	// in which case, send it back to the queue to try again.
+	gsReadyContainerID := gs.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation]
+	if pod.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation] != gsReadyContainerID {
+		return false, workerqueue.NewDebugError(errors.Errorf("pod and gameserver %s data are out of sync, retrying", gs.ObjectMeta.Name))
+	}
+
 	if gs.IsBeforeReady() {
 		hc.baseLogger.WithField("gs", gs.ObjectMeta.Name).WithField("state", gs.Status.State).Debug("skipUnhealthy: Is Before Ready. Checking failed container")
+		// If the reason for failure was a container failure, then we can skip moving to Unhealthy.
+		// otherwise, we know it was one of the other reasons (eviction, lack of ports), so we should definitely go to Unhealthy.
 		return hc.failedContainer(pod), nil
 	}
 
@@ -246,17 +258,23 @@ func (hc *HealthController) skipUnhealthy(gs *agonesv1.GameServer) (bool, error)
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == gs.Spec.Container {
 			if cs.State.Terminated != nil {
+				hc.baseLogger.WithField("gs", gs.ObjectMeta.Name).WithField("podStatus", pod.Status).Debug("skipUnhealthy: Container is terminated, returning false")
 				return false, nil
 			}
 			if cs.LastTerminationState.Terminated != nil {
 				// if the current container is running, and is the ready container, then we know this is some
 				// other pod update, and we previously had a restart before we got to being Ready, and therefore
 				// shouldn't move to Unhealthy.
-				return cs.ContainerID == gs.Annotations[agonesv1.GameServerReadyContainerIDAnnotation], nil
+				check := cs.ContainerID == gsReadyContainerID
+				if !check {
+					hc.baseLogger.WithField("gs", gs.ObjectMeta.Name).WithField("gsMeta", gs.ObjectMeta).WithField("podStatus", pod.Status).Debug("skipUnhealthy: Container crashed after Ready, returning false")
+				}
+				return check, nil
 			}
 			break
 		}
 	}
 
+	hc.baseLogger.WithField("gs", gs.ObjectMeta.Name).WithField("gsMeta", gs.ObjectMeta).WithField("podStatus", pod.Status).Debug("skipUnhealthy: Should not reach here")
 	return false, nil
 }

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -1155,7 +1155,7 @@ func TestFleetRecreateGameServers(t *testing.T) {
 			for _, gs := range list.Items {
 				gs := gs
 				var reply string
-				reply, err := e2e.SendGameServerUDP(&gs, "EXIT")
+				reply, err := framework.SendGameServerUDP(t, &gs, "EXIT")
 				if err != nil {
 					t.Fatalf("Could not message GameServer: %v", err)
 				}
@@ -1167,7 +1167,7 @@ func TestFleetRecreateGameServers(t *testing.T) {
 			for _, gs := range list.Items {
 				gs := gs
 				var reply string
-				reply, err := e2e.SendGameServerUDP(&gs, "UNHEALTHY")
+				reply, err := framework.SendGameServerUDP(t, &gs, "UNHEALTHY")
 				if err != nil {
 					t.Fatalf("Could not message GameServer: %v", err)
 				}
@@ -1332,7 +1332,7 @@ func TestFleetAggregatedPlayerStatus(t *testing.T) {
 		totalCapacity += capacity
 
 		msg := fmt.Sprintf("PLAYER_CAPACITY %d", capacity)
-		reply, err := e2e.SendGameServerUDP(gs, msg)
+		reply, err := framework.SendGameServerUDP(t, gs, msg)
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
@@ -1344,7 +1344,7 @@ func TestFleetAggregatedPlayerStatus(t *testing.T) {
 			logrus.WithField("msg", msg).WithField("gs", gs.ObjectMeta.Name).Info("Sending Player Connect")
 			// retry on failure. Will stop flakiness of UDP packets being sent/received.
 			err := wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
-				reply, err := e2e.SendGameServerUDP(gs, msg)
+				reply, err := framework.SendGameServerUDP(t, gs, msg)
 				if err != nil {
 					logrus.WithError(err).Warn("error with udp packet")
 					return false, nil

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -337,7 +338,7 @@ func TestAutoscalerStressCreate(t *testing.T) {
 			fas, err := fleetautoscalers.Create(ctx, fas, metav1.CreateOptions{})
 			if err == nil {
 				defer fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
-				assert.True(t, valid,
+				require.True(t, valid,
 					fmt.Sprintf("FleetAutoscaler created even if the parameters are NOT valid: %d %d %d",
 						bufferSize,
 						fas.Spec.Policy.Buffer.MinReplicas,
@@ -353,7 +354,7 @@ func TestAutoscalerStressCreate(t *testing.T) {
 				// the fleet autoscaler should scale the fleet now to expectedReplicas
 				framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(expectedReplicas))
 			} else {
-				assert.False(t, valid,
+				require.False(t, valid,
 					fmt.Sprintf("FleetAutoscaler NOT created even if the parameters are valid: %d %d %d (%s)",
 						bufferSize,
 						minReplicas,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -466,7 +466,7 @@ func (f *Framework) CreateAndApplyAllocation(t *testing.T, flt *agonesv1.Fleet) 
 // SendGameServerUDP sends a message to a gameserver and returns its reply
 // finds the first udp port from the spec to send the message to,
 // returns error if no Ports were allocated
-func SendGameServerUDP(gs *agonesv1.GameServer, msg string) (string, error) {
+func (f *Framework) SendGameServerUDP(t *testing.T, gs *agonesv1.GameServer, msg string) (string, error) {
 	if len(gs.Status.Ports) == 0 {
 		return "", errors.New("Empty Ports array")
 	}
@@ -474,7 +474,7 @@ func SendGameServerUDP(gs *agonesv1.GameServer, msg string) (string, error) {
 	// use first udp port
 	for _, p := range gs.Spec.Ports {
 		if p.Protocol == corev1.ProtocolUDP {
-			return SendGameServerUDPToPort(gs, p.Name, msg)
+			return f.SendGameServerUDPToPort(t, gs, p.Name, msg)
 		}
 	}
 	return "", errors.New("No UDP ports")
@@ -482,7 +482,8 @@ func SendGameServerUDP(gs *agonesv1.GameServer, msg string) (string, error) {
 
 // SendGameServerUDPToPort sends a message to a gameserver at the named port and returns its reply
 // returns error if no Ports were allocated or a port of the specified name doesn't exist
-func SendGameServerUDPToPort(gs *agonesv1.GameServer, portName string, msg string) (string, error) {
+func (f *Framework) SendGameServerUDPToPort(t *testing.T, gs *agonesv1.GameServer, portName string, msg string) (string, error) {
+	log := TestLogger(t)
 	if len(gs.Status.Ports) == 0 {
 		return "", errors.New("Empty Ports array")
 	}
@@ -493,42 +494,59 @@ func SendGameServerUDPToPort(gs *agonesv1.GameServer, portName string, msg strin
 		}
 	}
 	address := fmt.Sprintf("%s:%d", gs.Status.Address, port.Port)
-	return SendUDP(address, msg)
+	reply, err := f.SendUDP(t, address, msg)
+
+	if err != nil {
+		log.WithField("gs", gs.ObjectMeta.Name).WithField("status", fmt.Sprintf("%+v", gs.Status)).Info("Failed to send UDP packet to GameServer. Dumping Events!")
+		f.LogEvents(t, log, gs.ObjectMeta.Namespace, gs)
+	}
+
+	return reply, err
 }
 
 // SendUDP sends a message to an address, and returns its reply if
-// it returns one in 30 seconds
-func SendUDP(address, msg string) (string, error) {
-	conn, err := net.Dial("udp", address)
-	if err != nil {
-		return "", errors.Wrap(err, "could not dial GameServer address")
-	}
-	defer func() {
-		err = conn.Close()
-	}()
-
+// it returns one in 10 seconds. Will retry 5 times, in case UDP packets drop.
+func (f *Framework) SendUDP(t *testing.T, address, msg string) (string, error) {
+	log := TestLogger(t).WithField("address", address)
+	b := make([]byte, 1024)
+	var n int
 	// sometimes we get I/O timeout, so let's do a retry
-	err = wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
-		_, err := conn.Write([]byte(msg))
+	err := wait.PollImmediate(2*time.Second, time.Minute, func() (bool, error) {
+
+		conn, err := net.Dial("udp", address)
 		if err != nil {
-			logrus.WithError(err).Error("could not write message to GameServer")
+			log.WithError(err).Info("could not dial address")
+			return false, nil
 		}
+
+		defer func() {
+			err = conn.Close()
+		}()
+
+		_, err = conn.Write([]byte(msg))
+		if err != nil {
+			log.WithError(err).Info("could not write message to address")
+			return false, nil
+		}
+
+		err = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		if err != nil {
+			log.WithError(err).Info("Could not set read deadline")
+			return false, nil
+		}
+
+		n, err = conn.Read(b)
+		if err != nil {
+			log.WithError(err).Info("Could not read from address")
+		}
+
 		return err == nil, nil
 	})
+
 	if err != nil {
-		return "", errors.Wrap(err, "could not send message to GameServer after retries")
+		return "", errors.Wrap(err, "timed out attempting to send UDP packet to address")
 	}
 
-	b := make([]byte, 1024)
-
-	err = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
-	if err != nil {
-		return "", errors.Wrap(err, "could not set read deadline")
-	}
-	n, err := conn.Read(b)
-	if err != nil {
-		return "", errors.Wrap(err, "could not read response from the GameServer")
-	}
 	return string(b[:n]), nil
 }
 

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -58,7 +58,7 @@ func TestCreateConnect(t *testing.T) {
 	assert.NotEmpty(t, readyGs.Status.NodeName)
 	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
 
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "Hello World !")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "Hello World !")
 
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -78,7 +78,7 @@ func TestSDKSetLabel(t *testing.T) {
 	}
 
 	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "LABEL")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "LABEL")
 
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -116,7 +116,7 @@ func TestHealthCheckDisable(t *testing.T) {
 	}
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
-	_, err = e2eframework.SendGameServerUDP(readyGs, "UNHEALTHY")
+	_, err = framework.SendGameServerUDP(t, readyGs, "UNHEALTHY")
 
 	if err != nil {
 		t.Fatalf("Could not ping GameServer: %v", err)
@@ -145,7 +145,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "ANNOTATION")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "ANNOTATION")
 
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -183,7 +183,7 @@ func TestUnhealthyGameServerAfterHealthCheckFail(t *testing.T) {
 		assert.FailNow(t, "Failed to create a gameserver", err.Error())
 	}
 
-	reply, err := e2eframework.SendGameServerUDP(gs, "UNHEALTHY")
+	reply, err := framework.SendGameServerUDP(t, gs, "UNHEALTHY")
 	if err != nil {
 		assert.FailNow(t, "Failed to send a message to a gameserver", err.Error())
 	}
@@ -285,7 +285,7 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	logger.WithField("address", address).Info("Dialing UDP message to address")
 
 	messageAndWait := func(gs *agonesv1.GameServer, msg string, check func(gs *agonesv1.GameServer, pod *corev1.Pod) bool) error {
-		return wait.PollImmediate(3*time.Second, 3*time.Minute, func() (bool, error) {
+		return wait.PollImmediate(200*time.Millisecond, 3*time.Minute, func() (bool, error) {
 			gs, err := gsClient.Get(ctx, gs.ObjectMeta.Name, metav1.GetOptions{})
 			if err != nil {
 				logger.WithError(err).Warn("could not get gameserver")
@@ -477,7 +477,7 @@ func TestGameServerSelfAllocate(t *testing.T) {
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "ALLOCATE")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "ALLOCATE")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestGameServerReadyAllocateReady(t *testing.T) {
 	require.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
 
 	logger.Info("Moving to Allocated")
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "ALLOCATE")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "ALLOCATE")
 	require.NoError(t, err, "Could not message GameServer")
 
 	require.Equal(t, "ACK: ALLOCATE\n", reply)
@@ -515,7 +515,7 @@ func TestGameServerReadyAllocateReady(t *testing.T) {
 	require.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 
 	logger.Info("Moving to Ready again")
-	reply, err = e2eframework.SendGameServerUDP(readyGs, "READY")
+	reply, err = framework.SendGameServerUDP(t, readyGs, "READY")
 	require.NoError(t, err, "Could not message GameServer")
 	require.Equal(t, "ACK: READY\n", reply)
 	gs, err = framework.WaitForGameServerState(t, gs, agonesv1.GameServerStateReady, time.Minute)
@@ -578,7 +578,7 @@ func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
 
 	expectedMsg1 := "Ping 1"
 	errPoll := wait.PollImmediate(interval, timeOut, func() (done bool, err error) {
-		res, err := e2eframework.SendGameServerUDPToPort(readyGs, firstPort, expectedMsg1)
+		res, err := framework.SendGameServerUDPToPort(t, readyGs, firstPort, expectedMsg1)
 		if err != nil {
 			t.Logf("Could not message GameServer on %s: %v. Will try again...", firstPort, err)
 		}
@@ -590,7 +590,7 @@ func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
 
 	expectedMsg2 := "Ping 2"
 	errPoll = wait.PollImmediate(interval, timeOut, func() (done bool, err error) {
-		res, err := e2eframework.SendGameServerUDPToPort(readyGs, secondPort, expectedMsg2)
+		res, err := framework.SendGameServerUDPToPort(t, readyGs, secondPort, expectedMsg2)
 		if err != nil {
 			t.Logf("Could not message GameServer on %s: %v. Will try again...", secondPort, err)
 		}
@@ -621,7 +621,7 @@ func TestGameServerReserve(t *testing.T) {
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, gs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 	assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
 
-	reply, err := e2eframework.SendGameServerUDP(gs, "RESERVE 0")
+	reply, err := framework.SendGameServerUDP(t, gs, "RESERVE 0")
 	if err != nil {
 		assert.FailNow(t, "Could not message GameServer", err.Error())
 	}
@@ -632,7 +632,7 @@ func TestGameServerReserve(t *testing.T) {
 		assert.FailNow(t, "Time out on waiting for gs in a Reserved state", err.Error())
 	}
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "ALLOCATE")
+	reply, err = framework.SendGameServerUDP(t, gs, "ALLOCATE")
 	if err != nil {
 		assert.FailNow(t, "Could not message GameServer", err.Error())
 	}
@@ -644,7 +644,7 @@ func TestGameServerReserve(t *testing.T) {
 		assert.FailNow(t, "Time out on waiting for gs in an Allocated state", err.Error())
 	}
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "RESERVE 5s")
+	reply, err = framework.SendGameServerUDP(t, gs, "RESERVE 5s")
 	if err != nil {
 		assert.FailNow(t, "Could not message GameServer", err.Error())
 	}
@@ -666,7 +666,7 @@ func TestGameServerShutdown(t *testing.T) {
 	}
 	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
 
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "EXIT")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "EXIT")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
@@ -725,7 +725,7 @@ func TestGameServerPassthroughPort(t *testing.T) {
 	assert.NotEmpty(t, port.HostPort)
 	assert.Equal(t, port.HostPort, port.ContainerPort)
 
-	reply, err := e2eframework.SendGameServerUDP(readyGs, "Hello World !")
+	reply, err := framework.SendGameServerUDP(t, readyGs, "Hello World !")
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
 	}
@@ -781,7 +781,7 @@ func TestGameServerTcpUdpProtocol(t *testing.T) {
 
 	logrus.WithField("name", readyGs.ObjectMeta.Name).Info("GameServer created, sending UDP ping")
 
-	replyUDP, err := e2eframework.SendGameServerUDPToPort(readyGs, udpPort.Name, "Hello World !")
+	replyUDP, err := framework.SendGameServerUDPToPort(t, readyGs, udpPort.Name, "Hello World !")
 	require.NoError(t, err)
 	if err != nil {
 		t.Fatalf("Could not ping UDP GameServer: %v", err)
@@ -921,19 +921,19 @@ func TestGameServerSetPlayerCapacity(t *testing.T) {
 		assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
 		assert.Equal(t, int64(0), gs.Status.Players.Capacity)
 
-		reply, err := e2eframework.SendGameServerUDP(gs, "PLAYER_CAPACITY")
+		reply, err := framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY")
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
 		assert.Equal(t, "0\n", reply)
 
-		reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_CAPACITY 20")
+		reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY 20")
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
 		assert.Equal(t, "ACK: PLAYER_CAPACITY 20\n", reply)
 
-		reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_CAPACITY")
+		reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY")
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
@@ -959,19 +959,19 @@ func TestGameServerSetPlayerCapacity(t *testing.T) {
 		assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
 		assert.Equal(t, int64(10), gs.Status.Players.Capacity)
 
-		reply, err := e2eframework.SendGameServerUDP(gs, "PLAYER_CAPACITY")
+		reply, err := framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY")
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
 		assert.Equal(t, "10\n", reply)
 
-		reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_CAPACITY 20")
+		reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY 20")
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
 		assert.Equal(t, "ACK: PLAYER_CAPACITY 20\n", reply)
 
-		reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_CAPACITY")
+		reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY")
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
@@ -1011,7 +1011,7 @@ func TestPlayerConnectAndDisconnect(t *testing.T) {
 	for i := int64(1); i <= playerCount; i++ {
 		msg := "PLAYER_CONNECT " + fmt.Sprintf("%d", i)
 		logrus.WithField("msg", msg).Info("Sending Player Connect")
-		reply, err := e2eframework.SendGameServerUDP(gs, msg)
+		reply, err := framework.SendGameServerUDP(t, gs, msg)
 		if err != nil {
 			t.Fatalf("Could not message GameServer: %v", err)
 		}
@@ -1020,19 +1020,19 @@ func TestPlayerConnectAndDisconnect(t *testing.T) {
 
 	// deliberately do this before polling, to test the SDK returning the correct
 	// results before it is committed to the GameServer resource.
-	reply, err := e2eframework.SendGameServerUDP(gs, "PLAYER_CONNECTED 1")
+	reply, err := framework.SendGameServerUDP(t, gs, "PLAYER_CONNECTED 1")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
 	assert.Equal(t, "true\n", reply)
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "GET_PLAYERS")
+	reply, err = framework.SendGameServerUDP(t, gs, "GET_PLAYERS")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
 	assert.ElementsMatch(t, []string{"1", "2", "3"}, strings.Split(strings.TrimSpace(reply), ","))
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_COUNT")
+	reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_COUNT")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
@@ -1050,25 +1050,25 @@ func TestPlayerConnectAndDisconnect(t *testing.T) {
 
 	// let's disconnect player 2
 	logrus.Info("Disconnect Player 2")
-	reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_DISCONNECT 2")
+	reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_DISCONNECT 2")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
 	assert.Equal(t, "ACK: PLAYER_DISCONNECT 2\n", reply)
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_CONNECTED 2")
+	reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_CONNECTED 2")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
 	assert.Equal(t, "false\n", reply)
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "GET_PLAYERS")
+	reply, err = framework.SendGameServerUDP(t, gs, "GET_PLAYERS")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
 	assert.ElementsMatch(t, []string{"1", "3"}, strings.Split(strings.TrimSpace(reply), ","))
 
-	reply, err = e2eframework.SendGameServerUDP(gs, "PLAYER_COUNT")
+	reply, err = framework.SendGameServerUDP(t, gs, "PLAYER_COUNT")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"testing"
 
-	e2eframework "agones.dev/agones/test/e2e/framework"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -89,7 +88,7 @@ func TestPingUDP(t *testing.T) {
 	assert.Nil(t, err)
 
 	expected := "hello"
-	reply, err := e2eframework.SendUDP(fmt.Sprintf("%s:%d", externalIP, p), expected)
+	reply, err := framework.SendUDP(t, fmt.Sprintf("%s:%d", externalIP, p), expected)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, reply)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:


The Pod and GameServer data in the Informer cache are eventually consistent and can result in data races.

This fix ensures that they are in sync at the time that the GameServer is moved to Ready, so that Health checking can behave correctly if a crash occurs after the fact.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This also includes a combination of smaller fixes/debug for e2e flakiness,
as we narrowed down the problem.

* Retries on UDP packet sending
* Failing on UDP packet sending dumps gameserver details
* Drop parallelism on e2e tests from 32 to 16.
