### PR TITLE
Bug: `make install` uses local helm and jq

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -353,7 +353,7 @@ install: FEATURE_GATES ?= $(ALPHA_FEATURE_GATES)
 install: SERVICE_MONITOR := false
 install: HELM_ARGS ?=
 install: $(ensure-build-image) install-custom-pull-secret
-	-$(DOCKER_RUN) bash -c "[[ $$(helm status agones -n agones-system --output json | jq -r '.info.status') =~ (failed|pending-.*) ]] && helm uninstall agones --namespace=agones-system || true"
+	-$(DOCKER_RUN) bash -c '[[ $$(helm status agones -n agones-system --output json | jq -r ".info.status") =~ (failed|pending-.*) ]] && helm uninstall agones --namespace=agones-system || true'
 	$(DOCKER_RUN) \
 		helm upgrade --install --atomic --wait --namespace=agones-system \
 		--create-namespace \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

In a difference between " and ', meant that the `make install` command that would check the helm install and uninstall if necessary was actually using the local installations of `helm` and `jq` rather than the ones in the Docker container.

This didn't fail in most places, as Cloud Build, and many of our dev machines have these installed already, and the command is set to be ignored if it fails for whatever reason (as a safety measure).

I only noticed the output on screen when helping a teammate debug some other issues.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A