### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/site/content/en/docs/Installation/Creating Cluster/gke.md
+++ b/site/content/en/docs/Installation/Creating Cluster/gke.md
@@ -87,7 +87,7 @@ gcloud container clusters create [CLUSTER_NAME] --cluster-version={{% k8s-versio
   --tags=game-server \
   --scopes=gke-default \
   --num-nodes=4 \
-  --no-enable-autoupgrade \ 
+  --no-enable-autoupgrade \
   --enable-image-streaming \
   --machine-type=e2-standard-4
 ```


### PR DESCRIPTION
This allows the command can be copy/pasted.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
In the past two days I've copied this command a few times and gotten the error `unrecognized arguments: ` followed by `command not found: --enable-image-streaming`. It took me a few minutes to realize it's because there is an extra space, which means the backslash isn't escaping the newline which turns this into two commands (neither of which works). 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


