### PR TITLE
Unblock CI: Fix site link 404

### DIFF
--- a/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
+++ b/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
@@ -288,7 +288,7 @@ kubectl apply -f https://raw.githubusercontent.com/googleforgames/agones/{{< rel
 
 #### 2. Create X509 Root and Webhook certificates
 
-The procedure of generating a Self-signed CA certificate taken from [here](https://datacenteroverlords.com/2012/03/01/creating-your-own-ssl-certificate-authority/)
+The procedure of generating a Self-signed CA certificate is as follows:
 
 The first step is to create the private root key:
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This website for generating a self-signed SSL certificate is down, and also our instructions have since changed, so I removed the link altogether.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A, but unblocks CI.

**Special notes for your reviewer**:

N/A
