### PR TITLE
Move the agones sidecar containers to the beginning of the list of containers

### DIFF
--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -606,7 +606,11 @@ func (gs *GameServer) Pod(sidecars ...corev1.Container) (*corev1.Pod, error) {
 			return nil, err
 		}
 	}
-	pod.Spec.Containers = append(pod.Spec.Containers, sidecars...)
+	// Put the sidecars at the start of the list of containers so that the kubelet starts them first.
+	containers := make([]corev1.Container, 0, len(sidecars)+len(pod.Spec.Containers))
+	containers = append(containers, sidecars...)
+	containers = append(containers, pod.Spec.Containers...)
+	pod.Spec.Containers = containers
 
 	gs.podScheduling(pod)
 

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -1205,8 +1205,8 @@ func TestGameServerPodWithSidecarNoErrors(t *testing.T) {
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 	assert.Len(t, pod.Spec.Containers, 2, "Should have two containers")
 	assert.Equal(t, "other-agones-sdk", pod.Spec.ServiceAccountName)
-	assert.Equal(t, "container", pod.Spec.Containers[0].Name)
-	assert.Equal(t, "sidecar", pod.Spec.Containers[1].Name)
+	assert.Equal(t, "sidecar", pod.Spec.Containers[0].Name)
+	assert.Equal(t, "container", pod.Spec.Containers[1].Name)
 	assert.True(t, metav1.IsControlledBy(pod, fixture))
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**: This will cause the kubelet starts them first. See  https://medium.com/@marko.luksa/delaying-application-start-until-sidecar-is-ready-2ec2d21a7b74

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2355

**Special notes for your reviewer**:


