### PR TITLE
UE4 docs broke links with UE5 release

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/unreal.md
+++ b/site/content/en/docs/Guides/Client SDKs/unreal.md
@@ -58,15 +58,15 @@ However as your Unreal/Agones project gets more advanced you will want to unders
 
 A few helpful links for Unreal:
 
-- [UE4 Documentation Site](https://docs.unrealengine.com/en-US/index.html)
-- [UE4 Dedicated Servers](https://docs.unrealengine.com/en-US/Gameplay/Networking/HowTo/DedicatedServers/index.html)
+- [UE4 Documentation Site](https://docs.unrealengine.com/4.27/en-US/index.html)
+- [UE4 Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/Gameplay/Networking/HowTo/DedicatedServers/index.html)
   - useful guide to getting started with dedicated servers in Unreal
-- [UE4 Game Flow](https://docs.unrealengine.com/en-US/Gameplay/Framework/GameFlow/index.html)
-- [UE4 Game Mode](https://docs.unrealengine.com/en-US/API/Runtime/Engine/GameFramework/AGameMode/index.html)
+- [UE4 Game Flow](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Framework/GameFlow/)
+- [UE4 Game Mode](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/AGameMode/index.html)
   - useful for hooking up calls to Agones
-- [UE4 Game Session](https://docs.unrealengine.com/en-US/API/Runtime/Engine/GameFramework/AGameSession/index.html)
+- [UE4 Game Session](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/AGameSession/index.html)
   - as above there are hooks in Game Session that can be used to call into Agones
-- [UE4 Building & Packaging Games](https://docs.unrealengine.com/en-US/Engine/Deployment/BuildOperations/index.html)
+- [UE4 Building & Packaging Games](https://docs.unrealengine.com/4.27/en-US/Engine/Deployment/BuildOperations/index.html)
   - only building out Unreal game servers / clients, will also need to package into a container
 
 ## Getting Started


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Had to point the UE4 docs to a specific UE4 release version, as otherwise the links now 404 with the release of UE5.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Unblocks CI.

**Special notes for your reviewer**:

N/A
