### PR TITLE
Update the simple game server to avoid a race condition when transitioning from ready to allocated

### DIFF
--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -35,7 +35,7 @@ WITH_WINDOWS=1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REGISTRY)/simple-game-server:0.8
+server_tag = $(REGISTRY)/simple-game-server:0.9
 ifeq ($(WITH_WINDOWS), 1)
 server_tag_linux_amd64 = $(server_tag)-linux_amd64
 else


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix


**Special notes for your reviewer**:

The code previously assumed that each state transition for the game server could be observed via callbacks `WatchGameServer` which via some testing has been observed to not be true. 

Instead of looking for the changes, look for the new state. This changes the code from being edge triggered to level triggered, as per https://speakerdeck.com/thockin/edge-vs-level-triggered-logic