### PR TITLE
Add back CustomFasSyncInterval=false to e2e test

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -244,7 +244,7 @@ steps:
 
 - name: 'e2e-runner'
   args:
-    - 'PlayerTracking=true&StateAllocationFilter=true&PlayerAllocationFilter=true&SDKGracefulTermination=true'
+    - 'PlayerTracking=true&StateAllocationFilter=true&PlayerAllocationFilter=true&SDKGracefulTermination=true&CustomFasSyncInterval=false'
     - 'e2e-test-cluster'
     - "${_REGISTRY}"
   id: e2e-feature-gates


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Realised in #2695 that we had accidentally removed the test for when
`CustomFasSyncInterval` was turned off.

So adding it back in!

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A