### PR TITLE
Update the Kubernetes upgrade instructions to include instructions for upgrading gRPC

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes_update.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_update.md
@@ -32,3 +32,8 @@ List of items to do for upgrading to {version}:
     - [ ] Regenerate crd api reference docs - `make gen-api-docs`
 - [ ] Regenerate Kubernetes resource includes (e.g. ObjectMeta, PodTemplateSpec)
     - [ ] Start a cluster with `make gcloud-test-cluster`, uninstall agones using `helm uninstall agones -n agones-system`, and then run  `make gen-embedded-openapi` and `make gen-install`
+- [ ] If client-go pulled in a new version of gRPC, then also
+    - [ ] Update the SDK [base image grpc version](https://github.com/googleforgames/agones/blob/main/build/includes/sdk.mk#L30) and rebuild the image. Note that this can take a while and in the past we have had to manually push it to gcr because cloud build doesn't like how long it takes.
+    - [ ] Regenerate allocated API endpoints: [make gen-allocation-grpc](https://github.com/googleforgames/agones/blob/main/build/includes/allocation.mk#L55)
+    - [ ] Regenerate all client sdks: [make gen-all-sdk-grpc](https://github.com/googleforgames/agones/blob/main/build/README.md#make-gen-all-sdk-grpc)
+    - [ ] Update the version number in C++ Cmake scripts [here](https://github.com/googleforgames/agones/blob/main/sdks/cpp/CMakeLists.txt#L100) and [here](https://github.com/googleforgames/agones/blob/main/sdks/cpp/cmake/prerequisites.cmake#L34)

--- a/build/README.md
+++ b/build/README.md
@@ -13,7 +13,7 @@ Table of Contents
   * [Building on Different Platforms](#building-on-different-platforms)
      * [Linux](#linux)
      * [Windows](#windows)
-     * [macOS](#macos)  
+     * [macOS](#macos)
   * [Testing and Building](#testing-and-building)
      * [Running a Test Google Kubernetes Engine Cluster](#running-a-test-google-kubernetes-engine-cluster)
      * [Running a Test Minikube cluster](#running-a-test-minikube-cluster)
@@ -64,6 +64,7 @@ Table of Contents
         * [make gen-install](#make-gen-install)
         * [make gen-embedded-openapi](#make-gen-embedded-openapi)
         * [make gen-crd-client](#make-gen-crd-client)
+        * [make gen-all-sdk-grpc](#make-gen-all-sdk-grpc)
         * [make gen-sdk-grpc](#make-gen-sdk-grpc)
      * [Build Image Targets](#build-image-targets)
         * [make clean-config](#make-clean-config)
@@ -654,8 +655,11 @@ This should be run against a clean or brand new cluster, as external CRD's or sc
 #### `make gen-crd-client`
 Generate the Custom Resource Definition client(s)
 
+#### `make gen-all-sdk-grpc`
+Generate the SDK gRPC server and client code for all SDKs.
+
 #### `make gen-sdk-grpc`
-Generate the SDK gRPC server and client code
+Generate the SDK gRPC server and client code for a single SDK (specified in the `SDK_FOLDER` variable).
 
 ### Build Image Targets
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Follow up to https://github.com/googleforgames/agones/pull/2725 and https://github.com/googleforgames/agones/pull/2727 so that the next time we do a Kubernetes upgrade we remember how to upgrade gRPC across the project. 

I also snuck in a documentation fix to include `make gen-all-sdk-grpc` in the build documentation since it was previously missing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
_n/a_

**Special notes for your reviewer**:


