### PR TITLE
Increase the e2e cluster size to match what was observed

### DIFF
--- a/build/terraform/e2e/module.tf
+++ b/build/terraform/e2e/module.tf
@@ -41,7 +41,7 @@ module "gke_cluster" {
     "name"             = "e2e-test-cluster"
     "zone"             = "us-west1-c"
     "machineType"      = "e2-standard-4"
-    "initialNodeCount" = 8
+    "initialNodeCount" = 10
     "project"          = var.project
   }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #2494 

**Special notes for your reviewer**:

While recreating the e2e test cluster for the Kubernetes 1.22 update I noticed that the cluster size shrank from 12 nodes to 10 nodes. Here I'm bumping the size of the default node pool so that during the next upgrade it doesn't have to be manually adjusted. 

