### PR TITLE
Remove mention of the SDKWatchSendOnExecute feature gate in a comment in sdkserver_test.go

### DIFF
--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -1556,9 +1556,8 @@ func waitConnectedStreamCount(sc *SDKServer, count int) error {
 }
 
 func asyncWatchGameServer(t *testing.T, sc *SDKServer, stream sdk.SDK_WatchGameServerServer) {
-	// Note that new FeatureSDKWatchSendOnExecute feature gate
-	// uses getGameServer() function and therefore WatchGameServer()
-	// would block if gsWaitForSync is not Done().
+	// Note that WatchGameServer() uses getGameServer() and would block
+	// if gsWaitForSync is not Done().
 	go func() {
 		err := sc.WatchGameServer(&sdk.Empty{}, stream)
 		require.NoError(t, err)


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Cleans up a comment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Part of #2238

**Special notes for your reviewer**:
This was the last unresolved comment from #2353

