### PR TITLE
Queue updated GameServers with DeletionTimestamp

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -158,7 +158,7 @@ func NewController(
 			// no point in processing unless there is a State change
 			oldGs := oldObj.(*agonesv1.GameServer)
 			newGs := newObj.(*agonesv1.GameServer)
-			if oldGs.Status.State != newGs.Status.State || oldGs.ObjectMeta.DeletionTimestamp != newGs.ObjectMeta.DeletionTimestamp {
+			if oldGs.Status.State != newGs.Status.State || !newGs.ObjectMeta.DeletionTimestamp.IsZero() {
 				c.enqueueGameServerBasedOnState(newGs)
 			}
 		},

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -346,6 +346,13 @@ func TestControllerWatchGameServers(t *testing.T) {
 	gsWatch.Modify(copyFixture)
 	assert.Equal(t, "default/test", <-received)
 
+	// modify a gameserver with a deletion timestamp
+	now := metav1.Now()
+	deleted := copyFixture.DeepCopy()
+	deleted.ObjectMeta.DeletionTimestamp = &now
+	gsWatch.Modify(deleted)
+	assert.Equal(t, "default/test", <-received)
+
 	podWatch.Delete(pod)
 	assert.Equal(t, "default/test", <-received)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

I believe this closes the issue with Shutdown GameServer's very rarely getting stuck (very hard to test in an e2e test).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Closes #2360



