### PR TITLE
Move CI image builds to Artifact Registry

### DIFF
--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -15,10 +15,13 @@
 # limitations under the License.
 
 FEATURES=$1
+REGISTRY=$2
+
 echo $FEATURES
+echo $REGISTRY
 set -e
 echo "installing current release"
-DOCKER_RUN= make install FEATURE_GATES='"'$FEATURES'"'
+DOCKER_RUN= make install FEATURE_GATES='"'$FEATURES'"' REGISTRY='"'$REGISTRY'"'
 echo "starting e2e test"
 DOCKER_RUN= make test-e2e ARGS=-parallel=16 FEATURE_GATES='"'$FEATURES'"'
 echo "completed e2e test"

--- a/build/e2e-image/entrypoint.sh
+++ b/build/e2e-image/entrypoint.sh
@@ -16,6 +16,7 @@
 set -e
 FEATURES=$1
 TEST_CLUSTER_NAME=$2
+REGISTRY=$3
 
 echo $FEATURES
 export SHELL="/bin/bash"
@@ -33,7 +34,7 @@ kubectl port-forward statefulset/consul-consul-server 8500:8500 &
 echo "Waiting consul port-forward to launch on 8500..."
 timeout 60 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' 127.0.0.1 8500
 echo "consul port-forward launched. Starting e2e tests..."
-echo "consul lock -child-exit-code=true -timeout 1h -verbose LockE2E '/root/e2e.sh "$FEATURES"'"
-consul lock -child-exit-code=true -timeout 1h -verbose LockE2E '/root/e2e.sh "'$FEATURES'"'
+echo "consul lock -child-exit-code=true -timeout 1h -verbose LockE2E '/root/e2e.sh "$FEATURES" "$REGISTRY"'"
+consul lock -child-exit-code=true -timeout 1h -verbose LockE2E '/root/e2e.sh "'$FEATURES'" "'$REGISTRY'"'
 killall -q kubectl || true
 echo "successfully killed kubectl proxy"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -152,12 +152,16 @@ steps:
   waitFor:
     - lint
   dir: "build"
+  env:
+    - "REGISTRY=${_REGISTRY}"
   args: [ "-j", "4", "build-images"]
 - name: "make-docker"
   id: push-images
   waitFor:
     - build-images
   dir: "build"
+  env:
+    - "REGISTRY=${_REGISTRY}"
   args: [ "-j", "4", "push"]
 
 #
@@ -239,7 +243,10 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['PlayerTracking=true&NodeExternalDNS=false&StateAllocationFilter=true&PlayerAllocationFilter=true&CustomFasSyncInterval=true', 'e2e-test-cluster']
+  args:
+    - 'PlayerTracking=true&NodeExternalDNS=false&StateAllocationFilter=true&PlayerAllocationFilter=true&CustomFasSyncInterval=true'
+    - 'e2e-test-cluster'
+    - "${_REGISTRY}"
   id: e2e-feature-gates
   waitFor:
     - push-images
@@ -250,7 +257,10 @@ steps:
 #
 
 - name: 'e2e-runner'
-  args: ['', 'e2e-test-cluster']
+  args:
+    - ''
+    - 'e2e-test-cluster'
+    - "${_REGISTRY}"
   id: e2e-stable
   waitFor:
     - push-images
@@ -319,10 +329,15 @@ substitutions:
   _CPP_SDK_BUILD_CACHE_KEY: cpp-sdk-build
   _CPP_SDK_CONFORMANCE_CACHE_KEY: cpp-sdk-conformance
   _RUST_SDK_BUILD_CACHE_KEY: rust-sdk-build
-
+  _REGISTRY: us-docker.pkg.dev/${PROJECT_ID}/ci
 tags: ['ci']
 timeout: 7200s
-images: ['gcr.io/$PROJECT_ID/agones-controller', 'gcr.io/$PROJECT_ID/agones-ping']
+images:
+  - '${_REGISTRY}/agones-controller'
+  - '${_REGISTRY}/agones-sdk'
+  - '${_REGISTRY}/agones-ping'
+  - '${_REGISTRY}/agones-allocator'
 logsBucket: "gs://agones-build-logs"
 options:
- machineType: 'N1_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_32'
+  dynamic_substitutions: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Have removed the cleanup script for gcr.io, since it was overreaching on what it should delete -- so part of that work is to move CI builds to Artifact Registry, where we can keep production images separate from CI builds.

Have created us-docker.pkg.dev/agones-images/ci for images for and related to CI. These changes should make it so that Agones PR image builds to push to that registry, and testing should happen with those images.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Work on #2358

**Special notes for your reviewer**:

Production images will stay the same for now, this is just a first step.
