### PR TITLE
Fix build command: build-agones-sdk-image

### DIFF
--- a/build/includes/build-image.mk
+++ b/build/includes/build-image.mk
@@ -72,4 +72,4 @@ pull-remote-build-image:
 	-docker pull $(REMOTE_TAG) && docker tag $(REMOTE_TAG) $(LOCAL_TAG)
 
 ensure-agones-sdk-image:
-	$(MAKE) ensure-image IMAGE_TAG=$(sidecar_linux_amd64_tag) BUILD_TARGET=build-agones-sdk-server-image
+	$(MAKE) ensure-image IMAGE_TAG=$(sidecar_linux_amd64_tag) BUILD_TARGET=build-agones-sdk-image


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

I found that agones-sdk image build command failed when I tried to test `make run-sdk-conformance-test`.
The command has changed, but it seems to have leaked in #2521.

**Before this PR**
```
% make ensure-agones-sdk-image
/Library/Developer/CommandLineTools/usr/bin/make ensure-image IMAGE_TAG=gcr.io/agones-images/agones-sdk:1.24.0-11f7c21-linux-amd64 BUILD_TARGET=build-agones-sdk-server-image
Could not find gcr.io/agones-images/agones-sdk:1.24.0-11f7c21-linux-amd64 image. Building...
make[2]: *** No rule to make target `build-agones-sdk-server-image'.  Stop.
make[1]: *** [ensure-image] Error 2
make: *** [ensure-agones-sdk-image] Error 2
```

`BUILD_TARGET=build-agones-sdk-server-image` is defined, but it doesn't exist.
The correct one is `build-agones-sdk-image`.

**After this PR**
```
% make ensure-agones-sdk-image
/Library/Developer/CommandLineTools/usr/bin/make ensure-image IMAGE_TAG=gcr.io/agones-images/agones-sdk:1.24.0-8062a04-linux-amd64 BUILD_TARGET=build-agones-sdk-image
Could not find gcr.io/agones-images/agones-sdk:1.24.0-8062a04-linux-amd64 image. Building...
mkdir -p ~/.kube/
mkdir -p /Users/xxxxx/go/src/agones.dev/agones/build//.gocache
mkdir -p /Users/xxxxx/go/src/agones.dev/agones/build//.config/gcloud
mkdir -p ~/.config/helm
mkdir -p ~/.cache/helm
docker run --privileged --rm tonistiigi/binfmt:qemu-v6.2.0 --install arm64
...
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


