### PR TITLE
fix(make): current_project will be executed only when the relevant command is executed

### DIFF
--- a/build/includes/google-cloud.mk
+++ b/build/includes/google-cloud.mk
@@ -50,7 +50,7 @@ clean-gcloud-test-cluster: $(ensure-build-image)
 
 # Creates a gcloud cluster for end-to-end
 # it installs also a consul cluster to handle build system concurrency using a distributed lock
-gcloud-e2e-test-cluster: GCP_PROJECT ?= $(current_project)
+gcloud-e2e-test-cluster: GCP_PROJECT ?= $(shell $(current_project))
 gcloud-e2e-test-cluster: $(ensure-build-image)
 gcloud-e2e-test-cluster:
 	$(MAKE) terraform-init DIRECTORY=e2e
@@ -58,14 +58,14 @@ gcloud-e2e-test-cluster:
       	terraform apply -auto-approve -var project="$(GCP_PROJECT)"'
 
 # Deletes the gcloud e2e cluster and cleanup any left pvc volumes
-clean-gcloud-e2e-test-cluster: GCP_PROJECT ?= $(current_project)
+clean-gcloud-e2e-test-cluster: GCP_PROJECT ?= $(shell $(current_project))
 clean-gcloud-e2e-test-cluster: $(ensure-build-image)
 clean-gcloud-e2e-test-cluster:
 	$(MAKE) terraform-init DIRECTORY=e2e
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/e2e && terraform destroy -var project=$(GCP_PROJECT) -auto-approve'
 
 # Creates a gcloud cluster for prow
-gcloud-prow-build-cluster: GCP_PROJECT ?= $(current_project)
+gcloud-prow-build-cluster: GCP_PROJECT ?= $(shell $(current_project))
 gcloud-prow-build-cluster: $(ensure-build-image)
 gcloud-prow-build-cluster:
 	$(MAKE) terraform-init DIRECTORY=prow

--- a/build/includes/terraform.mk
+++ b/build/includes/terraform.mk
@@ -16,7 +16,7 @@
 GCP_TF_CLUSTER_NAME ?= agones-tf-cluster
 
 # the current project
-current_project := $(shell $(DOCKER_RUN) bash -c "gcloud config get-value project 2> /dev/null")
+current_project := $(DOCKER_RUN) bash -c "gcloud config get-value project 2> /dev/null"
 
 ### Deploy cluster with Terraform
 terraform-init: TERRAFORM_BUILD_DIR ?= $(mount_path)/build/terraform/$(DIRECTORY)
@@ -48,7 +48,7 @@ gcloud-terraform-cluster: GCP_TF_CLUSTER_NAME ?= agones-tf-cluster
 gcloud-terraform-cluster: LOG_LEVEL ?= debug
 gcloud-terraform-cluster: $(ensure-build-image)
 gcloud-terraform-cluster: FEATURE_GATES := ""
-gcloud-terraform-cluster: GCP_PROJECT ?= $(current_project)
+gcloud-terraform-cluster: GCP_PROJECT ?= $(shell $(current_project))
 gcloud-terraform-cluster:
 	$(MAKE) terraform-init DIRECTORY=gke
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && \
@@ -85,7 +85,7 @@ gcloud-terraform-install: CRD_CLEANUP := true
 gcloud-terraform-install: GCP_TF_CLUSTER_NAME ?= agones-tf-cluster
 gcloud-terraform-install: LOG_LEVEL ?= debug
 gcloud-terraform-install: FEATURE_GATES := $(ALPHA_FEATURE_GATES)
-gcloud-terraform-install: GCP_PROJECT ?= $(current_project)
+gcloud-terraform-install: GCP_PROJECT ?= $(shell $(current_project))
 gcloud-terraform-install:
 	$(MAKE) terraform-init DIRECTORY=gke
 	$(DOCKER_RUN) bash -c ' \
@@ -109,13 +109,13 @@ gcloud-terraform-install:
 		-var windows_machine_type=$(GCP_CLUSTER_NODEPOOL_WINDOWSMACHINETYPE)'
 	GCP_CLUSTER_NAME=$(GCP_TF_CLUSTER_NAME) $(MAKE) gcloud-auth-cluster
 
-gcloud-terraform-destroy-cluster: GCP_PROJECT ?= $(current_project)
+gcloud-terraform-destroy-cluster: GCP_PROJECT ?= $(shell $(current_project))
 gcloud-terraform-destroy-cluster:
 	$(MAKE) terraform-init DIRECTORY=gke
 	$(DOCKER_RUN) bash -c 'cd $(mount_path)/build/terraform/gke && terraform destroy -var project=$(GCP_PROJECT) -auto-approve'
 
 terraform-test: $(ensure-build-image)
-terraform-test: GCP_PROJECT ?= $(current_project)
+terraform-test: GCP_PROJECT ?= $(shell $(current_project))
 terraform-test:
 	$(MAKE) terraform-init TERRAFORM_BUILD_DIR=$(mount_path)/test/terraform
 	$(MAKE) run-terraform-test GCP_PROJECT=$(GCP_PROJECT)


### PR DESCRIPTION
Signed-off-by: aimuz <mr.imuz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

/kind bug

**What this PR does / Why we need it**:

Before restoration

```
➜  build git:(main) make        
Unable to find image 'agones-build:f1d1057367' locally
docker: Error response from daemon: pull access denied for agones-build, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
kubectl port-forward deployments/agones-controller -n agones-system 8080
Error from server (NotFound): namespaces "agones-system" not found
make: *** [controller-portforward] Error 1

```

After restoration

```
➜  build git:(fix-make) make     
kubectl port-forward deployments/agones-controller -n agones-system 8080
Error from server (NotFound): namespaces "agones-system" not found
make: *** [controller-portforward] Error 1

```

docker run was executed in the wrong phase 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


