### PR TITLE
Enable fieldalignment linter, then mostly ignore it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ output:
 linters:
   enable:
     - bodyclose
-    - deadcode
     - dupl
     - exportloopref
     - goconst
@@ -61,11 +60,16 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    - structcheck
     - unconvert
     - unparam
 
 linters-settings:
+  govet:
+    disable-all: false
+    enable-all: true
+    disable:
+      # extremely noisy, also against common Go style in most cases
+      - shadow
   gocritic:
     enabled-tags:
       - performance
@@ -90,3 +94,11 @@ issues:
   exclude-use-default: false
   exclude:
     - Using the variable on range scope .* in function literal
+  exclude-rules:
+    # Skip fieldalignment checks on:
+    # - tests: memory footprint doesn't matter
+    # - cmd/: we assume these are one-off config entries
+    # - pkg/apis: Keep strong convention on TypeMeta/ObjectMeta/Spec/Status
+    - path: '(.+)_test\.go|^test/|^cmd/.*|^pkg/apis/.*'
+      # fieldalignment is in the `govet` linter, so exclude based on text instead of all of govet
+      text: '^fieldalignment: .*'

--- a/pkg/cloudproduct/gke/gke.go
+++ b/pkg/cloudproduct/gke/gke.go
@@ -37,6 +37,8 @@ var logger = runtime.NewLoggerWithSource("gke")
 type gkeAutopilot struct{}
 
 // hostPortAssignment is the JSON structure of the `host-port-assignment` annotation
+//
+//nolint:govet // API-like, keep consistent
 type hostPortAssignment struct {
 	Min           int32           `json:"min,omitempty"`
 	Max           int32           `json:"max,omitempty"`

--- a/pkg/fleetautoscalers/controller.go
+++ b/pkg/fleetautoscalers/controller.go
@@ -58,12 +58,16 @@ import (
 )
 
 // fasThread is used for tracking each Fleet's autoscaling jobs
+//
+//nolint:govet // ignore fieldalignment, one per fleet autoscaler
 type fasThread struct {
 	generation int64
 	cancel     context.CancelFunc
 }
 
 // Controller is the FleetAutoscaler controller
+//
+//nolint:govet // ignore fieldalignment, singleton
 type Controller struct {
 	baseLogger            *logrus.Entry
 	clock                 clock.Clock

--- a/pkg/gameserverallocations/allocation_cache.go
+++ b/pkg/gameserverallocations/allocation_cache.go
@@ -48,7 +48,7 @@ func readyOrAllocatedGameServerMatcher(gs *agonesv1.GameServer) bool {
 // AllocationCache maintains a cache of GameServers that could potentially be allocated.
 type AllocationCache struct {
 	baseLogger       *logrus.Entry
-	cache            gameServerCacheEntry
+	cache            gameServerCache
 	gameServerLister listerv1.GameServerLister
 	gameServerSynced cache.InformerSynced
 	workerqueue      *workerqueue.WorkerQueue

--- a/pkg/gameserverallocations/cache.go
+++ b/pkg/gameserverallocations/cache.go
@@ -21,13 +21,15 @@ import (
 )
 
 // gameserver cache to keep the Ready state gameserver.
-type gameServerCacheEntry struct {
+//
+//nolint:govet // ignore fieldalignment, singleton embedded in AllocationCache
+type gameServerCache struct {
 	mu    sync.RWMutex
 	cache map[string]*agonesv1.GameServer
 }
 
 // Store saves the data in the cache.
-func (e *gameServerCacheEntry) Store(key string, gs *agonesv1.GameServer) {
+func (e *gameServerCache) Store(key string, gs *agonesv1.GameServer) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.cache == nil {
@@ -37,7 +39,7 @@ func (e *gameServerCacheEntry) Store(key string, gs *agonesv1.GameServer) {
 }
 
 // Delete deletes the data. If it exists returns true.
-func (e *gameServerCacheEntry) Delete(key string) bool {
+func (e *gameServerCache) Delete(key string) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	ret := false
@@ -52,7 +54,7 @@ func (e *gameServerCacheEntry) Delete(key string) bool {
 }
 
 // Load returns the data from cache. It return true if the value exists in the cache
-func (e *gameServerCacheEntry) Load(key string) (*agonesv1.GameServer, bool) {
+func (e *gameServerCache) Load(key string) (*agonesv1.GameServer, bool) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	val, ok := e.cache[key]
@@ -61,7 +63,7 @@ func (e *gameServerCacheEntry) Load(key string) (*agonesv1.GameServer, bool) {
 }
 
 // Range extracts data from the cache based on provided function f.
-func (e *gameServerCacheEntry) Range(f func(key string, gs *agonesv1.GameServer) bool) {
+func (e *gameServerCache) Range(f func(key string, gs *agonesv1.GameServer) bool) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	for k, v := range e.cache {
@@ -72,7 +74,7 @@ func (e *gameServerCacheEntry) Range(f func(key string, gs *agonesv1.GameServer)
 }
 
 // Len returns the current length of the cache
-func (e *gameServerCacheEntry) Len() int {
+func (e *gameServerCache) Len() int {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	return len(e.cache)

--- a/pkg/gameserverallocations/cache_test.go
+++ b/pkg/gameserverallocations/cache_test.go
@@ -27,7 +27,7 @@ func TestGameServerCacheEntry(t *testing.T) {
 	gs2 := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs2"}}
 	gs3 := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs3"}}
 
-	cache := gameServerCacheEntry{}
+	cache := gameServerCache{}
 
 	gs, ok := cache.Load("gs1")
 	assert.Nil(t, gs)

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -63,6 +63,8 @@ const (
 )
 
 // Controller is a the main GameServer crd controller
+//
+//nolint:govet // ignore fieldalignment, singleton
 type Controller struct {
 	baseLogger             *logrus.Entry
 	sidecarImage           string

--- a/pkg/gameservers/pernodecounter.go
+++ b/pkg/gameservers/pernodecounter.go
@@ -34,6 +34,8 @@ import (
 // Ready GameServers currently exist on each node.
 // This is useful for scheduling allocations, fleet management
 // mostly under a Packed strategy
+//
+//nolint:govet // ignore fieldalignment, singleton
 type PerNodeCounter struct {
 	logger           *logrus.Entry
 	gameServerSynced cache.InformerSynced

--- a/pkg/gameservers/portallocator.go
+++ b/pkg/gameservers/portallocator.go
@@ -41,6 +41,8 @@ type portAllocation map[int32]bool
 // appropriate locking is taken.
 // The PortAllocator does not currently support mixing static portAllocations (or any pods with defined HostPort)
 // within the dynamic port range other than the ones it coordinates.
+//
+//nolint:govet // ignore fieldalignment, singleton
 type PortAllocator struct {
 	logger             *logrus.Entry
 	mutex              sync.RWMutex

--- a/pkg/gameserversets/gameserver_state_cache.go
+++ b/pkg/gameserversets/gameserver_state_cache.go
@@ -23,9 +23,9 @@ import (
 
 // gameServerSetCacheEntry manages a list of items created and deleted locally for a single game server set.
 type gameServerSetCacheEntry struct {
-	mu              sync.Mutex
 	pendingCreation map[string]*agonesv1.GameServer
 	pendingDeletion map[string]*agonesv1.GameServer
+	mu              sync.Mutex
 }
 
 func (e *gameServerSetCacheEntry) created(gs *agonesv1.GameServer) {

--- a/pkg/metrics/controller.go
+++ b/pkg/metrics/controller.go
@@ -68,6 +68,8 @@ func init() {
 }
 
 // Controller is a metrics controller collecting Agones state metrics
+//
+//nolint:govet // ignore fieldalignment, singleton
 type Controller struct {
 	logger                    *logrus.Entry
 	gameServerLister          listerv1.GameServerLister

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -73,6 +73,8 @@ func defaultGs() *sdk.GameServer {
 // LocalSDKServer type is the SDKServer implementation for when the sidecar
 // is being run for local development, and doesn't connect to the
 // Kubernetes cluster
+//
+//nolint:govet // ignore fieldalignment, singleton
 type LocalSDKServer struct {
 	gsMutex           sync.RWMutex
 	gs                *sdk.GameServer

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -429,7 +429,6 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 
 	e := &alpha.Empty{}
 
-	// nolint: maligned
 	fixtures := map[string]struct {
 		testMode bool
 		gs       *agonesv1.GameServer

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -71,7 +71,8 @@ var (
 
 // SDKServer is a gRPC server, that is meant to be a sidecar
 // for a GameServer that will update the game server status on SDK requests
-// nolint: maligned
+//
+//nolint:govet // ignore fieldalignment, singleton
 type SDKServer struct {
 	logger             *logrus.Entry
 	gameServerName     string

--- a/pkg/util/workerqueue/workerqueue.go
+++ b/pkg/util/workerqueue/workerqueue.go
@@ -70,6 +70,8 @@ type Handler func(context.Context, string) error
 // WorkerQueue is an opinionated queue + worker for use
 // with controllers and related and processing Kubernetes watched
 // events and synchronising resources
+//
+//nolint:govet // ignore fieldalignment, singleton
 type WorkerQueue struct {
 	logger  *logrus.Entry
 	keyName string


### PR DESCRIPTION
This enables the fieldalignment linter by enabling all `govet` checks except shadowing. I then configured it to ignore large swaths of code (tests, cmd/, APIs), and nolint'd all the existing complaints because they seemed irrelevant.

Along the way:

* removed existing nolint:maligned, as `maligned` is no more.

* disabled `structcheck` and `deadcode` as they are deprecated (and I
believe have been subsumed by other linters)

* changed `gameServerCacheEntry` to `gameServerCache`. It is the
cache, not just an entry.

* fixed alignment of `gameServerSetCacheEntry`.

/kind cleanup
Closes #2325