### PR TITLE
Fleet scale down: Remove < Ready GameServers first

### DIFF
--- a/pkg/gameserversets/gameserversets_test.go
+++ b/pkg/gameserversets/gameserversets_test.go
@@ -38,9 +38,10 @@ func TestSortGameServersByLeastFullNodes(t *testing.T) {
 	}
 
 	list := []*agonesv1.GameServer{
-		{ObjectMeta: metav1.ObjectMeta{Name: "g1"}, Status: agonesv1.GameServerStatus{NodeName: "n2"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "g2"}, Status: agonesv1.GameServerStatus{NodeName: ""}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "g3"}, Status: agonesv1.GameServerStatus{NodeName: "n1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "g1"}, Status: agonesv1.GameServerStatus{NodeName: "n2", State: agonesv1.GameServerStateReady}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "g2"}, Status: agonesv1.GameServerStatus{NodeName: "", State: agonesv1.GameServerStateReady}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "g3"}, Status: agonesv1.GameServerStatus{NodeName: "n1", State: agonesv1.GameServerStateReady}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "g4"}, Status: agonesv1.GameServerStatus{NodeName: "n2", State: agonesv1.GameServerStateCreating}},
 	}
 
 	result := sortGameServersByLeastFullNodes(list, nc)
@@ -48,7 +49,8 @@ func TestSortGameServersByLeastFullNodes(t *testing.T) {
 	require.Len(t, result, len(list))
 	assert.Equal(t, "g2", result[0].ObjectMeta.Name)
 	assert.Equal(t, "g3", result[1].ObjectMeta.Name)
-	assert.Equal(t, "g1", result[2].ObjectMeta.Name)
+	assert.Equal(t, "g4", result[2].ObjectMeta.Name)
+	assert.Equal(t, "g1", result[3].ObjectMeta.Name)
 }
 
 func TestSortGameServersByNewFirst(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

When scaling down GameServers within a single node, Agones would remove GameServers that would be there the longest.

This would mean that what would usually happen is that Ready GameServers would be shut down preferentially over GameServers that where not yet Ready.

This would result in churn on the node, and a drop in Ready GameServers until the newer ones came to a Ready state.

This change will prefer GameServers that are in a state before Ready for deletion, when comparing GameServers that are stored on a single node.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2372

**Special notes for your reviewer**:


