### PR TITLE
C# Health and WatchGameServer fixes

### DIFF
--- a/build/build-sdk-images/csharp/Dockerfile
+++ b/build/build-sdk-images/csharp/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/19.04/packages-microsof
 
 
 RUN apt-get update \
-    && apt-get install -y dotnet-sdk-2.2
+    && apt-get install -y dotnet-sdk-3.1
 
 # code generation scripts
 COPY *.sh /root/

--- a/sdks/csharp/test/AgonesSDKClientTests.cs
+++ b/sdks/csharp/test/AgonesSDKClientTests.cs
@@ -121,7 +121,7 @@ namespace Agones.Tests
 		}
 
 		[TestMethod]
-		public void WatchGameServer_Returns_OK()
+		public async Task WatchGameServer_Returns_OK()
 		{
 			var mockClient = new Mock<SDK.SDKClient>();
 			var mockResponseStream = new Moq.Mock<IAsyncStreamReader<GameServer>>();
@@ -139,6 +139,17 @@ namespace Agones.Tests
 
 			mockSdk.WatchGameServer((gs) => { actualWatchReturn = gs; });
 
+			// Asynchronously wait for our callback to be invoked and actualWatchReturn to be set.
+			// This is because the underlying watch is started through a task so we can't expect the callback to
+			// run synchronously.
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
+			{
+				while (actualWatchReturn == null)
+				{
+					await Task.Delay(15, cts.Token);
+				}
+			}
+			
 			Assert.AreSame(expectedWatchReturn, actualWatchReturn);
 		}
 

--- a/sdks/csharp/test/csharp-sdk-test.csproj
+++ b/sdks/csharp/test/csharp-sdk-test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This PR fixes a few issues we've observed in the C# SDK.
- The `IClientStreamWriter<Empty>` used for calls to `HealthAsync()` was created once during the SDK's constructor and never recreated. This made it so any subsequent calls to `HealthAsync()` would instantly fail if the stream had encountered a transient error that could normally be resolved by recreating a stream from the underlying channel. The fix we're proposing for this is to always check whether a stream needs to be created before attempting to write to it, and just null out the stream if an exception occurs, so the next caller can create a fresh stream and retry writing. We chose to account for the possibility of `HealthAsync()` being called concurrently from multiple threads and thus had to synchronize access to the underlying stream. We  however think that the typical use case for this call is likely to be called from a single thread a time, hence the cost for the lock that was added should be minimal.
- `BeginInternalWatchAsync` had several related issues.
  - It would fail and return if any transient issue happened to the underlying stream or if a user callback threw an exception.
  - It was rethrowing any caught exception but if the exception was thrown after the first yielding `await`, there was no way for the caller of `WatchGameServer()` to be notified that an exception happened and the watch had stopped.
  - It would dispose the whole SDK object upon failure / completion, which felt particularly unexpected from a user perspective.
  - We made it so similarly to `HealthAsync()`, it will attempt to recreate its stream if the current one throws any exception and will retry subscribing to GameServer events, until it gets cancelled.
- Finalizers were removed from `AgonesSDK` and `Alpha`. C# finalizers are only intended to dispose of unmanaged resources which neither of these classes holds. Besides, any exception thrown in a finalizer takes down the whole process so these should only be defined when absolutely required.

**Special notes for your reviewer**:
We observed the `HealthAsync()` issue in our deployed environments for a while now where a pod would come up, start instantly failing its health check and eventually get killed by the side car because it had never reported healthy. The second pod that would come online to replace the first one would most of the time be able to succeed its first and subsequent health checks. We believe that this was caused by a race condition between the game server pod coming online and its side car. If the game server attempted to send its health check too early before the side car was ready to handle connections, the underlying `HealthAsync()` stream would become unusable and couldn't be repaired for the reasons explained above. 

