### PR TITLE
Fix replicas miscalculation when fleet replicas equals zero

### DIFF
--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -436,6 +436,12 @@ func (c *Controller) rollingUpdateActive(fleet *agonesv1.Fleet, active *agonesv1
 		return replicas, nil
 	}
 
+	// if the current number replicas from the fleet is zero, the rolling update can be ignored
+	// and the cleanup stage will remove dangling GameServerSets
+	if fleet.Spec.Replicas == 0 {
+		return 0, nil
+	}
+
 	// if the active spec replicas are greater than or equal the fleet spec replicas, then we don't
 	// need to do another rolling update upwards.
 	if active.Spec.Replicas >= (fleet.Spec.Replicas - sumAllocated) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

When attempting to scale down a fleet to zero, if we have the old gameserverset, currently the scale down will fail.
This PR fix the rolling update with scale zero.
And this PR adds unit test and e2e test.

This PR is based on closed #2515. Thank you @danieloliveira079!!
(I changed some test codes and tested locally)

**Which issue(s) this PR fixes**:

Closes #2509, #2617

**Special notes for your reviewer**:

none