### PR TITLE
If the user has specified cluster autoscaling behavior for their gameserver then don't overwrite it

### DIFF
--- a/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
+++ b/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
@@ -35,7 +35,7 @@ or their cloud specific documentation.
 ## Fleet Autoscaling
 
 Fleet autoscaling is the only type of autoscaling that exists in Agones. It is currently available as a
-buffer autoscaling strategy or as a webhook driven strategy, such that you can provide your own autoscaling logic. 
+buffer autoscaling strategy or as a webhook driven strategy, such that you can provide your own autoscaling logic.
 
 Have a look at the [Create a Fleet Autoscaler]({{< relref "../Getting Started/create-fleetautoscaler.md" >}}) quickstart, the
 [Create a Webhook Fleet Autoscaler]({{< relref "../Getting Started/create-webhook-fleetautoscaler.md" >}}) quickstart,
@@ -58,7 +58,7 @@ when it is created.
 
 ### Fleet Scale Down Strategy
 
-Fleet Scale Down strategy refers to the order in which the `GameServers` that belong to a `Fleet` are deleted, 
+Fleet Scale Down strategy refers to the order in which the `GameServers` that belong to a `Fleet` are deleted,
 when Fleets are shrunk in size.
 
 ## Fleet Scheduling
@@ -86,7 +86,7 @@ spec:
             image: {{% example-image %}}
 ```
 
-This is the *default* Fleet scheduling strategy. It is designed for dynamic Kubernetes environments, wherein you wish 
+This is the *default* Fleet scheduling strategy. It is designed for dynamic Kubernetes environments, wherein you wish
 to scale up and down as load increases or decreases, such as in a Cloud environment where you are paying
 for the infrastructure you use.
 
@@ -97,13 +97,43 @@ This affects the Cluster autoscaler, Allocation Scheduling, Pod Scheduling and F
 
 #### Cluster Autoscaler
 
+{{% feature expiryVersion="1.27.0" %}}
 To ensure that the Cluster Autoscaler doesn't attempt to evict and move `GameServer` `Pods` onto new Nodes during
 gameplay, Agones adds the annotation [`"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"`](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)
 to the backing Pod.
+{{% /feature %}}
+
+{{% feature publishVersion="1.27.0" %}}
+When using the “Packed” strategy, Agones will ensure that the Cluster Autoscaler doesn't attempt to evict and move `GameServer` `Pods` onto new Nodes during
+gameplay by adding the annotation [`"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"`](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)
+to the backing Pod.
+
+However, if a gameserver can tolerate [being evicted](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/#how-api-initiated-eviction-works)
+(generally in combination with setting an appropriate graceful termination period on the gameserver pod) and you
+want the Cluster Autoscaler to compact your cluster by evicting game servers when it would allow the Cluster
+Autoscaler to reduce the number of nodes in the cluster, then this behavior can be overridden by explicitly setting the
+`"cluster-autoscaler.kubernetes.io/safe-to-evict"` annotation to `"true"` in the metadata for the game server pod, e.g.
+
+```
+apiVersion: "agones.dev/v1"
+kind: GameServer
+metadata:
+  name: "simple-game-server"
+spec:
+  template:
+    # pod metadata. Name & Namespace is overwritten
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: true
+    spec:
+      containers:
+      - image: {{< example-image >}}
+```
+{{% /feature %}}
 
 #### Allocation Scheduling Strategy
 
-Under the "Packed" strategy, allocation will prioritise allocating `GameServers` to nodes that are running on 
+Under the "Packed" strategy, allocation will prioritise allocating `GameServers` to nodes that are running on
 Nodes that already have allocated `GameServers` running on them.
 
 #### Pod Scheduling Strategy
@@ -113,13 +143,13 @@ with a `preferredDuringSchedulingIgnoredDuringExecution` affinity with [hostname
 topology. This attempts to group together `GameServer` Pods within as few nodes in the cluster as it can.
 
 {{< alert title="Note" color="info">}}
-The default Kubernetes scheduler doesn't do a perfect job of packing, but it's a good enough job for what we need - 
-  at least at this stage. 
+The default Kubernetes scheduler doesn't do a perfect job of packing, but it's a good enough job for what we need -
+  at least at this stage.
 {{< /alert >}}
 
 #### Fleet Scale Down Strategy
 
-With the "Packed" strategy, Fleets will remove `Ready` `GameServers` from Nodes with the _least_ number of `Ready` and 
+With the "Packed" strategy, Fleets will remove `Ready` `GameServers` from Nodes with the _least_ number of `Ready` and
 `Allocated` `GameServers` on them. Attempting to empty Nodes so that they can be safely removed.
 
 ### Distributed


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: 
This change allows the object metadata annotation that controls the cluster autoscaler behavior to be passed along through the pod template to the game server pod. Previously, the annotation was always set by Agones, which would override any attempt by a user to set this annotation. 

This change allows game servers to mark themselves as being able to be preempted and removed by the cluster autoscaler, which allows the cluster autoscaler to compact nodes when there is space to downsize a cluster. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2747

**Special notes for your reviewer**:


