### PR TITLE
Build image: Use apt to install gcloud

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -31,19 +31,17 @@ RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
 
 # install gcloud + kubectl, because it's an easy way to test/dev against kubernetes.
 WORKDIR /opt
-RUN wget -q https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip -q google-cloud-sdk.zip && \
-    rm google-cloud-sdk.zip && \
-    /opt/google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/root/.bashrc
 
-# update the path for both go and gcloud
-ENV PATH /usr/local/go/bin:/go/bin:/opt/google-cloud-sdk/bin:$PATH
+# credits https://cloud.google.com/sdk/docs/install#deb
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && \
+    apt-get install google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin google-cloud-cli-app-engine-go -y && \
+    echo "source /usr/share/google-cloud-sdk/completion.bash.inc" >> /root/.bashrc
+
+# update the path for go
+ENV PATH /usr/local/go/bin:/go/bin:$PATH
 
 # install go tooling for development, building and testing
 RUN go install golang.org/x/tools/cmd/goimports@latest
-
-# RUN gcloud components update
-RUN gcloud components update && gcloud components install app-engine-go && \
-    gcloud components install gke-gcloud-auth-plugin
 
 # the kubernetes version for the file
 ENV KUBERNETES_VER 1.22.9


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Since there are now debian repos for install gcloud's cli, let's use that as the source of truth for gcloud installation within our build image.

**Which issue(s) this PR fixes**:

N/A just doing some cleanup with the new gke-gcloud-auth-plugin on my linux systems, so I figured I would make it all match.

**Special notes for your reviewer**:

I'd say let's merge this after stable release next week - 96% sure I haven't broken anything, but would hate it to block stable release.


