### PR TITLE
Send initial GameServer update in WatchGameServer

### DIFF
--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -335,7 +335,7 @@ func (l *LocalSDKServer) GetGameServer(context.Context, *sdk.Empty) (*sdk.GameSe
 // WatchGameServer will return current GameServer configuration, 3 times, every 5 seconds
 func (l *LocalSDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameServerServer) error {
 	l.logger.Info("Connected to watch GameServer...")
-	observer := make(chan struct{})
+	observer := make(chan struct{}, 1)
 
 	defer func() {
 		l.updateObservers.Delete(observer)
@@ -344,6 +344,10 @@ func (l *LocalSDKServer) WatchGameServer(_ *sdk.Empty, stream sdk.SDK_WatchGameS
 	l.updateObservers.Store(observer, true)
 
 	l.recordRequest("watch")
+
+	// send initial game server state
+	observer <- struct{}{}
+
 	for range observer {
 		l.gsMutex.RLock()
 		err := stream.Send(l.gs)

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -151,6 +151,7 @@ func TestLocalSDKServerSetLabel(t *testing.T) {
 				err := l.WatchGameServer(e, stream)
 				assert.Nil(t, err)
 			}()
+			assertInitialWatchUpdate(t, stream)
 
 			// make sure length of l.updateObservers is at least 1
 			err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
@@ -219,6 +220,7 @@ func TestLocalSDKServerSetAnnotation(t *testing.T) {
 				err := l.WatchGameServer(e, stream)
 				assert.Nil(t, err)
 			}()
+			assertInitialWatchUpdate(t, stream)
 
 			// make sure length of l.updateObservers is at least 1
 			err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
@@ -265,6 +267,8 @@ func TestLocalSDKServerWatchGameServer(t *testing.T) {
 		err := l.WatchGameServer(e, stream)
 		assert.Nil(t, err)
 	}()
+	assertInitialWatchUpdate(t, stream)
+
 	// wait for watching to begin
 	err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
 		found := false
@@ -309,6 +313,7 @@ func TestLocalSDKServerPlayerCapacity(t *testing.T) {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
 		assert.Nil(t, err)
 	}()
+	assertInitialWatchUpdate(t, stream)
 
 	// wait for watching to begin
 	err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
@@ -457,6 +462,7 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 				err := l.WatchGameServer(&sdk.Empty{}, stream)
 				assert.Nil(t, err)
 			}()
+			assertInitialWatchUpdate(t, stream)
 
 			// wait for watching to begin
 			err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
@@ -700,5 +706,14 @@ func assertNoWatchUpdate(t *testing.T, stream *gameServerMockStream) {
 	case <-stream.msgs:
 		assert.Fail(t, "should not get a message")
 	case <-time.After(time.Second):
+	}
+}
+
+// assertInitialWatchUpdate checks that the initial GameServer state is sent immediately after WatchGameServer
+func assertInitialWatchUpdate(t *testing.T, stream *gameServerMockStream) {
+	select {
+	case <-stream.msgs:
+	case <-time.After(time.Second):
+		assert.Fail(t, "timeout on receiving initial message")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> 
/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
This PR aligns the behaviour of the LocalSDKServer on [WatchGameServer(function(gameserver){…})](https://agones.dev/site/docs/guides/client-sdks/#watchgameserverfunctiongameserver) with the behaviour of the production SDKServer. Previously the initial game server state was not sent. I've also adjusted the tests to reflect (and check) this change.

**Which issue(s) this PR fixes**:
Closes #2437

**Special notes for your reviewer**:


