### PR TITLE
Update game server allocation yaml files to use selectors

### DIFF
--- a/examples/simple-game-server/gameserverallocation.yaml
+++ b/examples/simple-game-server/gameserverallocation.yaml
@@ -24,6 +24,6 @@ spec:
   # however we can also make available `matchExpressions` for even greater
   # flexibility.
   # Below is an example of a GameServer allocated against a given fleet.
-  required:
-    matchLabels:
-      agones.dev/fleet: simple-game-server
+  selectors:
+    - matchLabels:
+        agones.dev/fleet: simple-game-server

--- a/examples/supertuxkart/gameserverallocation.yaml
+++ b/examples/supertuxkart/gameserverallocation.yaml
@@ -15,6 +15,6 @@
 apiVersion: "allocation.agones.dev/v1"
 kind: GameServerAllocation
 spec:
-  required:
-    matchLabels:
-      agones.dev/fleet: supertuxkart
+  selectors:
+    - matchLabels:
+        agones.dev/fleet: supertuxkart

--- a/examples/xonotic/gameserverallocation.yaml
+++ b/examples/xonotic/gameserverallocation.yaml
@@ -20,6 +20,6 @@ spec:
   # however we can also make available `matchExpressions` for even greater
   # flexibility.
   # Below is an example of a GameServer allocated against a given fleet.
-  required:
-    matchLabels:
-      agones.dev/fleet: xonotic
+  selectors:
+    - matchLabels:
+        agones.dev/fleet: xonotic


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
The use of "required" and "preferred" is deprecated within the game server allocation yaml files. To reflect the deprecation, we are changing the allocation yaml files within /examples.

**Which issue(s) this PR fixes**:
Closes #2771 

**Special notes for your reviewer**:


