### PR TITLE
Change deprecated preferred & required to selectors in Player Capacity docs

### DIFF
--- a/site/content/en/docs/Integration Patterns/player-capacity.md
+++ b/site/content/en/docs/Integration Patterns/player-capacity.md
@@ -30,16 +30,15 @@ to 15 players, and if it cannot find one, will allocate a Ready one from the sam
 apiVersion: "allocation.agones.dev/v1"
 kind: GameServerAllocation
 spec:
-  preferred:
-    - gameServerState: Allocated
-      matchLabels:
+  selectors:
+    - matchLabels:
         agones.dev/fleet: lobby
+      gameServerState: Allocated
       players:
         minAvailable: 10
         maxAvailable: 15
-  required:
-    matchLabels:
-      agones.dev/fleet: lobby
+    - matchLabels:
+        agones.dev/fleet: lobby
 ```
 
 {{< alert title="Note" color="info">}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:
Because `preferred` and `required` fields are deprecated in agones, so I changed them to `selectors` 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes https://github.com/googleforgames/agones/issues/2570


