### PR TITLE
Enable image streaming for e2e test cluster

### DIFF
--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -19,7 +19,7 @@ GCP_TF_CLUSTER_NAME ?= agones-tf-cluster
 current_project := $(shell $(DOCKER_RUN) bash -c "gcloud config get-value project 2> /dev/null")
 
 ### Deploy cluster with Terraform
-terraform-init: TERRAFORM_BUILD_DIR ?= $(mount_path)/build/terraform/gke
+terraform-init: TERRAFORM_BUILD_DIR ?= $(mount_path)/build/terraform/$(DIRECTORY)
 terraform-init: $(ensure-build-image)
 terraform-init:
 	docker run --rm -it $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c '\

--- a/build/terraform/e2e/module.tf
+++ b/build/terraform/e2e/module.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "~> 3.88"
+      version = "~> 4.25.0"
     }
     helm = {
       source = "hashicorp/helm"
@@ -38,11 +38,12 @@ module "gke_cluster" {
   source = "../../../install/terraform/modules/gke"
 
   cluster = {
-    "name"             = "e2e-test-cluster"
-    "zone"             = "us-west1-c"
-    "machineType"      = "e2-standard-4"
-    "initialNodeCount" = 10
-    "project"          = var.project
+    "name"                  = "e2e-test-cluster"
+    "zone"                  = "us-west1-c"
+    "machineType"           = "e2-standard-4"
+    "initialNodeCount"      = 10
+    "enableImageStreaming"  = true
+    "project"               = var.project
   }
 
   firewallName = "gke-game-server-firewall"
@@ -82,4 +83,5 @@ resource "google_compute_firewall" "tcp" {
   }
 
   target_tags = ["game-server"]
+  source_ranges = ["0.0.0.0/0"]
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:
- Enable image streaming for e2e test cluster
- Update the version of the Terraform that creates e2e test cluster to "4.25.0". And add the `source_ranges` field to `google_compute_firewall` to fix a [Terraform backward incompatible issue](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_4_upgrade#resource-google_compute_firewall)
- Fix a bug that the `TERRAFORM_BUILD_DIR` does not respect the input `DIRECTORY` parameter

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


