### PR TITLE
Add the new gke-gcloud-auth-plugin binary to the build image

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -42,7 +42,8 @@ ENV PATH /usr/local/go/bin:/go/bin:/opt/google-cloud-sdk/bin:$PATH
 RUN go install golang.org/x/tools/cmd/goimports@latest
 
 # RUN gcloud components update
-RUN gcloud components update && gcloud components install app-engine-go
+RUN gcloud components update && gcloud components install app-engine-go && \
+    gcloud components install gke-gcloud-auth-plugin
 
 # the kubernetes version for the file
 ENV KUBERNETES_VER 1.22.9


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Without this change, you can no longer fetch credentials for GKE clusters after running `make shell`, which also causes `make gen-embedded-openapi` to fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #2494

**Special notes for your reviewer**: See https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke


