### PR TITLE
update grpc package version for arm64 Linux

### DIFF
--- a/sdks/csharp/sdk/AgonesSDK.nuspec
+++ b/sdks/csharp/sdk/AgonesSDK.nuspec
@@ -15,9 +15,9 @@
       <group targetFramework=".NETStandard2.0">
         <dependency id="Google.Api.CommonProtos" version="2.0.0" exclude="Build,Analyzers" />
         <dependency id="Google.Protobuf" version="3.15.0" exclude="Build,Analyzers" />
-        <dependency id="Grpc" version="2.28.1" exclude="Build,Analyzers" />
-        <dependency id="Grpc.Core" version="2.28.1" exclude="Build,Analyzers" />
-        <dependency id="Grpc.Tools" version="2.28.1" exclude="Build,Analyzers" />
+        <dependency id="Grpc" version="2.46.3" exclude="Build,Analyzers" />
+        <dependency id="Grpc.Core" version="2.46.3" exclude="Build,Analyzers" />
+        <dependency id="Grpc.Tools" version="2.47.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/sdks/csharp/sdk/csharp-sdk.csproj
+++ b/sdks/csharp/sdk/csharp-sdk.csproj
@@ -22,9 +22,9 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.CommonProtos" Version="2.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Grpc" Version="2.28.1" />
-    <PackageReference Include="Grpc.Core" Version="2.28.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.28.1">
+    <PackageReference Include="Grpc" Version="2.46.3" />
+    <PackageReference Include="Grpc.Core" Version="2.46.3" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/sdks/csharp/test/csharp-sdk-test.csproj
+++ b/sdks/csharp/test/csharp-sdk-test.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc" Version="2.28.1" />
+    <PackageReference Include="Grpc" Version="2.46.3" />
     <PackageReference Include="Grpc.Core.Testing" Version="2.28.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
When invoke agones sdk in c# gameserver on arm64 enviroment, occur exception like this

```
Unhandled exception. System.IO.IOException: Error loading native library "/app/runtimes/linux/native/libgrpc_csharp_ext.x64.so".
at Grpc.Core.Internal.UnmanagedLibrary..ctor(String[] libraryPathAlternatives)
at Grpc.Core.Internal.NativeExtension.LoadUnmanagedLibrary()
at Grpc.Core.Internal.NativeExtension.LoadNativeMethods()
at Grpc.Core.Internal.NativeExtension..ctor()
at Grpc.Core.Internal.NativeExtension.Get()
at Grpc.Core.Internal.NativeMethods.Get()
at Grpc.Core.GrpcEnvironment.GrpcNativeInit()
at Grpc.Core.GrpcEnvironment..ctor()
at Grpc.Core.GrpcEnvironment.AddRef()
at Grpc.Core.Channel..ctor(String target, ChannelCredentials credentials, IEnumerable`1 options)
at Grpc.Core.Channel..ctor(String host, Int32 port, ChannelCredentials credentials, IEnumerable`1 options)
at Grpc.Core.Channel..ctor(String host, Int32 port, ChannelCredentials credentials)
at Agones.AgonesSDK..ctor(Double requestTimeoutSec, SDKClient sdkClient, CancellationTokenSource cancellationTokenSource, ILogger logger)
```

Describe to  [grpc blog](https://grpc.io/blog/grpc-on-arm64/#overview-of-grpc-and-protobuf-support-on-arm64-linux) Grpc.Core nuget packages now have aarch64 Linux support (starting from v2.38.1).

but grpc version using in agones c# sdk is under v2.38.1


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


