### PR TITLE
Stop exporting fleet metrics on delete

### DIFF
--- a/pkg/metrics/controller.go
+++ b/pkg/metrics/controller.go
@@ -256,10 +256,9 @@ func (c *Controller) recordFleetDeletion(obj interface{}) {
 
 	// wait 15 minutes, there delete the labels
 	// TOXO: need tests for this
-	// TOXO: move to 15 minutes
 	log := c.logger.WithField("fleet", f.ObjectMeta.Name)
 	log.Debug("Fleet deleted. Waiting to delete metrics")
-	err := wait.PollInfinite(time.Minute, func() (bool, error) {
+	err := wait.PollInfinite(15*time.Minute, func() (bool, error) {
 		err := c.resyncFleets()
 		if err != nil {
 			c.logger.WithError(err).Error("Could not resync Fleet Metrics")
@@ -276,7 +275,9 @@ func (c *Controller) recordFleetDeletion(obj interface{}) {
 // resyncFleets resets the view "fleets_replicas_count" and recalculates all the totals.
 // TOXO: needs tests
 func (c *Controller) resyncFleets() error {
-	// TOXO: probably need a mutex somewhere
+	// TOXO: might need it's own mutex? 🤔
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	fleets, err := c.fleetLister.List(labels.Everything())
 	if err != nil {
 		return errors.Wrap(err, "could not resync fleets")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

POC for removing deleted Fleet metrics from export 15 minutes after a Fleet is deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #2478

**Special notes for your reviewer**:

Would love feedback on if we like the approach.
