### PR TITLE
Rename `LifecycleContract` feature gate to `SafeToEvict`

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -68,7 +68,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.14
 
 # Enable all alpha feature gates. Keep in sync with `false` (alpha) entries in pkg/util/runtime/features.go:featureDefaults
-ALPHA_FEATURE_GATES ?= "LifecycleContract=true&PlayerAllocationFilter=true&PlayerTracking=true&ResetMetricsOnDelete=true&Example=true"
+ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&PlayerTracking=true&ResetMetricsOnDelete=true&SafeToEvict=true&Example=true"
 
 # Build with Windows support
 WITH_WINDOWS=1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -245,7 +245,7 @@ steps:
 
 - name: 'e2e-runner'
   args:
-    - 'CustomFasSyncInterval=false&SDKGracefulTermination=false&StateAllocationFilter=false&LifecycleContract=true&PlayerAllocationFilter=true&PlayerTracking=true&ResetMetricsOnDelete=true&Example=true'
+    - 'CustomFasSyncInterval=false&SDKGracefulTermination=false&StateAllocationFilter=false&PlayerAllocationFilter=true&PlayerTracking=true&ResetMetricsOnDelete=true&SafeToEvict=true&Example=true'
     - 'e2e-test-cluster'
     - "${_REGISTRY}"
   id: e2e-feature-gates

--- a/install/helm/agones/defaultfeaturegates.yaml
+++ b/install/helm/agones/defaultfeaturegates.yaml
@@ -20,10 +20,10 @@ SDKGracefulTermination: true
 StateAllocationFilter: true
 
 # Alpha features
-LifecycleContract: false
 PlayerAllocationFilter: false
 PlayerTracking: false
 ResetMetricsOnDelete: false
+SafeToEvict: false
 
 # Example feature
 Example: false

--- a/install/helm/agones/templates/crds/_gameserverspecschema.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecschema.yaml
@@ -153,7 +153,7 @@ properties:
             type: integer
             title: The initial player capacity of this Game Server
             minimum: 0
-{{- if .featureLifecycleContract }}
+{{- if .featureSafeToEvict }}
       immutableReplicas:
         type: integer
         title: Immutable count of Pods to a GameServer. Always 1. (Implementation detail of implementing the Scale subresource.)

--- a/install/helm/agones/templates/crds/_gameserverstatus.yaml
+++ b/install/helm/agones/templates/crds/_gameserverstatus.yaml
@@ -65,7 +65,7 @@ status:
           nullable: true
           items:
             type: string
-{{- if .featureLifecycleContract }}
+{{- if .featureSafeToEvict }}
     immutableReplicas:
       type: integer
       title: Immutable count of Pods to a GameServer. Always 1. (Implementation detail of implementing the Scale subresource.)

--- a/install/helm/agones/templates/crds/fleet.yaml
+++ b/install/helm/agones/templates/crds/fleet.yaml
@@ -100,7 +100,7 @@ spec:
                             - type: integer
                             - type: string
                 template:
-                  {{- $data := dict "metadata" true "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureLifecycleContract" $featureGates.LifecycleContract }}
+                  {{- $data := dict "metadata" true "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureSafeToEvict" $featureGates.SafeToEvict }}
                   {{- include "gameserver.schema" $data | indent 17 }}
             status:
               description: 'FleetStatus is the status of a Fleet. More info:

--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -56,10 +56,10 @@ spec:
           type: date
       schema:
         openAPIV3Schema:
-          {{- $data := dict "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureLifecycleContract" $featureGates.LifecycleContract }}
+          {{- $data := dict "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureSafeToEvict" $featureGates.SafeToEvict }}
           {{- include "gameserver.schema" $data | indent 9 }}{{- /* include the schema then status, as it's easier to align */ -}}
           {{- include "gameserver.status" $data | indent 11 }}
-{{- if $featureGates.LifecycleContract }}
+{{- if $featureGates.SafeToEvict }}
       subresources:
         # scale enables the scale subresource. We can't actually scale GameServers, but this allows
         # for the use of PodDisruptionBudget (PDB) without having to use a PDB per Pod.

--- a/install/helm/agones/templates/crds/gameserverset.yaml
+++ b/install/helm/agones/templates/crds/gameserverset.yaml
@@ -80,7 +80,7 @@ spec:
                     - Packed
                     - Distributed
                 template:
-                  {{- $data := dict "metadata" true "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureLifecycleContract" $featureGates.LifecycleContract }}
+                  {{- $data := dict "metadata" true "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureSafeToEvict" $featureGates.SafeToEvict }}
                   {{- include "gameserver.schema" $data | indent 18 }}
             status:
               description: 'GameServerSetStatus is the status of a GameServerSet. More info:

--- a/install/helm/agones/templates/pdb.yaml
+++ b/install/helm/agones/templates/pdb.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $featureGates := include "agones.featureGates" . | fromYaml }}
-{{- if $featureGates.LifecycleContract }}
+{{- if $featureGates.SafeToEvict }}
 {{- range .Values.gameservers.namespaces }}
 ---
 apiVersion: policy/v1

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -43,9 +43,6 @@ const (
 	////////////////
 	// Alpha features
 
-	// FeatureLifecycleContract enables the `lifecycleContract` API to specify disruption tolerance.
-	FeatureLifecycleContract Feature = "LifecycleContract"
-
 	// FeaturePlayerAllocationFilter is a feature flag that enables the ability for Allocations to filter based on
 	// player capacity.
 	FeaturePlayerAllocationFilter Feature = "PlayerAllocationFilter"
@@ -56,6 +53,9 @@ const (
 	// FeatureResetMetricsOnDelete is a feature flag that tells the metrics service to unregister and register
 	// relevant metric views to reset their state immediately when an Agones resource is deleted.
 	FeatureResetMetricsOnDelete Feature = "ResetMetricsOnDelete"
+
+	// FeatureSafeToEvict enables the `SafeToEvict` API to specify disruption tolerance.
+	FeatureSafeToEvict Feature = "SafeToEvict"
 
 	////////////////
 	// Example feature
@@ -97,10 +97,10 @@ var (
 		FeatureStateAllocationFilter:  true,
 
 		// Alpha features
-		FeatureLifecycleContract:      false,
 		FeaturePlayerAllocationFilter: false,
 		FeaturePlayerTracking:         false,
 		FeatureResetMetricsOnDelete:   false,
+		FeatureSafeToEvict:            false,
 
 		// Example feature
 		FeatureExample: false,

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -30,10 +30,10 @@ The current set of `alpha` and `beta` feature gates:
 | [Custom resync period for FleetAutoscaler](https://github.com/googleforgames/agones/issues/1955)                      | `CustomFasSyncInterval`  | Enabled  | `Beta`  | 1.25.0 |
 | [Graceful Termination for GameServer SDK](https://github.com/googleforgames/agones/pull/2205)                         | `SDKGracefulTermination` | Enabled  | `Beta`  | 1.18.0 |
 | [GameServer state filtering on GameServerAllocations](https://github.com/googleforgames/agones/issues/1239)           | `StateAllocationFilter`  | Enabled  | `Beta`  | 1.26.0 |
-| [Lifecycle Contracts](https://github.com/googleforgames/agones/issues/2794)                                           | `LifecycleContract`      | Disabled | `Alpha` | 1.28.0 |
 | [GameServer player capacity filtering on GameServerAllocations](https://github.com/googleforgames/agones/issues/1239) | `PlayerAllocationFilter` | Disabled | `Alpha` | 1.14.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}})                                                      | `PlayerTracking`         | Disabled | `Alpha` | 1.6.0  |
 | [Reset Metric Export on Fleet / Autoscaler deletion]({{% relref "./metrics.md#dropping-metric-labels" %}})            | `ResetMetricsOnDelete`   | Disabled | `Alpha` | 1.26.0 |
+| [GameServer `SafeToEvict` API](https://github.com/googleforgames/agones/issues/2794)                                  | `SafeToEvict`            | Disabled | `Alpha` | 1.29.0 |
 | Example Gate (not in use)                                                                                             | `Example`                | Disabled | None    | 0.13.0 |
 {{% /feature %}}
 {{% feature expiryVersion="1.29.0" %}}


### PR DESCRIPTION
Per #2794, rename `LifecycleContract` to `SafeToEvict`.

**Special notes for your reviewer**:

Sits on top of #2836 - merge that one first.
