### PR TITLE
GameServerRestartBeforeReadyCrash: Run serially

### DIFF
--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -259,7 +259,8 @@ func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 }
 
 func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
-	t.Parallel()
+	// TODO(#2445): The feature is flaky when pod updates are slow, run serially to avoid.
+	// t.Parallel()
 	ctx := context.Background()
 	logger := e2eframework.TestLogger(t)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:

Narrow the race in #2445 by running GameServerRestartBeforeReadyCrash serially. See https://github.com/googleforgames/agones/issues/2445#issuecomment-1302385202 for a detailed analysis.

Does not fix the issue - this is stopgap until we understand how to fix it.