### PR TITLE
Remove google-private

### DIFF
--- a/examples/allocation-endpoint/terraform/main.tf
+++ b/examples/allocation-endpoint/terraform/main.tf
@@ -76,7 +76,6 @@ resource "google_cloud_run_service_iam_binding" "binding" {
 
 
 resource "google_cloud_run_service" "aep_cloud_run" {
-  provider = google-private
   project = var.project_id
   name     = "allocation-endpoint-proxy"
   location = var.region


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
removes `google-private` provider from `allocation-endpoint` terraform and users `google` provider.

**Which issue(s) this PR fixes**:
Closes #2512 


