### PR TITLE
Unblock CI: Remove EKS Autoscaler terraform link

### DIFF
--- a/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
+++ b/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
@@ -28,7 +28,6 @@ or their cloud specific documentation.
 
 ### Amazon Elastic Kubernetes Service
 * [Cluster Autoscaler for EKS](https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html)
-* [Terraform EKS Module: Autoscaling Example](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/irsa_autoscale_refresh)
 
 ### Azure Kubernetes Service
 * [Cluster Autoscaler on Azure Kubernetes Service (AKS) - Preview](https://docs.microsoft.com/en-us/azure/aks/autoscaler)

--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -21,4 +21,4 @@ ExternalTimeout: 60
 IgnoreURLs:
   - http://localhost
 HTTPHeaders:
-  User-Agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
+  User-Agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This repository of Terraform examples keeps changing its structure, and I'm not even sure which example is now using autoscaler -- so I'm going to remove it from the site, as I'm not sure its relevant, is brittle and as long as we point to the EKS autoscaling documentation I think we are good.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Unblocks CI.

**Special notes for your reviewer**:

I also incremented the User Agent, just to be safe, as we've had some 403's lately.
