### PR TITLE
Fix case of HTTP module reference

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Agones.Build.cs
+++ b/sdks/unreal/Agones/Source/Agones/Agones.Build.cs
@@ -24,7 +24,7 @@ public class Agones : ModuleRules
 		PublicDependencyModuleNames.AddRange(new[]
 		{
 			"Core",
-			"Http",
+			"HTTP",
 			"Json",
 			"JsonUtilities",
 			"WebSockets"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / Why we need it**:
This fixes the warning of the following in Unreal Engine:
"Module 'Http' (referenced via Target -> Agones.Build.cs) has incorrect text case. Did you mean 'HTTP'?"

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
