### PR TITLE
Get the initial game server state before marking the simple game server ready

### DIFF
--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -35,7 +35,7 @@ WITH_WINDOWS=1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REGISTRY)/simple-game-server:0.7
+server_tag = $(REGISTRY)/simple-game-server:0.8
 ifeq ($(WITH_WINDOWS), 1)
 server_tag_linux_amd64 = $(server_tag)-linux_amd64
 else


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:

If you are allocating the simple game servers at a high rate, then you can move from `Scheduled` -> `Ready` -> `Allocated` between the call to `ready(s)` and the call in `shutdownAfterNAllocations` to get the initial game server state. This was always the case (and testing found that even in older versions of the simple game server using the `automaticShutdownDelayMin` flag some got stuck forever), but since the watch function tends to fire multiple times the game servers often eventually received the signal to exit. This got worse with [my recent change](https://github.com/googleforgames/agones/pull/2409) where I'm explicitly looking for the transition from `Ready` to `Allocated` (to count the number of times it happens rather than the number of times we get a callback with the Allocated state, which isn't accurate). Now, if that initial transition to `Allocated` is missed the game server will _never_ decide to exit (or move back to ready), leaving it stuck. 

Running another test with this code left zero stuck game servers in the `Allocated` state, so the race condition appears to be resolved. 
