### PR TITLE
Split port allocators, implement Autopilot port allocation/policies

### DIFF
--- a/pkg/cloudproduct/cloudproduct.go
+++ b/pkg/cloudproduct/cloudproduct.go
@@ -19,10 +19,14 @@ import (
 	"fmt"
 
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"agones.dev/agones/pkg/client/informers/externalversions"
 	"agones.dev/agones/pkg/cloudproduct/generic"
 	"agones.dev/agones/pkg/cloudproduct/gke"
+	"agones.dev/agones/pkg/portallocator"
 	"agones.dev/agones/pkg/util/runtime"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -33,6 +37,12 @@ type CloudProduct interface {
 	// SyncPodPortsToGameServer runs after a Pod has been assigned to a Node and before we sync
 	// Pod host ports to the GameServer status.
 	SyncPodPortsToGameServer(*agonesv1.GameServer, *corev1.Pod) error
+
+	// ValidateGameServer is called by GameServer.Validate to allow for product specific validation.
+	ValidateGameServer(*agonesv1.GameServer) []metav1.StatusCause
+
+	// NewPortAllocator creates a PortAllocator. See gameservers.NewPortAllocator for parameters.
+	NewPortAllocator(int32, int32, informers.SharedInformerFactory, externalversions.SharedInformerFactory) portallocator.Interface
 }
 
 const (

--- a/pkg/cloudproduct/generic/generic.go
+++ b/pkg/cloudproduct/generic/generic.go
@@ -15,7 +15,11 @@ package generic
 
 import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"agones.dev/agones/pkg/client/informers/externalversions"
+	"agones.dev/agones/pkg/portallocator"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 )
 
 func New() (*generic, error) { return &generic{}, nil }
@@ -23,3 +27,13 @@ func New() (*generic, error) { return &generic{}, nil }
 type generic struct{}
 
 func (*generic) SyncPodPortsToGameServer(*agonesv1.GameServer, *corev1.Pod) error { return nil }
+
+func (*generic) NewPortAllocator(minPort, maxPort int32,
+	kubeInformerFactory informers.SharedInformerFactory,
+	agonesInformerFactory externalversions.SharedInformerFactory) portallocator.Interface {
+	return portallocator.New(minPort, maxPort, kubeInformerFactory, agonesInformerFactory)
+}
+
+func (*generic) ValidateGameServer(*agonesv1.GameServer) []metav1.StatusCause {
+	return nil
+}

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -126,10 +126,10 @@ func TestControllerSyncGameServer(t *testing.T) {
 			return true, gs, nil
 		})
 
-		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced, c.portAllocator.nodeSynced)
+		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced)
 		defer cancel()
 
-		err := c.portAllocator.syncAll()
+		err := c.portAllocator.Run(ctx)
 		assert.Nil(t, err)
 
 		err = c.syncGameServer(ctx, "default/test")
@@ -213,10 +213,10 @@ func TestControllerSyncGameServerWithDevIP(t *testing.T) {
 			return true, gs, nil
 		})
 
-		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced, c.portAllocator.nodeSynced)
+		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced)
 		defer cancel()
 
-		err := c.portAllocator.syncAll()
+		err := c.portAllocator.Run(ctx)
 		assert.Nil(t, err)
 
 		err = c.syncGameServer(ctx, "default/test")
@@ -241,10 +241,10 @@ func TestControllerSyncGameServerWithDevIP(t *testing.T) {
 			return true, nil, nil
 		})
 
-		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced, c.portAllocator.nodeSynced)
+		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced)
 		defer cancel()
 
-		err := c.portAllocator.syncAll()
+		err := c.portAllocator.Run(ctx)
 		require.NoError(t, err)
 
 		err = c.syncGameServer(ctx, "default/test")
@@ -695,9 +695,9 @@ func TestControllerSyncGameServerPortAllocationState(t *testing.T) {
 			return true, gs, nil
 		})
 
-		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced, c.portAllocator.nodeSynced)
+		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced)
 		defer cancel()
-		err := c.portAllocator.syncAll()
+		err := c.portAllocator.Run(ctx)
 		require.NoError(t, err)
 
 		result, err := c.syncGameServerPortAllocationState(ctx, fixture)
@@ -734,9 +734,9 @@ func TestControllerSyncGameServerPortAllocationState(t *testing.T) {
 			return true, gs, errors.New("update-err")
 		})
 
-		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced, c.portAllocator.nodeSynced)
+		ctx, cancel := agtesting.StartInformers(mocks, c.gameServerSynced)
 		defer cancel()
-		err := c.portAllocator.syncAll()
+		err := c.portAllocator.Run(ctx)
 		require.NoError(t, err)
 
 		_, err = c.syncGameServerPortAllocationState(ctx, fixture)

--- a/pkg/portallocator/doc.go
+++ b/pkg/portallocator/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package portallocator defines a generic port allocator for game servers
+package portallocator

--- a/pkg/portallocator/portallocator.go
+++ b/pkg/portallocator/portallocator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package portallocator
 
 import (
 	"context"
@@ -33,17 +33,27 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// portallocator.Interface manages the dynamic port allocation strategy.
+//
+// The portallocator does not currently support mixing static portAllocations (or any pods with defined HostPort)
+// within the dynamic port range other than the ones it coordinates.
+type Interface interface {
+	// Run sets up the current state of port allocations and
+	// starts tracking Pod and Node changes
+	Run(ctx context.Context) error
+
+	// Allocate assigns a port to the GameServer and returns it.
+	Allocate(gs *agonesv1.GameServer) *agonesv1.GameServer
+
+	// DeAllocate marks the given ports as no longer allocated
+	DeAllocate(gs *agonesv1.GameServer)
+}
+
 // A set of port allocations for a node
 type portAllocation map[int32]bool
 
-// PortAllocator manages the dynamic port
-// allocation strategy. Only use exposed methods to ensure
-// appropriate locking is taken.
-// The PortAllocator does not currently support mixing static portAllocations (or any pods with defined HostPort)
-// within the dynamic port range other than the ones it coordinates.
-//
 //nolint:govet // ignore fieldalignment, singleton
-type PortAllocator struct {
+type portAllocator struct {
 	logger             *logrus.Entry
 	mutex              sync.RWMutex
 	portAllocations    []portAllocation
@@ -58,18 +68,23 @@ type PortAllocator struct {
 	nodeInformer       cache.SharedIndexInformer
 }
 
-// NewPortAllocator returns a new dynamic port
-// allocator. minPort and maxPort are the top and bottom portAllocations that can be allocated in the range for
-// the game servers
-func NewPortAllocator(minPort, maxPort int32,
+// New returns a new dynamic port allocator. minPort and maxPort are the
+// top and bottom portAllocations that can be allocated in the range for
+// the game servers.
+func New(minPort, maxPort int32,
 	kubeInformerFactory informers.SharedInformerFactory,
-	agonesInformerFactory externalversions.SharedInformerFactory) *PortAllocator {
+	agonesInformerFactory externalversions.SharedInformerFactory) Interface {
+	return newAllocator(minPort, maxPort, kubeInformerFactory, agonesInformerFactory)
+}
 
+func newAllocator(minPort, maxPort int32,
+	kubeInformerFactory informers.SharedInformerFactory,
+	agonesInformerFactory externalversions.SharedInformerFactory) *portAllocator {
 	v1 := kubeInformerFactory.Core().V1()
 	nodes := v1.Nodes()
 	gameServers := agonesInformerFactory.Agones().V1().GameServers()
 
-	pa := &PortAllocator{
+	pa := &portAllocator{
 		mutex:              sync.RWMutex{},
 		minPort:            minPort,
 		maxPort:            maxPort,
@@ -93,7 +108,7 @@ func NewPortAllocator(minPort, maxPort int32,
 
 // Run sets up the current state of port allocations and
 // starts tracking Pod and Node changes
-func (pa *PortAllocator) Run(ctx context.Context) error {
+func (pa *portAllocator) Run(ctx context.Context) error {
 	pa.logger.Debug("Running")
 
 	if !cache.WaitForCacheSync(ctx.Done(), pa.gameServerSynced, pa.nodeSynced) {
@@ -109,7 +124,7 @@ func (pa *PortAllocator) Run(ctx context.Context) error {
 }
 
 // Allocate assigns a port to the GameServer and returns it.
-func (pa *PortAllocator) Allocate(gs *agonesv1.GameServer) *agonesv1.GameServer {
+func (pa *portAllocator) Allocate(gs *agonesv1.GameServer) *agonesv1.GameServer {
 	pa.mutex.Lock()
 	defer pa.mutex.Unlock()
 
@@ -205,8 +220,8 @@ func (pa *PortAllocator) Allocate(gs *agonesv1.GameServer) *agonesv1.GameServer 
 	return allocate(gs)
 }
 
-// DeAllocate marks the given port as no longer allocated
-func (pa *PortAllocator) DeAllocate(gs *agonesv1.GameServer) {
+// DeAllocate marks the given ports as no longer allocated
+func (pa *portAllocator) DeAllocate(gs *agonesv1.GameServer) {
 	// skip if it wasn't previously allocated
 
 	found := func() bool {
@@ -238,7 +253,7 @@ func (pa *PortAllocator) DeAllocate(gs *agonesv1.GameServer) {
 
 // syncDeleteGameServer when a GameServer Pod is deleted
 // make the HostPort available
-func (pa *PortAllocator) syncDeleteGameServer(object interface{}) {
+func (pa *portAllocator) syncDeleteGameServer(object interface{}) {
 	if gs, ok := object.(*agonesv1.GameServer); ok {
 		pa.logger.WithField("gs", gs).Debug("Syncing deleted GameServer")
 		pa.DeAllocate(gs)
@@ -251,7 +266,7 @@ func (pa *PortAllocator) syncDeleteGameServer(object interface{}) {
 // portAllocations are marked as taken.
 // Locks the mutex while doing this.
 // This is basically a stop the world Garbage Collection on port allocations, but it only happens on startup.
-func (pa *PortAllocator) syncAll() error {
+func (pa *portAllocator) syncAll() error {
 	pa.mutex.Lock()
 	defer pa.mutex.Unlock()
 
@@ -289,7 +304,7 @@ func (pa *PortAllocator) syncAll() error {
 // registerExistingGameServerPorts registers the gameservers against gsRegistry and the ports against nodePorts.
 // and returns an ordered list of portAllocations per cluster nodes, and an array of
 // any GameServers allocated a port, but not yet assigned a Node will returned as an array of port values.
-func (pa *PortAllocator) registerExistingGameServerPorts(gameservers []*agonesv1.GameServer, nodes []*corev1.Node, gsRegistry map[types.UID]bool) ([]portAllocation, []int32) {
+func (pa *portAllocator) registerExistingGameServerPorts(gameservers []*agonesv1.GameServer, nodes []*corev1.Node, gsRegistry map[types.UID]bool) ([]portAllocation, []int32) {
 	// setup blank port values
 	nodePortAllocation := pa.nodePortAllocation(nodes)
 	nodePortCount := make(map[string]int64, len(nodes))
@@ -341,7 +356,7 @@ func (pa *PortAllocator) registerExistingGameServerPorts(gameservers []*agonesv1
 
 // nodePortAllocation returns a map of port allocations all set to being available
 // with a map key for each node, as well as the node registry record (since we're already looping)
-func (pa *PortAllocator) nodePortAllocation(nodes []*corev1.Node) map[string]portAllocation {
+func (pa *portAllocator) nodePortAllocation(nodes []*corev1.Node) map[string]portAllocation {
 	nodePorts := map[string]portAllocation{}
 
 	for _, n := range nodes {
@@ -354,7 +369,7 @@ func (pa *PortAllocator) nodePortAllocation(nodes []*corev1.Node) map[string]por
 	return nodePorts
 }
 
-func (pa *PortAllocator) newPortAllocation() portAllocation {
+func (pa *portAllocator) newPortAllocation() portAllocation {
 	p := make(portAllocation, (pa.maxPort-pa.minPort)+1)
 	for i := pa.minPort; i <= pa.maxPort; i++ {
 		p[i] = false

--- a/pkg/portallocator/portallocator_test.go
+++ b/pkg/portallocator/portallocator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package portallocator
 
 import (
 	"fmt"
@@ -48,7 +48,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 
 	t.Run("test allocated port counts", func(t *testing.T) {
 		m := agtesting.NewMocks()
-		pa := NewPortAllocator(10, 50, m.KubeInformerFactory, m.AgonesInformerFactory)
+		pa := newAllocator(10, 50, m.KubeInformerFactory, m.AgonesInformerFactory)
 		nodeWatch := watch.NewFake()
 		m.KubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
 
@@ -137,7 +137,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 
 	t.Run("ports are all allocated", func(t *testing.T) {
 		m := agtesting.NewMocks()
-		pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+		pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 		nodeWatch := watch.NewFake()
 		m.KubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
 
@@ -173,7 +173,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 		m := agtesting.NewMocks()
 		minPort := int32(10)
 		maxPort := int32(20)
-		pa := NewPortAllocator(minPort, maxPort, m.KubeInformerFactory, m.AgonesInformerFactory)
+		pa := newAllocator(minPort, maxPort, m.KubeInformerFactory, m.AgonesInformerFactory)
 		nodeWatch := watch.NewFake()
 		m.KubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
 
@@ -241,7 +241,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 	t.Run("ports are unique in a node", func(t *testing.T) {
 		fixture := dynamicGameServerFixture()
 		m := agtesting.NewMocks()
-		pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+		pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 
 		m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			nl := &corev1.NodeList{Items: []corev1.Node{n1}}
@@ -264,7 +264,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 
 	t.Run("portPolicy as an empty string", func(t *testing.T) {
 		m := agtesting.NewMocks()
-		pa := NewPortAllocator(10, 50, m.KubeInformerFactory, m.AgonesInformerFactory)
+		pa := newAllocator(10, 50, m.KubeInformerFactory, m.AgonesInformerFactory)
 		nodeWatch := watch.NewFake()
 		m.KubeClient.AddWatchReactor("nodes", k8stesting.DefaultWatchReactor(nodeWatch, nil))
 
@@ -292,7 +292,7 @@ func TestPortAllocatorAllocate(t *testing.T) {
 func TestPortAllocatorMultithreadAllocate(t *testing.T) {
 	fixture := dynamicGameServerFixture()
 	m := agtesting.NewMocks()
-	pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+	pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 
 	m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		nl := &corev1.NodeList{Items: []corev1.Node{n1, n2}}
@@ -331,7 +331,7 @@ func TestPortAllocatorDeAllocate(t *testing.T) {
 
 	fixture := dynamicGameServerFixture()
 	m := agtesting.NewMocks()
-	pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+	pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 	nodes := []corev1.Node{n1, n2, n3}
 	m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		nl := &corev1.NodeList{Items: nodes}
@@ -372,7 +372,7 @@ func TestPortAllocatorSyncPortAllocations(t *testing.T) {
 	t.Parallel()
 
 	m := agtesting.NewMocks()
-	pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+	pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 
 	m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		nl := &corev1.NodeList{Items: []corev1.Node{n1, n2, n3}}
@@ -463,7 +463,7 @@ func TestPortAllocatorSyncDeleteGameServer(t *testing.T) {
 		},
 		Status: agonesv1.GameServerStatus{State: agonesv1.GameServerStateReady, Ports: []agonesv1.GameServerStatusPort{{Port: 10}}, NodeName: n2.ObjectMeta.Name}}
 
-	pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+	pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 
 	m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		nl := &corev1.NodeList{Items: []corev1.Node{n1, n2, n3}}
@@ -522,7 +522,7 @@ func TestNodePortAllocation(t *testing.T) {
 	t.Parallel()
 
 	m := agtesting.NewMocks()
-	pa := NewPortAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
+	pa := newAllocator(10, 20, m.KubeInformerFactory, m.AgonesInformerFactory)
 	nodes := []corev1.Node{n1, n2, n3}
 	m.KubeClient.AddReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		nl := &corev1.NodeList{Items: nodes}
@@ -559,7 +559,7 @@ func TestTakePortAllocation(t *testing.T) {
 func TestPortAllocatorRegisterExistingGameServerPorts(t *testing.T) {
 	t.Parallel()
 	m := agtesting.NewMocks()
-	pa := NewPortAllocator(10, 13, m.KubeInformerFactory, m.AgonesInformerFactory)
+	pa := newAllocator(10, 13, m.KubeInformerFactory, m.AgonesInformerFactory)
 
 	gs1 := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs1", UID: "1"},
 		Spec: agonesv1.GameServerSpec{
@@ -603,7 +603,7 @@ func dynamicGameServerFixture() *agonesv1.GameServer {
 
 // countAllocatedPorts counts how many of a given port have been
 // allocated across nodes
-func countAllocatedPorts(pa *PortAllocator, p int32) int {
+func countAllocatedPorts(pa *portAllocator, p int32) int {
 	count := 0
 	for _, node := range pa.portAllocations {
 		if node[p] {
@@ -614,7 +614,7 @@ func countAllocatedPorts(pa *PortAllocator, p int32) int {
 }
 
 // countTotalAllocatedPorts counts the total number of allocated ports
-func countTotalAllocatedPorts(pa *PortAllocator) int {
+func countTotalAllocatedPorts(pa *portAllocator) int {
 	count := 0
 	for _, node := range pa.portAllocations {
 		for _, alloc := range node {
@@ -626,7 +626,7 @@ func countTotalAllocatedPorts(pa *PortAllocator) int {
 	return count
 }
 
-func countTotalPorts(pa *PortAllocator) int {
+func countTotalPorts(pa *portAllocator) int {
 	count := 0
 	for _, node := range pa.portAllocations {
 		count += len(node)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

Continuing #2777: In the Agones on GKE Autopilot implementation, we have no need for the port allocator - the informer/etc. is an unnecessary moving piece. This PR allows for cloud products to provide their own port allocation
implementation. We do this by:

 * Splitting portallocator off to its own package. It was basically self-sufficient anyways, except it was a little too friendly with controller_test.go. I solved that by introducing a `TestInterface` for controller_test.go to upcast to.
 * Allow cloud product implementations to define their own port allocator.
 * Defining a new port allocator for GKE that does a simple per-port HostPort allocation, and adds the host-port-assignment annotation to the pod template.
 * Extend cloudproduct again to add a GameServer validator
 * And in Autopilot, reject if the PortPolicy is not `Dynamic`