### PR TITLE
Add metric for number of reserved replicas

### DIFF
--- a/pkg/metrics/controller.go
+++ b/pkg/metrics/controller.go
@@ -241,7 +241,7 @@ func (c *Controller) recordFleetChanges(obj interface{}) {
 	}
 
 	c.recordFleetReplicas(f.Name, f.Namespace, f.Status.Replicas, f.Status.AllocatedReplicas,
-		f.Status.ReadyReplicas, f.Spec.Replicas)
+		f.Status.ReadyReplicas, f.Spec.Replicas, f.Status.ReservedReplicas)
 }
 
 func (c *Controller) recordFleetDeletion(obj interface{}) {
@@ -250,10 +250,10 @@ func (c *Controller) recordFleetDeletion(obj interface{}) {
 		return
 	}
 
-	c.recordFleetReplicas(f.Name, f.Namespace, 0, 0, 0, 0)
+	c.recordFleetReplicas(f.Name, f.Namespace, 0, 0, 0, 0, 0)
 }
 
-func (c *Controller) recordFleetReplicas(fleetName, fleetNamespace string, total, allocated, ready, desired int32) {
+func (c *Controller) recordFleetReplicas(fleetName, fleetNamespace string, total, allocated, ready, desired, reserved int32) {
 
 	ctx, _ := tag.New(context.Background(), tag.Upsert(keyName, fleetName), tag.Upsert(keyNamespace, fleetNamespace))
 
@@ -265,6 +265,8 @@ func (c *Controller) recordFleetReplicas(fleetName, fleetNamespace string, total
 		fleetsReplicasCountStats.M(int64(ready)))
 	recordWithTags(ctx, []tag.Mutator{tag.Upsert(keyType, "desired")},
 		fleetsReplicasCountStats.M(int64(desired)))
+	recordWithTags(ctx, []tag.Mutator{tag.Upsert(keyType, "reserved")},
+		fleetsReplicasCountStats.M(int64(reserved)))
 }
 
 // recordGameServerStatusChanged records gameserver status changes, however since it's based

--- a/pkg/metrics/controller_test.go
+++ b/pkg/metrics/controller_test.go
@@ -203,8 +203,8 @@ func TestControllerFleetReplicasCount(t *testing.T) {
 	defer c.close()
 	c.run(t)
 
-	f := fleet("fleet-test", 8, 2, 5, 1)
-	fd := fleet("fleet-deleted", 100, 100, 100, 100)
+	f := fleet("fleet-test", 8, 2, 5, 1, 1)
+	fd := fleet("fleet-deleted", 100, 100, 100, 100, 100)
 	c.fleetWatch.Add(f)
 	f = f.DeepCopy()
 	f.Status.ReadyReplicas = 1
@@ -234,10 +234,12 @@ func TestControllerFleetReplicasCount(t *testing.T) {
 
 	reader.ReadAndExport(exporter)
 	assertMetricData(t, exporter, "fleets_replicas_count", []expectedMetricData{
+		{labels: []string{"fleet-deleted", defaultNs, "reserved"}, val: int64(0)},
 		{labels: []string{"fleet-deleted", defaultNs, "allocated"}, val: int64(0)},
 		{labels: []string{"fleet-deleted", defaultNs, "desired"}, val: int64(0)},
 		{labels: []string{"fleet-deleted", defaultNs, "ready"}, val: int64(0)},
 		{labels: []string{"fleet-deleted", defaultNs, "total"}, val: int64(0)},
+		{labels: []string{"fleet-test", defaultNs, "reserved"}, val: int64(1)},
 		{labels: []string{"fleet-test", defaultNs, "allocated"}, val: int64(2)},
 		{labels: []string{"fleet-test", defaultNs, "desired"}, val: int64(5)},
 		{labels: []string{"fleet-test", defaultNs, "ready"}, val: int64(1)},

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -150,7 +150,7 @@ func generateGsEvents(count int, state agonesv1.GameServerState, fleetName strin
 	}
 }
 
-func fleet(fleetName string, total, allocated, ready, desired int32) *agonesv1.Fleet {
+func fleet(fleetName string, total, allocated, ready, desired, reserved int32) *agonesv1.Fleet {
 	return &agonesv1.Fleet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fleetName,
@@ -161,6 +161,7 @@ func fleet(fleetName string, total, allocated, ready, desired int32) *agonesv1.F
 			Replicas: desired,
 		},
 		Status: agonesv1.FleetStatus{
+			ReservedReplicas:  reserved,
 			AllocatedReplicas: allocated,
 			ReadyReplicas:     ready,
 			Replicas:          total,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

The current metrics for fleets include total game servers, allocated game servers, ready game servers, and desired game servers, however, doesn't include `reserved` game servers.
This PR adds the count metrics for `reserved` game servers.

**Which issue(s) this PR fixes**:

Closes #2609

**Special notes for your reviewer**:
None

