### PR TITLE
Bug: Passing arguments to the constructor results in an error

### DIFF
--- a/sdks/csharp/sdk/AgonesSDK.cs
+++ b/sdks/csharp/sdk/AgonesSDK.cs
@@ -69,6 +69,7 @@ namespace Agones
 			}
 			else
 			{
+				cts = cancellationTokenSource;
 				ownsCts = false;
 			}
 			

--- a/sdks/csharp/sdk/Alpha.cs
+++ b/sdks/csharp/sdk/Alpha.cs
@@ -57,6 +57,7 @@ namespace Agones
             }
             else
             {
+                cts = cancellationTokenSource;
                 ownsCts = false;
             }
             

--- a/sdks/csharp/test/AgonesAlphaSDKClientTests.cs
+++ b/sdks/csharp/test/AgonesAlphaSDKClientTests.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Agones.Tests
 {
@@ -131,6 +132,31 @@ namespace Agones.Tests
 
             var result = await mockSdk.Alpha().GetConnectedPlayersAsync();
             CollectionAssert.AreEquivalent(expected, result);
+        }
+
+        [TestMethod]
+        public void InstantiateWithParameters_OK()
+        {
+            var mockSdk = new AgonesSDK();
+            var mockChannel = new Channel(mockSdk.Host, mockSdk.Port, ChannelCredentials.Insecure);
+            ILogger mockLogger = new Mock<ILogger>().Object;
+            CancellationTokenSource mockCancellationTokenSource = new Mock<CancellationTokenSource>().Object;
+            bool exceptionOccured = false;
+            try
+            {
+                new Alpha(
+                    channel: mockChannel,
+                    requestTimeoutSec: 15,
+                    cancellationTokenSource: mockCancellationTokenSource,
+                    logger: mockLogger
+                );
+            }
+            catch
+            {
+                exceptionOccured = true;
+            }
+
+            Assert.IsFalse(exceptionOccured);
         }
     }
 }

--- a/sdks/csharp/test/AgonesSDKClientTests.cs
+++ b/sdks/csharp/test/AgonesSDKClientTests.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Agones.Tests
 {
@@ -239,6 +240,30 @@ namespace Agones.Tests
 
 			var result = await mockSdk.SetAnnotationAsync(expectedKeyValue.Key, expectedKeyValue.Value);
 			Assert.AreEqual(expectedKeyValue, actualKeyValue);
+		}
+
+		[TestMethod]
+		public void InstantiateWithParameters_OK()
+		{
+			var mockClient = new Mock<SDK.SDKClient>().Object;
+			ILogger mockLogger = new Mock<ILogger>().Object;
+			CancellationTokenSource mockCancellationTokenSource = new Mock<CancellationTokenSource>().Object;
+			bool exceptionOccured = false;
+			try
+			{
+				new AgonesSDK(
+					requestTimeoutSec: 15,
+					sdkClient: mockClient,
+					cancellationTokenSource: mockCancellationTokenSource,
+					logger: mockLogger
+				);
+			}
+			catch
+			{
+				exceptionOccured = true;
+			}
+
+			Assert.IsFalse(exceptionOccured);
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
NullReferenceException is raised because the cts variable is not initialized.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes # https://github.com/googleforgames/agones/issues/2713

**Special notes for your reviewer**:


