### PR TITLE
Made `strategy` configurable on relevant deployments

### DIFF
--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -25,6 +25,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.agones.ping.updateStrategy }}
+  strategy:
+{{- toYaml .Values.agones.ping.updateStrategy | nindent 4}}
+{{- end }}
   selector:
     matchLabels:
       agones.dev/role: ping

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -132,6 +132,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.agones.allocator.replicas }}
+{{- if .Values.agones.allocator.updateStrategy }}
+  strategy:
+{{- toYaml .Values.agones.allocator.updateStrategy | nindent 4}}
+{{- end }}
   selector:
     matchLabels:
       multicluster.agones.dev/role: allocator

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -95,6 +95,7 @@ agones:
     allocationBatchWaitTime: 500ms
   ping:
     install: true
+    updateStrategy: {}
     resources: {}
       # requests:
       #   cpu: 1
@@ -138,6 +139,7 @@ agones:
       timeoutSeconds: 1
   allocator:
     install: true
+    updateStrategy: {}
     apiServerQPS: 400
     apiServerQPSBurst: 500
     logLevel: info

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -214,9 +214,11 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 {{% feature publishVersion="1.26.0" %}}
 **New Configuration Features:**
-| Parameter                                                | Description                                                                                                               | Default                |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-|                                                          |                                                                                                                           |                        |
+| Parameter                                                | Description                                                                                                                         | Default                |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `agones.allocator.updateStrategy`                        | The [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) to apply to the ping deployment      | `{}`                   |
+| `agones.ping.updateStrategy`                             | The [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) to apply to the allocator deployment | `{}`                   |
+
 {{% /feature %}}
 
 [toleration]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Making `strategy` configurable for the allocator and ping services will give the ability to be more flexible in the way the deployments upgrade are performed in live clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


