### PR TITLE
Remove Katacoda

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Agones is in active development - we would love your help in shaping its future!
 
 ### Kubernetes
 - [You should totally read this comic, and interactive tutorial](https://cloud.google.com/kubernetes-engine/kubernetes-comic/)
-- [Katacoda's free, interactive Kubernetes course](https://www.katacoda.com/courses/kubernetes)
 
 ## Licence
 


### PR DESCRIPTION
Katacoda.com is shutdown.
https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Removes link to Katacoda which is shutdown.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


