### PR TITLE
Fix feature flags on "High Density" documentation

### DIFF
--- a/site/content/en/docs/Integration Patterns/high-density-gameservers.md
+++ b/site/content/en/docs/Integration Patterns/high-density-gameservers.md
@@ -7,7 +7,7 @@ description: >
   How to run multiple concurrent game sessions in a single GameServer process.
 ---
 
-{{< alpha title="Allocation Player Filter and Allocation State Filter" gate="PlayerAllocationFilter,StateAllocationFilter" >}}
+{{< alpha title="Allocation State Filter" gate="StateAllocationFilter" >}}
 
 Depending on the setup and resource requirements of your game server process, sometimes it can be a more economical 
 use of resources to run multiple concurrent game sessions from within a single `GameServer` instance.

--- a/site/layouts/shortcodes/alpha.html
+++ b/site/layouts/shortcodes/alpha.html
@@ -3,7 +3,7 @@
 {{- $title := .Get "title" }}
 <div class="alert alert-warning" role="alert">
     <h4 class="alert-heading">Warning</h4>
-    <p>The {{ $title }} {{- if gt $len_gate 1 }}features are{{ else }}feature is{{ end }} currently <strong><a href="{{ ref . "/docs/Guides/feature-stages.md#alpha" }}">Alpha</a></strong>,
+    <p>The {{ $title }} {{- if gt $len_gate 1 }} features are{{ else }} feature is{{ end }} currently <strong><a href="{{ ref . "/docs/Guides/feature-stages.md#alpha" }}">Alpha</a></strong>,
         not enabled by default, and may change in the future.</p>
 <p>Use the Feature {{- if gt $len_gate 1 }}Gates{{- else}}Gate{{- end }} {{ range $index, $value := first (sub $len_gate 1) $gate }} <code>{{- $value }}</code>, {{ end }}{{ if gt $len_gate 1 }}and{{ end }}{{ range (last 1 $gate) }} <code>{{ . }}</code>{{ end }}
 to enable and test {{ if gt $len_gate 1 }}these features{{else}}this feature{{ end }}.</p>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

You don't need `PlayerAllocationFilter` feature flag enabled for the high density gameserver integration guide, so I don't know why I wrote that you did!

This fixes that, and a small spacing issue in the alpha.html shortcode.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A
