### PR TITLE
Add an extra step to the kubernetes upgrade tasks.

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes_update.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_update.md
@@ -25,6 +25,7 @@ List of items to do for upgrading to {version}:
 - [ ] Update the dev tooling to create clusters
     - [ ] Minikube
     - [ ] Kind
+- [ ] Update the k8s image used in the helm [pre-delete-hook](https://github.com/googleforgames/agones/blob/main/install/helm/agones/templates/hooks/pre_delete_hook.yaml)
 - [ ] Update client-go
 - [ ] Update CRD API reference
     - [ ] Update links to k8s documentation in `site/assets/templates/crd-doc-config.json`


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Add an extra step to the k8s upgrade tasks so that we keep the image used for uninstall up to date. We had been using one that was very old (prior to https://github.com/googleforgames/agones/pull/2615) and we should use one that is at the same version as the version of Kubernetes that we support to ensure maximum compatibility. 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:


