### PR TITLE
Remove curl|bash from dockerfile to address vulnerability issues

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:buster
 
 RUN apt-get update && \
     apt-get install -y build-essential gnupg curl git wget psmisc rsync make python bash-completion \
-    zip nano jq graphviz gettext-base plantuml && \
+    zip nano jq graphviz gettext-base plantuml software-properties-common && \
     apt-get clean
 
 # install go
@@ -39,7 +39,7 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && un
 ENV PATH /usr/local/go/bin:/go/bin:/opt/google-cloud-sdk/bin:$PATH
 
 # install go tooling for development, building and testing
-RUN go get -u golang.org/x/tools/cmd/goimports
+RUN go install golang.org/x/tools/cmd/goimports@latest
 
 # RUN gcloud components update
 RUN gcloud components update && gcloud components install app-engine-go
@@ -68,7 +68,7 @@ RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
 RUN echo "source <(helm completion bash)" >> /root/.bashrc
 
 # install golang-ci linter
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.42.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
 
 #
 #  \ \      / /__| |__  ___(_) |_ ___
@@ -84,8 +84,21 @@ RUN mkdir /tmp/hugo && \
     mv /tmp/hugo/hugo /usr/local/bin/ && \
     rm -r /tmp/hugo
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+RUN add-apt-repository -y -r ppa:chris-lea/node.js
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list.save
+
+ARG KEYRING=/usr/share/keyrings/nodesource.gpg
+ARG VERSION=node_12.x
+
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
+RUN gpg --no-default-keyring --keyring "$KEYRING" --list-keys
+
+ARG DISTRO="jessie"
+RUN echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && apt-get install -y nodejs
 
 # install API reference docs generator
 RUN mkdir -p /go/src/github.com/ahmetb && \

--- a/build/build-sdk-images/node/Dockerfile
+++ b/build/build-sdk-images/node/Dockerfile
@@ -16,8 +16,23 @@ FROM $BASE_IMAGE
 
 ## --allow-releaseinfo-change is a workaround for the new debian release
 ## Can be removed when upgrading to bullseye
-RUN apt-get --allow-releaseinfo-change update && curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y curl && apt-get install -y software-properties-common && \
+    apt-get install -y gnupg && apt-get clean
+RUN add-apt-repository -y -r ppa:chris-lea/node.js
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list.save
+
+ARG KEYRING=/usr/share/keyrings/nodesource.gpg
+ARG VERSION=node_12.x
+
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
+RUN gpg --no-default-keyring --keyring "$KEYRING" --list-keys
+
+ARG DISTRO="jessie"
+RUN echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && apt-get install -y nodejs
 
 # Installing request is to address a bug with node-pre-gyp
 RUN npm install --unsafe-perm --global request@2.88.2 grpc-tools@1.8.1

--- a/build/build-sdk-images/restapi/Dockerfile
+++ b/build/build-sdk-images/restapi/Dockerfile
@@ -15,7 +15,7 @@ ARG BASE_IMAGE=agones-build-sdk-base:latest
 FROM $BASE_IMAGE
 
 RUN apt-get --allow-releaseinfo-change update && \
-    apt-get install -y wget jq && \
+    apt-get install -y wget jq software-properties-common gnupg && \
     apt-get clean
 
 # install go
@@ -27,8 +27,21 @@ RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir -p ${GOPATH}
 
 RUN echo '§' && apt-get -qy update 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -qq -y nodejs
+RUN add-apt-repository -y -r ppa:chris-lea/node.js
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list.save
+
+ARG KEYRING=/usr/share/keyrings/nodesource.gpg
+ARG VERSION=node_12.x
+
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
+RUN gpg --no-default-keyring --keyring "$KEYRING" --list-keys
+
+ARG DISTRO="jessie"
+RUN echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && apt-get install -y nodejs
 
 RUN apt-get install -qq -y openjdk-11-jre > /dev/null
 

--- a/examples/nodejs-simple/Dockerfile
+++ b/examples/nodejs-simple/Dockerfile
@@ -14,9 +14,24 @@
 
 FROM debian:buster
 RUN useradd -u 1000 -m server
-RUN apt-get update && apt-get install -y curl  && apt-get clean
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+RUN apt-get update && apt-get install -y curl software-properties-common gnupg  && \
+    apt-get clean
+
+RUN add-apt-repository -y -r ppa:chris-lea/node.js
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list
+RUN rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list.save
+
+ARG KEYRING=/usr/share/keyrings/nodesource.gpg
+ARG VERSION=node_12.x
+
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
+RUN gpg --no-default-keyring --keyring "$KEYRING" --list-keys
+
+ARG DISTRO="jessie"
+RUN echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && apt-get install -y nodejs
 
 WORKDIR /home/server
 

--- a/examples/nodejs-simple/Makefile
+++ b/examples/nodejs-simple/Makefile
@@ -28,7 +28,7 @@ REPOSITORY = gcr.io/agones-images
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/nodejs-simple-server:0.5
+server_tag = $(REPOSITORY)/nodejs-simple-server:0.6
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/nodejs-simple/README.md
+++ b/examples/nodejs-simple/README.md
@@ -42,7 +42,7 @@ $ make run
 
 The example can also be run via docker:
 ```
-$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5
+$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.6
 ```
 Or directly via npm:
 ```
@@ -51,7 +51,7 @@ $ npm start
 
 You will see the output like the following:
 ```
-docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5
+docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.6
 
 > @ start /home/server/examples/nodejs-simple
 > node src/index.js
@@ -63,7 +63,7 @@ Connecting to the SDK server...
 To see help, pass `--help` as the argument (use the preferred command below, all are equivalent):
 ```
 $ make args="--help" run
-$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5 --help
+$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.6 --help
 $ npm start -- --help
 ```
 
@@ -71,14 +71,14 @@ You can optionally specify how long the server will stay up once the basic tests
 To do this pass arguments through, e.g. to increase the shutdown duration to 120 seconds:
 ```
 $ make args="--timeout=120" run
-$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5 --timeout=120
+$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.6 --timeout=120
 $ npm start -- --timeout=120
 ```
 
 To make run indefinitely use the special timeout value of 0:
 ```
 $ make args="--timeout=0" run
-$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5 --timeout=0
+$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.6 --timeout=0
 $ npm start -- --timeout=0
 ```
 
@@ -90,6 +90,6 @@ $ cd ../../build; make run-sdk-conformance-local TIMEOUT=120 FEATURE_GATES="Play
 Then enable the alpha suite:
 ```
 $ make args="--alpha" run
-$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.5 --alpha
+$ docker run --network=host gcr.io/agones-images/nodejs-simple-server:0.6 --alpha
 $ npm start -- --alpha
 ```

--- a/examples/nodejs-simple/gameserver.yaml
+++ b/examples/nodejs-simple/gameserver.yaml
@@ -32,5 +32,5 @@ spec:
     spec:
       containers:
       - name: nodejs-simple
-        image: gcr.io/agones-images/nodejs-simple-server:0.5
+        image: gcr.io/agones-images/nodejs-simple-server:0.6
         # args: ["--timeout=0"] # Change the timeout here, if you like the nodejs server to run longer.

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -49,10 +49,12 @@ func (t testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	res, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	err = json.Unmarshal(res, &faRequest)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	// return different errors for tests
@@ -65,6 +67,7 @@ func (t testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_, err = io.WriteString(w, "invalid data")
 		if err != nil {
 			http.Error(w, "Error writing json from /address", http.StatusInternalServerError)
+			return
 		}
 	}
 
@@ -88,11 +91,13 @@ func (t testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	result, err := json.Marshal(&review)
 	if err != nil {
 		http.Error(w, "Error marshaling json", http.StatusInternalServerError)
+		return
 	}
 
 	_, err = io.WriteString(w, string(result))
 	if err != nil {
 		http.Error(w, "Error writing json from /address", http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/pkg/util/apiserver/apiserver.go
+++ b/pkg/util/apiserver/apiserver.go
@@ -98,6 +98,7 @@ func NewAPIServer(mux *http.ServeMux) *APIServer {
 		if err != nil {
 			s.logger.WithError(errors.WithStack(err)).Error("error return openapi")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 	})
 

--- a/pkg/util/https/https.go
+++ b/pkg/util/https/https.go
@@ -53,6 +53,7 @@ func ErrorHTTPHandler(logger *logrus.Entry, f ErrorHandlerFunc) http.HandlerFunc
 		if err != nil {
 			runtime.HandleError(LogRequest(logger, r), err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 	}
 }

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -370,7 +370,7 @@ func patchFleetAutoscaler(ctx context.Context, fas *autoscalingv1.FleetAutoscale
 	if bufferSize.Type == intstr.Int {
 		bufferSizeFmt = fmt.Sprintf("%d", bufferSize.IntValue())
 	} else {
-		bufferSizeFmt = fmt.Sprintf(`"%s"`, bufferSize.String())
+		bufferSizeFmt = fmt.Sprintf("%q", bufferSize.String())
 	}
 
 	patch := fmt.Sprintf(

--- a/test/e2e/framework/perf.go
+++ b/test/e2e/framework/perf.go
@@ -100,7 +100,7 @@ func (p *StatsCollector) Report() {
 		Info(p.name)
 
 	if p.outputDir != "" {
-		err := os.MkdirAll(p.outputDir, 0755)
+		err := os.MkdirAll(p.outputDir, 0o755)
 		if err != nil {
 			logrus.WithError(err).Errorf("unable to create a folder: %s", p.outputDir)
 			return

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -891,7 +891,7 @@ spec:
         - name: simple-game-server
           image: gcr.io/agones-images/simple-game-server:0.6
 `
-	err := ioutil.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0644)
+	err := ioutil.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0o644)
 	require.NoError(t, err)
 
 	cmd := exec.Command("kubectl", "apply", "-f", "/tmp/invalid.yaml")


### PR DESCRIPTION
Files affected are:
build/build-sdk-images/node/Dockerfile,
build/build-sdk-images/restapi/Dockerfile,
build/build-image/Dockerfile,
examples/nodejs-simple/Dockerfile

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

 /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Resolve the unvendored shell script is being executed using curl | bash.



