### PR TITLE
Fixed missing "const" parameter for SetAnnotation & SetLabels.

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -240,7 +240,7 @@ void UAgonesComponent::HandleWatchMessage(const void* Data, SIZE_T Size, SIZE_T 
 }
 
 void UAgonesComponent::SetLabel(
-	FString& Key, FString& Value, const FSetLabelDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
+	const FString& Key, const FString& Value, const FSetLabelDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	const FKeyValuePair Label = {Key, Value};
 	FString Json;
@@ -300,7 +300,7 @@ void UAgonesComponent::Shutdown(const FShutdownDelegate SuccessDelegate, const F
 }
 
 void UAgonesComponent::SetAnnotation(
-	FString& Key, FString& Value, const FSetAnnotationDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
+	const FString& Key, const FString& Value, const FSetAnnotationDelegate SuccessDelegate, const FAgonesErrorDelegate ErrorDelegate)
 {
 	const FKeyValuePair Label = {Key, Value};
 	FString Json;

--- a/sdks/unreal/Agones/Source/Agones/Public/AgonesComponent.h
+++ b/sdks/unreal/Agones/Source/Agones/Public/AgonesComponent.h
@@ -207,7 +207,7 @@ public:
 	 * \param ErrorDelegate - Called on Unsuccessful call.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Agones | Metadata")
-	void SetAnnotation(FString& Key, FString& Value, FSetAnnotationDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate);
+	void SetAnnotation(const FString& Key, const FString& Value, FSetAnnotationDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate);
 
 	/**
 	 * \brief SetLabel sets a metadata label on the `GameServer` with the prefix 'agones.dev/sdk-'
@@ -218,7 +218,7 @@ public:
 	 * \param ErrorDelegate - Called on Unsuccessful call.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Agones | Metadata")
-	void SetLabel(FString& Key, FString& Value, FSetLabelDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate);
+	void SetLabel(const FString& Key, const FString& Value, FSetLabelDelegate SuccessDelegate, FAgonesErrorDelegate ErrorDelegate);
 
 	/**
 	 * \brief Shutdown marks the Game Server as ready to shutdown


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

/king bug

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2411 

**Special notes for your reviewer**:

```
1>------ Build started: Project: Agones2411, Configuration: Development_Editor x64 ------
1>Building Agones2411Editor...
1>Using Visual Studio 2019 14.29.30138 toolchain (C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133) and Windows 10.0.19041.0 SDK (C:\Program Files (x86)\Windows Kits\10).
1>Building 4 actions with 24 processes...
1>  [1/4] Module.Agones.cpp
1>  [2/4] UE4Editor-Agones.lib
1>     Creating library C:\Git\Agones2411\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.lib and object C:\Git\Agones2411\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.exp
1>  [3/4] UE4Editor-Agones.dll
1>     Creating library C:\Git\Agones2411\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.suppressed.lib and object C:\Git\Agones2411\Plugins\Agones\Intermediate\Build\Win64\UE4Editor\Development\Agones\UE4Editor-Agones.suppressed.exp
1>  [4/4] Agones2411Editor.target
1>Total time in Parallel executor: 2,58 seconds
1>Total execution time: 2,98 seconds
========== Build: 1 succeeded, 0 failed, 
```


