### PR TITLE
Fix panic when playertracking is false

### DIFF
--- a/sdks/go/alpha.go
+++ b/sdks/go/alpha.go
@@ -40,7 +40,7 @@ func newAlpha(conn *grpc.ClientConn) *Alpha {
 // If the player capacity is set from outside the SDK, use SDK.GameServer() instead.
 func (a *Alpha) GetPlayerCapacity() (int64, error) {
 	c, err := a.client.GetPlayerCapacity(context.Background(), &alpha.Empty{})
-	return c.Count, errors.Wrap(err, "could not get player capacity")
+	return c.GetCount(), errors.Wrap(err, "could not get player capacity")
 }
 
 // SetPlayerCapacity changes the player capacity to a new value.
@@ -54,7 +54,7 @@ func (a *Alpha) SetPlayerCapacity(capacity int64) error {
 // list of connected playerIDs.
 func (a *Alpha) PlayerConnect(id string) (bool, error) {
 	ok, err := a.client.PlayerConnect(context.Background(), &alpha.PlayerID{PlayerID: id})
-	return ok.Bool, errors.Wrap(err, "could not register connected player")
+	return ok.GetBool(), errors.Wrap(err, "could not register connected player")
 }
 
 // PlayerDisconnect Decreases the SDK’s stored player count by one, and removes the playerID from status.players.id.
@@ -62,25 +62,25 @@ func (a *Alpha) PlayerConnect(id string) (bool, error) {
 // playerID value exists within the list.
 func (a *Alpha) PlayerDisconnect(id string) (bool, error) {
 	ok, err := a.client.PlayerDisconnect(context.Background(), &alpha.PlayerID{PlayerID: id})
-	return ok.Bool, errors.Wrap(err, "could not register disconnected player")
+	return ok.GetBool(), errors.Wrap(err, "could not register disconnected player")
 }
 
 // GetPlayerCount returns the current player count.
 func (a *Alpha) GetPlayerCount() (int64, error) {
 	count, err := a.client.GetPlayerCount(context.Background(), &alpha.Empty{})
-	return count.Count, errors.Wrap(err, "could not get player count")
+	return count.GetCount(), errors.Wrap(err, "could not get player count")
 }
 
 // IsPlayerConnected returns if the playerID is currently connected to the GameServer.
 // This is always accurate, even if the value hasn’t been updated to the GameServer status yet.
 func (a *Alpha) IsPlayerConnected(id string) (bool, error) {
 	ok, err := a.client.IsPlayerConnected(context.Background(), &alpha.PlayerID{PlayerID: id})
-	return ok.Bool, errors.Wrap(err, "could not get if player is connected")
+	return ok.GetBool(), errors.Wrap(err, "could not get if player is connected")
 }
 
 // GetConnectedPlayers returns the list of the currently connected player ids.
 // This is always accurate, even if the value hasn’t been updated to the GameServer status yet.
 func (a *Alpha) GetConnectedPlayers() ([]string, error) {
 	list, err := a.client.GetConnectedPlayers(context.Background(), &alpha.Empty{})
-	return list.List, errors.Wrap(err, "could not list connected players")
+	return list.GetList(), errors.Wrap(err, "could not list connected players")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

```markdown
| "PLAYER_CAPACITY"   | With one argument, gets the player capacity; with two arguments sets the player capacity |
| "PLAYER_CONNECT"    | Connects the specified player to the game server                                         |
| "PLAYER_DISCONNECT" | Disconnects the specified player from the game server                                    |
| "PLAYER_CONNECTED"  | Returns true/false depending on whether the specified player is connected                |
| "GET_PLAYERS"       | Returns a list of the connected players                                                  |
| "PLAYER_COUNT"      | Returns a count of the connected players                                                 |
```

When the FeatureFlag:PlayerTracking is false(default), all the commands above emit panic.
This is because alpha is using protobuf/proto. So, the values would be better to access with auto-generated Get() methods.

https://github.com/googleforgames/agones/blob/94128b43efa027378037cbdec81db15cfa5e3833/pkg/sdk/alpha/alpha.pb.go#L109-L114

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #1957

**Special notes for your reviewer**:


