### PR TITLE
Cloud Build: No more need for Docker 20 tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
 # Print Docker version
 #
 
-- name: "gcr.io/cloud-builders/docker:20.10.13"
+- name: gcr.io/cloud-builders/docker
   id: docker-version
   args: ["--version"]
 
@@ -63,9 +63,9 @@ steps:
 #
 
 - name: "ubuntu"
-  args: ["bash", "-c", "echo 'FROM gcr.io/cloud-builders/docker:20.10.13\nRUN apt-get install make\nENTRYPOINT [\"/usr/bin/make\"]' > Dockerfile.build"]
+  args: ["bash", "-c", "echo 'FROM gcr.io/cloud-builders/docker\nRUN apt-get install make\nENTRYPOINT [\"/usr/bin/make\"]' > Dockerfile.build"]
   waitFor: ['-']
-- name: "gcr.io/cloud-builders/docker:20.10.13"
+- name: gcr.io/cloud-builders/docker
   id: build-make-docker
   args: ['build', '-f', 'Dockerfile.build', '-t', 'make-docker', '.'] # we need docker and make to run everything.
 
@@ -106,7 +106,7 @@ steps:
 # build the e2e test runner
 #
 
-- name: 'gcr.io/cloud-builders/docker'
+- name: gcr.io/cloud-builders/docker
   args: ['build', '-f', 'Dockerfile', '-t', 'e2e-runner', '.']
   dir: 'build/e2e-image'
   id: build-e2e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

The default docker version in Cloud Build is now 20.x.x - so we no longer need to specify the tag, and can go back to using latest.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A