### PR TITLE
Generating TLS certificates for agones controller and admissions cont…

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -37,7 +37,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: {{ .Values.agones.controller.safeToEvict | quote }}
-{{- if .Values.agones.controller.generateTLS }}
+{{- if .Values.agones.controller.generateTLS | and (not .Values.agones.controller.reuseGeneratedTLS) }}
         revision/tls-cert: {{ .Release.Revision | quote }}
 {{- end }}
 {{- if and (.Values.agones.metrics.prometheusServiceDiscovery) (.Values.agones.metrics.prometheusEnabled) }}

--- a/install/helm/agones/templates/extensions.yaml
+++ b/install/helm/agones/templates/extensions.yaml
@@ -11,11 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- $ca := genCA "admission-controller-ca" 3650 }}
-{{- $cn := printf "agones-controller-service" }}
-{{- $altName1 := printf "agones-controller-service.%s"  .Release.Namespace }}
-{{- $altName2 := printf "agones-controller-service.%s.svc" .Release.Namespace }}
-{{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
+{{- $certCert := "" }}
+{{- $certKey := "" }}
+{{- if .Values.agones.controller.generateTLS }}
+  {{- $previous := lookup "v1" "Secret" .Release.Namespace (include "agones.fullname" . | printf "%s-cert") }}
+  {{- if $previous | and .Values.agones.controller.reuseGeneratedTLS }}
+    {{- $certCert = index $previous.data "server.crt" | b64dec }}
+    {{- $certKey = index $previous.data "server.key" | b64dec }}
+  {{- else }}
+    {{- $ca := genCA "admission-controller-ca" 3650 }}
+    {{- $cn := printf "agones-controller-service" }}
+    {{- $altName1 := printf "agones-controller-service.%s"  .Release.Namespace }}
+    {{- $altName2 := printf "agones-controller-service.%s.svc" .Release.Namespace }}
+    {{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
+    {{- $certCert = $cert.Cert }}
+    {{- $certKey = $cert.Key }}
+  {{- end }}
+{{- end }}
 ---
 {{- if .Values.agones.registerApiService }}
 apiVersion: apiregistration.k8s.io/v1
@@ -35,11 +47,11 @@ spec:
   service:
     name: agones-controller-service
     namespace: {{ .Release.Namespace }}
-        {{- if .Values.agones.controller.generateTLS }}
-  caBundle: {{ b64enc $ca.Cert }}
-        {{- else }}
+{{- if .Values.agones.controller.generateTLS }}
+  caBundle: {{ b64enc $certCert }}
+{{- else }}
   caBundle: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
-        {{- end }}
+{{- end }}
   version: v1
 {{- end}}
 {{- if .Values.agones.registerWebhooks }}
@@ -66,7 +78,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /validate
 {{- if .Values.agones.controller.generateTLS }}
-      caBundle: {{ b64enc $ca.Cert }}
+      caBundle: {{ b64enc $certCert }}
 {{- else }}
       caBundle: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
 {{- end }}
@@ -123,7 +135,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /mutate
 {{- if .Values.agones.controller.generateTLS }}
-      caBundle: {{ b64enc $ca.Cert }}
+      caBundle: {{ b64enc $certCert }}
 {{- else }}
       caBundle: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
 {{- end }}
@@ -161,8 +173,8 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.agones.controller.generateTLS }}
-  server.crt: {{ b64enc $cert.Cert }}
-  server.key: {{ b64enc $cert.Key }}
+  server.crt: {{ b64enc $certCert }}
+  server.key: {{ b64enc $certKey }}
 {{- else }}
   server.crt: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
   server.key: {{ default (.Files.Get "certs/server.key") .Values.agones.controller.tlsKey | b64enc }}

--- a/install/helm/agones/templates/extensions.yaml
+++ b/install/helm/agones/templates/extensions.yaml
@@ -11,21 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- $certCert := "" }}
-{{- $certKey := "" }}
+{{- $cert := "" }}
+{{- $key := "" }}
 {{- if .Values.agones.controller.generateTLS }}
   {{- $previous := lookup "v1" "Secret" .Release.Namespace (include "agones.fullname" . | printf "%s-cert") }}
   {{- if $previous | and .Values.agones.controller.reuseGeneratedTLS }}
-    {{- $certCert = index $previous.data "server.crt" | b64dec }}
-    {{- $certKey = index $previous.data "server.key" | b64dec }}
+    {{- $cert = index $previous.data "server.crt" | b64dec }}
+    {{- $key = index $previous.data "server.key" | b64dec }}
   {{- else }}
-    {{- $ca := genCA "admission-controller-ca" 3650 }}
-    {{- $cn := printf "agones-controller-service" }}
+    {{- $cn := printf "agones-controller-service.%s.svc" .Release.Namespace }}
     {{- $altName1 := printf "agones-controller-service.%s"  .Release.Namespace }}
     {{- $altName2 := printf "agones-controller-service.%s.svc" .Release.Namespace }}
-    {{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
-    {{- $certCert = $cert.Cert }}
-    {{- $certKey = $cert.Key }}
+    {{- $certObj := genSelfSignedCert $cn nil (list $altName1 $altName2) 3650 }}
+    {{- $cert = $certObj.Cert }}
+    {{- $key = $certObj.Key }}
   {{- end }}
 {{- end }}
 ---
@@ -48,7 +47,7 @@ spec:
     name: agones-controller-service
     namespace: {{ .Release.Namespace }}
 {{- if .Values.agones.controller.generateTLS }}
-  caBundle: {{ b64enc $certCert }}
+  caBundle: {{ b64enc $cert }}
 {{- else }}
   caBundle: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
 {{- end }}
@@ -78,7 +77,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /validate
 {{- if .Values.agones.controller.generateTLS }}
-      caBundle: {{ b64enc $certCert }}
+      caBundle: {{ b64enc $cert }}
 {{- else }}
       caBundle: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
 {{- end }}
@@ -135,7 +134,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /mutate
 {{- if .Values.agones.controller.generateTLS }}
-      caBundle: {{ b64enc $certCert }}
+      caBundle: {{ b64enc $cert }}
 {{- else }}
       caBundle: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
 {{- end }}
@@ -173,8 +172,8 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.agones.controller.generateTLS }}
-  server.crt: {{ b64enc $certCert }}
-  server.key: {{ b64enc $certKey }}
+  server.crt: {{ b64enc $cert }}
+  server.key: {{ b64enc $key }}
 {{- else }}
   server.crt: {{ default (.Files.Get "certs/server.crt") .Values.agones.controller.tlsCert | b64enc }}
   server.key: {{ default (.Files.Get "certs/server.key") .Values.agones.controller.tlsKey | b64enc }}

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -65,7 +65,7 @@ agones:
               - key: agones.dev/agones-system
                 operator: Exists
     generateTLS: true
-    reuseGeneratedTLS: true
+    reuseGeneratedTLS: false
     tlsCert: ""
     tlsKey: ""
     safeToEvict: false

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -65,6 +65,7 @@ agones:
               - key: agones.dev/agones-system
                 operator: Exists
     generateTLS: true
+    reuseGeneratedTLS: true
     tlsCert: ""
     tlsKey: ""
     safeToEvict: false

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -120,6 +120,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.controller.healthCheck.timeoutSeconds`      | Number of seconds after which the probe times out (in seconds)                                  | `1`                    |
 | `agones.controller.resources`                       | Controller [resource requests/limit][resources]                                                 | `{}`                   |
 | `agones.controller.generateTLS`                     | Set to true to generate TLS certificates or false to provide your own certificates              | `true`                 |
+| `agones.controller.reuseGeneratedTLS`               | Set to true to reuse generated TLS certificates with lookup existing secrets                    | `true`                 |
 | `agones.controller.tlsCert`                         | Custom TLS certificate provided as a string                                                     | \`\`                   |
 | `agones.controller.tlsKey`                          | Custom TLS private key provided as a string                                                     | \`\`                   |
 | `agones.controller.nodeSelector`                    | Controller [node labels][nodeSelector] for pod assignment                                       | `{}`                   |
@@ -275,8 +276,10 @@ That means that you skipped the `--cleanup` flag and you should either delete th
 
 ## Controller TLS Certificates
 
-By default agones chart generates tls certificates used by the admission controller, while this is handy, it requires the agones controller to restart on each `helm upgrade` command.
-For most use cases the controller would have required a restart anyway (eg: controller image updated). However if you really need to avoid restarts we suggest that you turn off tls automatic generation (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).
+By default agones chart generates tls certificates used by the admission controller and reuses them on each `helm upgrade` command using `lookup` templating function.
+This prevents agones controller from restart during update of values not related to controller itself (especially when using agones as a subchart dependency in umbrella charts).
+To turn off this feature and generate tls certificates on each `helm upgrade` command (e.g. to force integrity between versions) set `agones.controller.reuseGeneratedTLS` to `false`.
+Another approach to avoid restarts and having more control we suggest that you turn off tls automatic generation (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).
 
 {{< alert title="Tip" color="info">}}
 You can use our script located at {{< ghlink href="install/helm/agones/certs/cert.sh" >}}cert.sh{{< /ghlink >}} to generate them.

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -120,7 +120,6 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.controller.healthCheck.timeoutSeconds`      | Number of seconds after which the probe times out (in seconds)                                  | `1`                    |
 | `agones.controller.resources`                       | Controller [resource requests/limit][resources]                                                 | `{}`                   |
 | `agones.controller.generateTLS`                     | Set to true to generate TLS certificates or false to provide your own certificates              | `true`                 |
-| `agones.controller.reuseGeneratedTLS`               | Set to true to reuse generated TLS certificates with lookup existing secrets                    | `true`                 |
 | `agones.controller.tlsCert`                         | Custom TLS certificate provided as a string                                                     | \`\`                   |
 | `agones.controller.tlsKey`                          | Custom TLS private key provided as a string                                                     | \`\`                   |
 | `agones.controller.nodeSelector`                    | Controller [node labels][nodeSelector] for pod assignment                                       | `{}`                   |
@@ -209,6 +208,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 | Parameter                                           | Description                                                                                     | Default                |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
+| `agones.controller.reuseGeneratedTLS`               | Set to true to reuse generated TLS certificates with lookup existing secrets                    | `false`                |
 |                       |                           |                            |
 {{% /feature %}}
 
@@ -276,14 +276,24 @@ That means that you skipped the `--cleanup` flag and you should either delete th
 
 ## Controller TLS Certificates
 
-By default agones chart generates tls certificates used by the admission controller and reuses them on each `helm upgrade` command using `lookup` templating function.
-This prevents agones controller from restart during update of values not related to controller itself (especially when using agones as a subchart dependency in umbrella charts).
-To turn off this feature and generate tls certificates on each `helm upgrade` command (e.g. to force integrity between versions) set `agones.controller.reuseGeneratedTLS` to `false`.
-Another approach to avoid restarts and having more control we suggest that you turn off tls automatic generation (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).
+{{% feature expiryVersion="1.21.0" %}}
+By default agones chart generates tls certificates used by the admission controller, while this is handy, it requires the agones controller to restart on each `helm upgrade` command.
+For most use cases the controller would have required a restart anyway (eg: controller image updated). However if you really need to avoid restarts we suggest that you turn off tls automatic generation (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).
 
 {{< alert title="Tip" color="info">}}
 You can use our script located at {{< ghlink href="install/helm/agones/certs/cert.sh" >}}cert.sh{{< /ghlink >}} to generate them.
 {{< /alert >}}
+{{% /feature %}}
+{{% feature publishVersion="1.21.0" %}}
+By default agones chart generates tls certificates used by the admission controller, while this is handy, it requires the agones controller to restart on each `helm upgrade` command.
+For most use cases the controller would have required a restart anyway (eg: controller image updated).
+However if you need to avoid restarts (especially when using agones as a subchart dependency in umbrella charts) set `agones.controller.reuseGeneratedTLS` to `true`.
+Another approach to avoid the controller restarting during an upgrade is to turn off automatic TLS certificate generation altogether (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).
+
+{{< alert title="Tip" color="info">}}
+You can use our script located at {{< ghlink href="install/helm/agones/certs/cert.sh" >}}cert.sh{{< /ghlink >}} to generate them.
+{{< /alert >}}
+{{% /feature %}}
 
 ## Reserved Allocator Load Balancer IP
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / Why we need it**:
This PR is extending generating tls certificates functionality for painless integration of agones to umbrella charts.

**Which issue(s) this PR fixes**:
Closes #2389 

**Special notes for your reviewer**:
Helm upgrades was tested on microk8s using command
```
microk8s.helm3 upgrade --install agones . --set agones.ping.install=false --set agones.allocator.install=false
```
with various state transitions including:
- changing from reusing and not reusing generated tls certs
- disabling generation of tls and then reusing certs provided from file
and checking whether allocation and fleet status check (force admission controller to run and use certs for requests) is working

I think allocator also needs this feature but it would be a little bit more complex.