### PR TITLE
Building and pushing ARM64 images

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -415,6 +415,8 @@ build-required-src-dist:
 	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/build-required-src-dist.sh
 
 # Create docker builder used in creating arm64 images
+# According to the docker documentation, to build the images for ARM64 arch CPU 
+# we would need to use buildx command which uses builder https://docs.docker.com/desktop/multi-arch/
 create-arm64-builder:
 	-docker buildx create --name $(BUILDX_ARM64_BUILDER)
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -426,6 +426,7 @@ endif
 
 build-controller-image-amd64: $(ensure-build-image) build-controller-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_amd64_tag) $(DOCKER_BUILD_ARGS)
+# creating docker builder and then using that builder to build controller image in buildx command
 build-controller-image-arm64: $(ensure-build-image) build-controller-binary
 	$(MAKE) create-arm64-builder 
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/controller/ --tag=$(controller_arm64_tag) $(DOCKER_BUILD_ARGS)
@@ -486,6 +487,7 @@ endif
 
 build-agones-sdk-image-amd64: $(ensure-build-image) build-agones-sdk-binary-linux-amd64
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_amd64_tag) $(DOCKER_BUILD_ARGS)
+# creating docker builder and then using that builder to build sdk image in buildx command
 build-agones-sdk-image-arm64: $(ensure-build-image) build-agones-sdk-binary-linux-arm64
 	$(MAKE) create-arm64-builder 
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_arm64_tag) $(DOCKER_BUILD_ARGS) 
@@ -535,6 +537,7 @@ endif
 
 build-ping-image-amd64: $(ensure-build-image) build-ping-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_amd64_tag) $(DOCKER_BUILD_ARGS)
+# creating docker builder and then using that builder to build ping image in buildx command
 build-ping-image-arm64: $(ensure-build-image) build-ping-binary
 	$(MAKE) create-arm64-builder 
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/ping/ --tag=$(ping_arm64_tag) $(DOCKER_BUILD_ARGS) 
@@ -577,6 +580,7 @@ endif
 
 build-allocator-image-amd64: $(ensure-build-image) build-allocator-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/allocator/ --tag=$(allocator_amd64_tag) $(DOCKER_BUILD_ARGS)
+# creating docker builder and then using that builder to build allocator image in buildx command
 build-allocator-image-arm64: $(ensure-build-image) build-allocator-binary
 	$(MAKE) create-arm64-builder 
 	docker buildx build $(agones_path)/cmd/allocator/ --builder $(BUILDX_ARM64_BUILDER) --tag=$(allocator_arm64_tag) --build-arg ARCH=arm64 --platform linux/arm64 $(DOCKER_BUILD_ARGS) 

--- a/build/Makefile
+++ b/build/Makefile
@@ -429,8 +429,7 @@ endif
 build-controller-image-amd64: $(ensure-build-image) build-controller-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build controller image in buildx command
-build-controller-image-arm64: $(ensure-build-image) build-controller-binary
-	$(MAKE) create-arm64-builder 
+build-controller-image-arm64: $(ensure-build-image) build-controller-binary create-arm64-builder 
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/controller/ --tag=$(controller_arm64_tag) $(DOCKER_BUILD_ARGS)
 
 # push the gameservers controller image
@@ -490,8 +489,7 @@ endif
 build-agones-sdk-image-amd64: $(ensure-build-image) build-agones-sdk-binary-linux-amd64
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build sdk image in buildx command
-build-agones-sdk-image-arm64: $(ensure-build-image) build-agones-sdk-binary-linux-arm64
-	$(MAKE) create-arm64-builder 
+build-agones-sdk-image-arm64: $(ensure-build-image) build-agones-sdk-binary-linux-arm64 create-arm64-builder 
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_arm64_tag) $(DOCKER_BUILD_ARGS) 
 
 build-agones-sdk-image-windows: build-agones-sdk-binary
@@ -540,8 +538,7 @@ endif
 build-ping-image-amd64: $(ensure-build-image) build-ping-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build ping image in buildx command
-build-ping-image-arm64: $(ensure-build-image) build-ping-binary
-	$(MAKE) create-arm64-builder 
+build-ping-image-arm64: $(ensure-build-image) build-ping-binary create-arm64-builder 
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/ping/ --tag=$(ping_arm64_tag) $(DOCKER_BUILD_ARGS) 
 
 # Build a static binary for the allocator service
@@ -583,8 +580,7 @@ endif
 build-allocator-image-amd64: $(ensure-build-image) build-allocator-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/allocator/ --tag=$(allocator_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build allocator image in buildx command
-build-allocator-image-arm64: $(ensure-build-image) build-allocator-binary
-	$(MAKE) create-arm64-builder 
+build-allocator-image-arm64: $(ensure-build-image) build-allocator-binary create-arm64-builder 
 	docker buildx build $(agones_path)/cmd/allocator/ --builder $(BUILDX_ARM64_BUILDER) --tag=$(allocator_arm64_tag) --build-arg ARCH=arm64 --platform linux/arm64 $(DOCKER_BUILD_ARGS) 
 
 # push the gameservers sidecar image

--- a/build/Makefile
+++ b/build/Makefile
@@ -417,6 +417,7 @@ build-required-src-dist:
 # Create docker builder used in creating arm64 images
 # According to the docker documentation, to build the images for ARM64 arch CPU 
 # we would need to use buildx command which uses builder https://docs.docker.com/desktop/multi-arch/
+# We primarily need this for M1 Macs, see: https://medium.com/geekculture/docker-build-with-mac-m1-d668c802ab96
 create-arm64-builder:
 	-docker buildx create --name $(BUILDX_ARM64_BUILDER)
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -418,6 +418,7 @@ build-required-src-dist:
 # According to the docker documentation, to build the images for ARM64 arch CPU 
 # we would need to use buildx command which uses builder https://docs.docker.com/desktop/multi-arch/
 # We primarily need this for M1 Macs, see: https://medium.com/geekculture/docker-build-with-mac-m1-d668c802ab96
+# Making this command optional (using - as prefix) because it will fail once built for the first time, so we ignore failures.
 create-arm64-builder:
 	-docker buildx create --name $(BUILDX_ARM64_BUILDER)
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -48,6 +48,7 @@ GCP_BUCKET_CHARTS ?= agones-chart
 MINIKUBE_PROFILE ?= agones
 GO_BUILD_TAGS ?= none
 BUILDX_WINDOWS_BUILDER = windows-builder
+BUILDX_ARM64_BUILDER = arm64-builder
 WINDOWS_DOCKER_PUSH_ARGS =
 # Versions of Windows Server to support, default is Windows Server 2019.
 # For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
@@ -413,6 +414,10 @@ build-licenses:
 build-required-src-dist:
 	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/build-required-src-dist.sh
 
+# Create docker builder used in creating arm64 images
+create-arm64-builder:
+	-docker buildx create --name $(BUILDX_ARM64_BUILDER)
+
 # Build the image for the gameserver controller
 build-controller-image: build-controller-image-amd64
 ifeq ($(WITH_ARM64), 1)
@@ -422,7 +427,8 @@ endif
 build-controller-image-amd64: $(ensure-build-image) build-controller-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_amd64_tag) $(DOCKER_BUILD_ARGS)
 build-controller-image-arm64: $(ensure-build-image) build-controller-binary
-	docker buildx build --platform linux/arm64 --build-arg ARCH=arm64 $(agones_path)/cmd/controller/ --tag=$(controller_arm64_tag) $(DOCKER_BUILD_ARGS)
+	$(MAKE) create-arm64-builder 
+	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/controller/ --tag=$(controller_arm64_tag) $(DOCKER_BUILD_ARGS)
 
 # push the gameservers controller image
 push-controller-image: push-controller-image-amd64
@@ -472,7 +478,7 @@ ensure-windows-buildx:
 # Build the image for the gameserver sidecar and SDK binaries
 build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses build-required-src-dist build-agones-sdk-image-amd64
 ifeq ($(WITH_ARM64), 1)
-build-agones-sdk-image: build-agones-sdk-image-arm64
+build-agones-sdk-image: build-agones-sdk-image-arm64 
 endif
 ifeq ($(WITH_WINDOWS), 1)
 build-agones-sdk-image: build-agones-sdk-image-windows
@@ -481,7 +487,8 @@ endif
 build-agones-sdk-image-amd64: $(ensure-build-image) build-agones-sdk-binary-linux-amd64
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_amd64_tag) $(DOCKER_BUILD_ARGS)
 build-agones-sdk-image-arm64: $(ensure-build-image) build-agones-sdk-binary-linux-arm64
-	docker buildx build --platform linux/arm64 --build-arg ARCH=arm64 $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_arm64_tag) $(DOCKER_BUILD_ARGS)
+	$(MAKE) create-arm64-builder 
+	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_arm64_tag) $(DOCKER_BUILD_ARGS) 
 
 build-agones-sdk-image-windows: build-agones-sdk-binary
 build-agones-sdk-image-windows: $(foreach winver, $(WINDOWS_VERSIONS), build-agones-sdk-image-windows-$(winver))
@@ -515,7 +522,7 @@ endif
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create $(ping_tag) $(push_ping_manifest)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(ping_tag)
 
-push-ping-image-amd64: $(ensure-build-image)
+push-ping-image-amd64: $(ensure-build-image) build-ping-image-amd64
 	docker push $(ping_amd64_tag)
 push-ping-image-arm64:
 	$(MAKE) DOCKER_BUILD_ARGS=--push build-ping-image-arm64
@@ -523,13 +530,14 @@ push-ping-image-arm64:
 # Build the image for the ping service
 build-ping-image: build-ping-image-amd64
 ifeq ($(WITH_ARM64), 1)
-build-ping-image: build-ping-image-arm64
+build-ping-image: build-ping-image-arm64 
 endif
 
 build-ping-image-amd64: $(ensure-build-image) build-ping-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_amd64_tag) $(DOCKER_BUILD_ARGS)
 build-ping-image-arm64: $(ensure-build-image) build-ping-binary
-	docker buildx build --platform linux/arm64 --build-arg ARCH=arm64 $(agones_path)/cmd/ping/ --tag=$(ping_arm64_tag) $(DOCKER_BUILD_ARGS)
+	$(MAKE) create-arm64-builder 
+	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/ping/ --tag=$(ping_arm64_tag) $(DOCKER_BUILD_ARGS) 
 
 # Build a static binary for the allocator service
 build-allocator-binary: $(ensure-build-image) build-allocator-binary-linux-amd64
@@ -570,7 +578,8 @@ endif
 build-allocator-image-amd64: $(ensure-build-image) build-allocator-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/allocator/ --tag=$(allocator_amd64_tag) $(DOCKER_BUILD_ARGS)
 build-allocator-image-arm64: $(ensure-build-image) build-allocator-binary
-	docker buildx build $(agones_path)/cmd/allocator/ --tag=$(allocator_arm64_tag) --build-arg ARCH=arm64 --platform linux/arm64 $(DOCKER_BUILD_ARGS)
+	$(MAKE) create-arm64-builder 
+	docker buildx build $(agones_path)/cmd/allocator/ --builder $(BUILDX_ARM64_BUILDER) --tag=$(allocator_arm64_tag) --build-arg ARCH=arm64 --platform linux/arm64 $(DOCKER_BUILD_ARGS) 
 
 # push the gameservers sidecar image
 push-agones-sdk-image: push-agones-sdk-linux-image-amd64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: 
In order to build arm64 based images in Mac M1 device, we need to create a builder and use it to build images.

According to the docker documentation, to build the images for ARM64 arch CPU we would need to use `buildx` command which uses `builder`. So to create builder: 
```bash
docker buildx create --name mybuilder
```
We can see the supported platforms by:
```bash
docker buildx inspect --bootstrap
```
using builder in our command for building images:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/94632788/179048992-c0deefe6-0fdd-4374-843f-814b74193042.png">

So finally we are able to build images for Mac m1.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2517 

**Special notes for your reviewer**:
Reference 1: [build-and-run-multi-architecture-images](https://docs.docker.com/desktop/multi-arch/#build-and-run-multi-architecture-images) 
Reference 2: [Docker build with Mac M1](https://medium.com/geekculture/docker-build-with-mac-m1-d668c802ab96)
