### PR TITLE
v2: Flaky TestFleetRecreateGameServers fix.

### DIFF
--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -1224,9 +1224,10 @@ func TestFleetRecreateGameServers(t *testing.T) {
 					// if we didn't get a response because the GameServer has gone away, then the packet dropped on the return,
 					// but we're in the state we want, so we can ignore that we didn't get a response.
 					_, gsErr := framework.AgonesClient.AgonesV1().GameServers(gs.ObjectMeta.Namespace).Get(ctx, gs.ObjectMeta.Name, metav1.GetOptions{})
-					if !k8serrors.IsNotFound(gsErr) {
-						t.Fatalf("Could not message GameServer: %v", err)
+					if k8serrors.IsNotFound(gsErr) {
+						continue
 					}
+					t.Fatalf("Could not message GameServer: %v", err)
 				}
 
 				assert.Equal(t, "ACK: EXIT\n", reply)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Oops, need to skip the assert.Equals(...) on the response when there is no GameServer, as otherwise it will fail, since no response was received.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Saw this show up in https://github.com/googleforgames/agones/pull/2537#issuecomment-1091253962

**Special notes for your reviewer**:

N/A


