### PR TITLE
Refactor rolling update test to support >1 inactive GameServerSets

### DIFF
--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1328,7 +1328,8 @@ func TestControllerRollingUpdateDeployment(t *testing.T) {
 			expected: expected{
 				inactiveSpecReplicas: []int32{0, 0},
 				replicas:             10,
-				updated:              true,
+				// TODO(2574): This should be `true`, inactive gss 0 should be updated
+				updated: false,
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
This PR refactors the Rolling Update Deployment table tests to support >1 inactive game server sets. 
It also adds a test that replicates [Issue 2574: Presence of >2 GSS can cause a rolling update to become stuck until an allocation ends](https://github.com/googleforgames/agones/issues/2574) and highlights the issue.

**Special notes for your reviewer**:
The idea of this PR is to minimally reproduce [Issue 2574](https://github.com/googleforgames/agones/issues/2574).
