### PR TITLE
Fix intermediate certificate handling (#2602)

### DIFF
--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -412,8 +412,13 @@ func (h *serviceHandler) verifyClientCertificate(rawCerts [][]byte, verifiedChai
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 
-	for _, cert := range rawCerts[1:] {
-		opts.Intermediates.AppendCertsFromPEM(cert)
+	for _, rawCert := range rawCerts[1:] {
+		cert, err := x509.ParseCertificate(rawCert)
+		if err != nil {
+			logger.WithError(err).Warning("cannot parse intermediate certificate")
+			return errors.New("bad intermediate certificate: " + err.Error())
+		}
+		opts.Intermediates.AddCert(cert)
 	}
 
 	c, err := x509.ParseCertificate(rawCerts[0])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:
This PR changes intermediate certificates to be correctly parsed as raw ASN.1 binary data rather than PEM. Currently the codebase attempts to parse them as PEM data, but it silently fails.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2602

**Special notes for your reviewer**:
I ran the e2e tests in a private cluster, but I also deployed it alongside my application and verified that intermediate certificates are being handled properly. I think it would be good to add an intermediate certificate test to the e2e tests, but I am unsure of how to do so (and I'm not certain when I might have that bandwidth).


