### PR TITLE
Unreal SDK fix for setting capacity for Player Tracking and Editor error messages

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Classes/Classes.h
+++ b/sdks/unreal/Agones/Source/Agones/Classes/Classes.h
@@ -266,7 +266,7 @@ struct FDuration
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadOnly, Category="Agones")
-	int64 Seconds;
+	int64 Seconds = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -284,7 +284,7 @@ struct FPlayerCapacity
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadOnly, Category="Agones")
-	int64 Count;
+	int64 Count = 0;
 };
 
 USTRUCT(BlueprintType)

--- a/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
+++ b/sdks/unreal/Agones/Source/Agones/Private/AgonesComponent.cpp
@@ -438,7 +438,7 @@ void UAgonesComponent::SetPlayerCapacity(
 		return;
 	}
 
-	FHttpRequestRef Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Post, Json);
+	FHttpRequestRef Request = BuildAgonesRequest("alpha/player/capacity", FHttpVerb::Put, Json);
 	Request->OnProcessRequestComplete().BindWeakLambda(this,
 		[SuccessDelegate, ErrorDelegate](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, const bool bSucceeded) {
 			if (!IsValidResponse(bSucceeded, HttpResponse, ErrorDelegate))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
This PR resolves two problems in the Unreal SDK.
1. Error messages about uninitialized properties is shown in the Unreal Editor at startup. This is from the `FDuration` and `FPlayerCapacity` structs not having any default value for their int64 properties.
2. Failure to set the server's player capacity for Player Tracking. This is due to the original implementation using the incorrect HTTP method.

**Which issue(s) this PR fixes**:
Closes #2844
Closes #2845

**Special notes for your reviewer**:
Unreal Engine version 5.1.0

**Build logs***
```
CONSOLE: C:\Program Files\Epic Games\UE_5.0\Engine\Build\BatchFiles\Rebuild.bat  AgonesTestBuildEditor Win64 Development -Project="C:\Users\tomas\Repos\AgonesTestBuild\AgonesTestBuild.uproject" -WaitMutex -FromMsBuild
Cleaning AgonesTestBuildEditor and UnrealHeaderTool binaries...
Using bundled DotNet SDK
Log file: C:\Users\tomas\AppData\Local\UnrealBuildTool\Log.txt
Creating makefile for AgonesTestBuildEditor (no existing makefile)
Parsing headers for AgonesTestBuildEditor
  Running UnrealHeaderTool "C:\Users\tomas\Repos\AgonesTestBuild\AgonesTestBuild.uproject" "C:\Users\tomas\Repos\AgonesTestBuild\Intermediate\Build\Win64\AgonesTestBuildEditor\Development\AgonesTestBuildEditor.uhtmanifest" -LogCmds="loginit warning, logexit warning, logdatabase error" -Unattended -WarningsAsErrors -abslog="C:\Users\tomas\AppData\Local\UnrealBuildTool\Log_UHT.txt" -installed
Reflection code generated for AgonesTestBuildEditor in 2,6697422 seconds
Building AgonesTestBuildEditor...
Using Visual Studio 2022 14.31.31107 toolchain (C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103) and Windows 10.0.19041.0 SDK (C:\Program Files (x86)\Windows Kits\10).
[Adaptive Build] Excluded from AgonesTestBuild unity file: AgonesTestBuild.cpp, AgonesTestBuildGameModeBase.cpp
Determining max actions to execute in parallel (24 physical cores, 48 logical cores)
  Executing up to 24 processes, one per physical core
Building 14 actions with 14 processes...
[1/14] Resource Default.rc2
[2/14] Resource Default.rc2
[3/14] Compile SharedPCH.Engine.ShadowErrors.cpp
[4/14] Compile AgonesTestBuild.init.gen.cpp
[5/14] Compile AgonesTestBuild.cpp
[6/14] Compile AgonesTestBuildGameModeBase.gen.cpp
[7/14] Compile AgonesTestBuildGameModeBase.cpp
[8/14] Link UnrealEditor-AgonesTestBuild.lib
   Creating library C:\Users\tomas\Repos\AgonesTestBuild\Intermediate\Build\Win64\UnrealEditor\Development\AgonesTestBuild\UnrealEditor-AgonesTestBuild.lib and object C:\Users\tomas\Repos\AgonesTestBuild\Intermediate\Build\Win64\UnrealEditor\Development\AgonesTestBuild\UnrealEditor-AgonesTestBuild.exp
[9/14] Compile Module.Agones.cpp
[10/14] Compile Module.Agones.gen.cpp
[11/14] Link UnrealEditor-Agones.lib
   Creating library C:\Users\tomas\Repos\AgonesTestBuild\Plugins\Agones\Intermediate\Build\Win64\UnrealEditor\Development\Agones\UnrealEditor-Agones.lib and object C:\Users\tomas\Repos\AgonesTestBuild\Plugins\Agones\Intermediate\Build\Win64\UnrealEditor\Development\Agones\UnrealEditor-Agones.exp
[12/14] Link UnrealEditor-AgonesTestBuild.dll
   Creating library C:\Users\tomas\Repos\AgonesTestBuild\Intermediate\Build\Win64\UnrealEditor\Development\AgonesTestBuild\UnrealEditor-AgonesTestBuild.suppressed.lib and object C:\Users\tomas\Repos\AgonesTestBuild\Intermediate\Build\Win64\UnrealEditor\Development\AgonesTestBuild\UnrealEditor-AgonesTestBuild.suppressed.exp
[13/14] Link UnrealEditor-Agones.dll
   Creating library C:\Users\tomas\Repos\AgonesTestBuild\Plugins\Agones\Intermediate\Build\Win64\UnrealEditor\Development\Agones\UnrealEditor-Agones.suppressed.lib and object C:\Users\tomas\Repos\AgonesTestBuild\Plugins\Agones\Intermediate\Build\Win64\UnrealEditor\Development\Agones\UnrealEditor-Agones.suppressed.exp
[14/14] WriteMetadata AgonesTestBuildEditor.target
Total time in Parallel executor: 37,97 seconds
Total execution time: 42,66 seconds
Rebuild succeeded at 11:43:45 AM 
```