### PR TITLE
Wait for the shutdown signal before having the simple game server exit

### DIFF
--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -35,7 +35,7 @@ WITH_WINDOWS=1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REGISTRY)/simple-game-server:0.9
+server_tag = $(REGISTRY)/simple-game-server:0.10
 ifeq ($(WITH_WINDOWS), 1)
 server_tag_linux_amd64 = $(server_tag)-linux_amd64
 else

--- a/examples/simple-game-server/main.go
+++ b/examples/simple-game-server/main.go
@@ -180,12 +180,12 @@ func shutdownAfterNAllocations(s *sdk.SDK, readyIterations, shutdownDelaySec int
 				}
 
 				log.Println("Moving Game Server to Shutdown")
-				shutdownErr := s.Shutdown()
-				if shutdownErr != nil {
+				if shutdownErr := s.Shutdown(); shutdownErr != nil {
 					log.Fatalf("Could not shutdown game server: %v", shutdownErr)
 				}
-				log.Println("Exiting Game Server")
-				os.Exit(0)
+				// The process will exit when Agones removes the pod and the
+				// container receives the SIGTERM signal
+				return
 			}(remainingIterations)
 		}
 	}); err != nil {
@@ -450,7 +450,8 @@ func exit(s *sdk.SDK) {
 	if shutdownErr != nil {
 		log.Printf("Could not shutdown")
 	}
-	os.Exit(0)
+	// The process will exit when Agones removes the pod and the
+	// container receives the SIGTERM signal
 }
 
 // gameServerName returns the GameServer name


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:

I tested both scenarios: connecting with `nc` and sending the `EXIT` command and using the `automaticShutdownDelaySec` flag on the fleet and in both cases the game server exits as expected.
