### PR TITLE
Update the go runtime environment version for the website from 1.13 to 1.16

### DIFF
--- a/site/app.yaml
+++ b/site/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: go113
+runtime: go116
 service: ${SERVICE}
 
 handlers:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Bump golang version to (hopefully) get rid of the deprecation warning seen during the release process. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2382

**Special notes for your reviewer**: 


