### PR TITLE
Fix connection timeout on Rust SDK.

### DIFF
--- a/examples/rust-simple/Makefile
+++ b/examples/rust-simple/Makefile
@@ -27,7 +27,7 @@ REPOSITORY ?= gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/rust-simple-server:0.9
+server_tag = $(REPOSITORY)/rust-simple-server:0.10
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "agones"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/googleforgames/agones"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This is a fix for the Rust SDK flakiness!

The previous iteration of the code would fail as soon as the initial connection would fail at any timeout greater than 2 seconds.

We move the connection to being lazy, so that the connection is only attempted on first attempt, so we can retry connecting if there is a failure for up to 30 seconds.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

This can either be merged before #2438, or if #2438 gets merged first, I'll need to remove the workaround as part of the PR before this gets merged.
