### PR TITLE
Fix allocator service document

### DIFF
--- a/site/content/en/docs/Advanced/allocator-service.md
+++ b/site/content/en/docs/Advanced/allocator-service.md
@@ -109,8 +109,11 @@ spec:
     kind: ClusterIssuer
 EOF
 
-# Add ca.crt to the allocator-tls-ca Secret
+# Wait for the allocator-tls Secret
+sleep 1
 TLS_CA_VALUE=$(kubectl get secret allocator-tls -n agones-system -ojsonpath='{.data.ca\.crt}')
+
+# Add ca.crt to the allocator-tls-ca Secret
 kubectl get secret allocator-tls-ca -o json -n agones-system | jq '.data["tls-ca.crt"]="'${TLS_CA_VALUE}'"' | kubectl apply -f -
 echo $TLS_CA_VALUE | base64 -d > ca.crt
 # In case of MacOS
@@ -194,7 +197,7 @@ curl --key ${KEY_FILE} \
      --data '{"namespace":"'${NAMESPACE}'"}' \
      https://${EXTERNAL_IP}/gameserverallocation \
      -X POST
-     
+
 ```
 
 You should expect to see the following output:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

It seems like the command `$(kubectl get secret allocator-tls -n agones-system -ojsonpath='{.data.ca\.crt}')` is executed too fast sometimes.

```bash
#!/bin/bash
# Create a self-signed ClusterIssuer
cat <<EOF | kubectl apply -f -
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: selfsigned
spec:
  selfSigned: {}
EOF

EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

# for EKS use hostname
# HOST_NAME=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')

# Create a Certificate with IP for the allocator-tls secret
cat <<EOF | kubectl apply -f -
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: allocator-tls
  namespace: agones-system
spec:
  commonName: ${EXTERNAL_IP}
  ipAddresses:
    - ${EXTERNAL_IP}
  secretName: allocator-tls
  issuerRef:
    name: selfsigned
    kind: ClusterIssuer
EOF

# Add ca.crt to the allocator-tls-ca Secret
TLS_CA_VALUE=$(kubectl get secret allocator-tls -n agones-system -ojsonpath='{.data.ca\.crt}')
echo "HERE?"
echo $TLS_CA_VALUE
```

The result is

```bash
clusterissuer.cert-manager.io/selfsigned created
certificate.cert-manager.io/allocator-tls created
Error from server (NotFound): secrets "allocator-tls" not found
HERE?

```

So, I added `sleep 1`. (Maybe the command could be replaced with the while statement.)
I think this is a pretty bad solution but `kubectl wait` needs `--for=condition=` which Secret doesn't have.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2467

**Special notes for your reviewer**:


