### PR TITLE
fix: solve the native collection's memory leak detected by Unity 2021…

### DIFF
--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -290,6 +290,8 @@ namespace Agones
                 Log($"Agones SendRequest failed: {api} {req.error}");
             }
 
+            req.Dispose();
+
             return result;
         }
 


### PR DESCRIPTION
….3.7f1

On Unity 2021.3.7f1, several error messages says "A Native Collection has not been disposed, resulting in a memory leak, Allocated from:xxx"; When look into this issue, it points into AgonesSdk and the UnityWebRequest's Dispose has not been called. After calling the Dispose() at the end of the method, the same error disappeared.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Fix the memory leak detected by the Unity; The whole error message is as follow: "A Native Collection has not been disposed, resulting in a memory leak, Allocated from:xxx";

You can reproduce the issue on Unity 2021.3.7f1, after the fix, the error will disappear.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


