### PR TITLE
Fix sdkServer.logLevel nil in Gameserver in local-mode

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -124,7 +124,7 @@ ensure-build-sdk-image:
 
 # Run SDK conformance Sidecar server in docker in order to run
 # SDK client test against it. Useful for test development
-run-sdk-conformance-local: TIMEOUT ?= 30
+run-sdk-conformance-local: TIMEOUT ?= 40
 run-sdk-conformance-local: TESTS ?= ready,allocate,setlabel,setannotation,gameserver,health,shutdown,watch,reserve
 run-sdk-conformance-local: FEATURE_GATES ?=
 run-sdk-conformance-local: ensure-agones-sdk-image
@@ -133,7 +133,7 @@ run-sdk-conformance-local: ensure-agones-sdk-image
 
 # Run SDK conformance test, previously built, for a specific SDK_FOLDER
 # Sleeps the start of the sidecar to test that the SDK blocks on connection correctly
-run-sdk-conformance-no-build: TIMEOUT ?= 30
+run-sdk-conformance-no-build: TIMEOUT ?= 40
 run-sdk-conformance-no-build: RANDOM := $(shell bash -c 'echo $$RANDOM')
 run-sdk-conformance-no-build: DELAY ?= $(shell bash -c "echo $$[ ($(RANDOM) % 5 ) + 1 ]")
 run-sdk-conformance-no-build: TESTS ?= $(DEFAULT_CONFORMANCE_TESTS)

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -178,7 +178,7 @@ func registerLocal(grpcServer *grpc.Server, ctlConf config) (func(), error) {
 		}
 	}
 
-	s, err := sdkserver.NewLocalSDKServer(filePath)
+	s, err := sdkserver.NewLocalSDKServer(filePath, ctlConf.TestSdkName)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func registerLocal(grpcServer *grpc.Server, ctlConf config) (func(), error) {
 // registerLocal registers the local test SDK servers, and returns a cancel func that
 // closes all the SDK implementations
 func registerTestSdkServer(grpcServer *grpc.Server, ctlConf config) (func(), error) {
-	s, err := sdkserver.NewLocalSDKServer("")
+	s, err := sdkserver.NewLocalSDKServer("", "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / Why we need it**:

/kind bug

In local-mode sdk-server, the `SdkServer.LogLevel` is always ignored, even if the users set the LogLevel.
It always set to the info level.
In the current codebase, the local-sdkserver's behavier is defined by `pkg/sdkserver/localsdk.go`.

In the `pkg/sdkserver/localsdk.go`, there is no function for setting logLevel.
So the LogLevel is always set to the Info(Level=4).

In this PR, I added the function which set logLevel to the local-sdkserver if specified and added the unit test for this.

**After this PR**

User can set LogLevel

```
LogLevel: Debug
{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"/Users/xxxxxx/git/agones/examples/simple-game-server/gameserver.yaml","Delay":0,"Timeout":0,"Test":"","TestSdkName":"test","GRPCPort":9357,"HTTPPort":9358},"featureGates":"CustomFasSyncInterval=false\u0026Example=true\u0026NodeExternalDNS=true\u0026PlayerAllocationFilter=false\u0026PlayerTracking=false\u0026SDKGracefulTermination=false\u0026StateAllocationFilter=false","message":"Starting sdk sidecar","severity":"info","source":"main","time":"2022-05-14T17:32:34.496763+09:00","version":"dev"}
{"filePath":"/Users/xxxxxx/git/agones/examples/simple-game-server/gameserver.yaml","message":"Reading GameServer configuration","severity":"info","source":"*sdkserver.LocalSDKServer","time":"2022-05-14T17:32:34.497066+09:00"}
{"grpcEndpoint":"localhost:9357","message":"Starting SDKServer grpc service...","severity":"info","source":"main","time":"2022-05-14T17:32:34.501695+09:00"}
{"httpEndpoint":"localhost:9358","message":"Starting SDKServer grpc-gateway...","severity":"info","source":"main","time":"2022-05-14T17:32:34.502205+09:00"}
{"message":"Ready request has been received!","severity":"info","source":"*sdkserver.LocalSDKServer","time":"2022-05-14T17:32:39.863248+09:00"}
{"message":"Received ready request","severity":"debug","source":"*sdkserver.LocalSDKServer","time":"2022-05-14T17:32:39.863334+09:00"}
```

```
LogLevel: Error
{"ctlConf":{"Address":"localhost","IsLocal":true,"LocalFile":"/Users/xxxxxx/git/agones/examples/simple-game-server/gameserver.yaml","Delay":0,"Timeout":0,"Test":"","TestSdkName":"test","GRPCPort":9357,"HTTPPort":9358},"featureGates":"CustomFasSyncInterval=false\u0026Example=true\u0026NodeExternalDNS=true\u0026PlayerAllocationFilter=false\u0026PlayerTracking=false\u0026SDKGracefulTermination=false\u0026StateAllocationFilter=false","message":"Starting sdk sidecar","severity":"info","source":"main","time":"2022-05-14T17:31:12.769861+09:00","version":"dev"}
{"filePath":"/Users/xxxxxx/git/agones/examples/simple-game-server/gameserver.yaml","message":"Reading GameServer configuration","severity":"info","source":"*sdkserver.LocalSDKServer","time":"2022-05-14T17:31:12.770279+09:00"}
```

**Which issue(s) this PR fixes**:

Closes #2221

**Special notes for your reviewer**:

In this PR, I updated the proto file and go file about `sdk.proto`.
If other further updates are required, please let me know.

Thank you
