### PR TITLE
SafeToEvict: Implement Eviction API, add SetEviction cloud product hook

### DIFF
--- a/install/helm/agones/templates/crds/_gameserverspecschema.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecschema.yaml
@@ -154,6 +154,21 @@ properties:
             title: The initial player capacity of this Game Server
             minimum: 0
 {{- if .featureSafeToEvict }}
+      eviction:
+        type: object
+        title: Eviction tolerance of the game server
+        properties:
+          safe:
+            type: string
+            title: Game server supports termination via SIGTERM
+            description: |
+              - Never: The game server should run to completion. Agones sets Pod annotation `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` and label `agones.dev/safe-to-evict: "false"`, which matches a restrictive PodDisruptionBudget.
+              - OnUpgrade: On SIGTERM, the game server will exit within `terminationGracePeriodSeconds` or be terminated; Agones sets Pod annotation `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"`, which blocks evictions by Cluster Autoscaler. Evictions from node upgrades proceed normally.
+              - Always: On SIGTERM, the game server will exit within `terminationGracePeriodSeconds` or be terminated, typically within 10m; Agones sets Pod annotation `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`, which allows evictions by Cluster Autoscaler.
+            enum:
+            - Always
+            - OnUpgrade
+            - Never
       immutableReplicas:
         type: integer
         title: Immutable count of Pods to a GameServer. Always 1. (Implementation detail of implementing the Scale subresource.)

--- a/install/helm/agones/templates/crds/_gameserverstatus.yaml
+++ b/install/helm/agones/templates/crds/_gameserverstatus.yaml
@@ -66,6 +66,15 @@ status:
           items:
             type: string
 {{- if .featureSafeToEvict }}
+    eviction:
+      type: object
+      properties:
+        safe:
+          type: string
+          enum:
+          - Always
+          - OnUpgrade
+          - Never
     immutableReplicas:
       type: integer
       title: Immutable count of Pods to a GameServer. Always 1. (Implementation detail of implementing the Scale subresource.)

--- a/pkg/apis/agones/v1/apihooks_test.go
+++ b/pkg/apis/agones/v1/apihooks_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	"agones.dev/agones/pkg/util/runtime"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetEviction(t *testing.T) {
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
+
+	emptyPodAnd := func(f func(*corev1.Pod)) *corev1.Pod {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+				Labels:      map[string]string{},
+			},
+		}
+		f(pod)
+		return pod
+	}
+	for desc, tc := range map[string]struct {
+		featureFlags string
+		safeToEvict  EvictionSafe
+		pod          *corev1.Pod
+		wantPod      *corev1.Pod
+	}{
+		"SafeToEvict feature gate disabled => no change": {
+			featureFlags: "SafeToEvict=false",
+			// intentionally leave pod nil, it'll crash if anything's touched.
+		},
+		"SafeToEvict: Always, no incoming labels/annotations": {
+			featureFlags: "SafeToEvict=true",
+			safeToEvict:  EvictionSafeAlways,
+			pod:          emptyPodAnd(func(*corev1.Pod) {}),
+			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = True
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = True
+			}),
+		},
+		"SafeToEvict: OnUpgrade, no incoming labels/annotations": {
+			featureFlags: "SafeToEvict=true",
+			safeToEvict:  EvictionSafeOnUpgrade,
+			pod:          emptyPodAnd(func(*corev1.Pod) {}),
+			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = False
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = True
+			}),
+		},
+		"SafeToEvict: Never, no incoming labels/annotations": {
+			featureFlags: "SafeToEvict=true",
+			safeToEvict:  EvictionSafeNever,
+			pod:          emptyPodAnd(func(*corev1.Pod) {}),
+			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = False
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = False
+			}),
+		},
+		"SafeToEvict: Always, incoming labels/annotations": {
+			featureFlags: "SafeToEvict=true",
+			safeToEvict:  EvictionSafeAlways,
+			pod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = "just don't touch, ok?"
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = "seriously, leave it"
+			}),
+			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = "just don't touch, ok?"
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = "seriously, leave it"
+			}),
+		},
+		"SafeToEvict: OnUpgrade, incoming labels/annotations": {
+			featureFlags: "SafeToEvict=true",
+			safeToEvict:  EvictionSafeOnUpgrade,
+			pod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = "better not touch"
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = "not another one"
+			}),
+			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = "better not touch"
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = "not another one"
+			}),
+		},
+		"SafeToEvict: Never, incoming labels/annotations": {
+			featureFlags: "SafeToEvict=true",
+			safeToEvict:  EvictionSafeNever,
+			pod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = "a passthrough"
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = "or is it passthru?"
+			}),
+			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
+				pod.ObjectMeta.Annotations[PodSafeToEvictAnnotation] = "a passthrough"
+				pod.ObjectMeta.Labels[SafeToEvictLabel] = "or is it passthru?"
+			}),
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			err := runtime.ParseFeatures(tc.featureFlags)
+			assert.NoError(t, err)
+
+			err = (generic{}).SetEviction(tc.safeToEvict, tc.pod)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantPod, tc.pod)
+		})
+	}
+}

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -3029,6 +3029,9 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 <p>Packages:</p>
 <ul>
 <li>
+<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
+</li>
+<li>
 <a href="#agones.dev%2fv1">agones.dev/v1</a>
 </li>
 <li>
@@ -3037,10 +3040,296 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 <li>
 <a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
 </li>
-<li>
-<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
-</li>
 </ul>
+<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
+</li></ul>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
+</h3>
+<p>
+<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+multicluster.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerAllocationPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-23.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
+GameServerAllocationPolicySpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>priority</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
+</p>
+<p>
+<p>ClusterConnectionInfo defines the connection information for a cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clusterName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Optional: the name of the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationEndpoints</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The endpoints for the allocator service in the targeted cluster.
+If the AllocationEndpoints is not set, the allocation happens on local cluster.
+If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The cluster namespace from which to allocate gameservers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverCa</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
+</h3>
+<p>
+<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currPriority</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>currPriority Current priority index from the orderedPriorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>orderedPriorities</code></br>
+<em>
+[]int32
+</em>
+</td>
+<td>
+<p>orderedPriorities list of ordered priorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorityToCluster</code></br>
+<em>
+map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
+</em>
+</td>
+<td>
+<p>priorityToCluster Map of priority to cluster-policies map</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterBlackList</code></br>
+<em>
+map[string]bool
+</em>
+</td>
+<td>
+<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
+</p>
+<p>
+<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>priority</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <h2 id="agones.dev/v1">agones.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
@@ -3325,6 +3614,20 @@ PlayersSpec
 <p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>eviction</code></br>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, SafeToEvict feature flag) Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -3493,6 +3796,52 @@ int64
 </tr>
 </tbody>
 </table>
+<h3 id="agones.dev/v1.Eviction">Eviction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>Eviction specifies the eviction tolerance of the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>safe</code></br>
+<em>
+<a href="#agones.dev/v1.EvictionSafe">
+EvictionSafe
+</a>
+</em>
+</td>
+<td>
+<p>(Alpha, SafeToEvict feature flag)
+Game server supports termination via SIGTERM:
+- Always: Allow eviction for both Cluster Autoscaler and node drain for upgrades
+- OnUpgrade: Allow eviction for upgrades alone
+- Never (default): Pod should run to completion</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.EvictionSafe">EvictionSafe
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Eviction">Eviction</a>)
+</p>
+<p>
+<p>EvictionSafe specified whether the game server supports termination via SIGTERM</p>
+</p>
 <h3 id="agones.dev/v1.FleetSpec">FleetSpec
 </h3>
 <p>
@@ -3987,6 +4336,20 @@ PlayersSpec
 <p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>eviction</code></br>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, SafeToEvict feature flag) Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="agones.dev/v1.GameServerState">GameServerState
@@ -4086,6 +4449,19 @@ PlayerStatus
 <em>(Optional)</em>
 <p>[Stage:Alpha]
 [FeatureFlag:PlayerTracking]</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code></br>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<p>(Alpha, SafeToEvict feature flag) Eviction specifies the eviction tolerance of the GameServer.</p>
 </td>
 </tr>
 </tbody>
@@ -4263,6 +4639,20 @@ PlayersSpec
 <td>
 <em>(Optional)</em>
 <p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code></br>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, SafeToEvict feature flag) Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
 </td>
 </tr>
 </table>
@@ -5764,295 +6154,6 @@ Kubernetes admissionregistration/v1.ServiceReference
 <em>(Optional)</em>
 <p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
 If unspecified, system trust roots on the apiserver are used.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
-</li></ul>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
-</h3>
-<p>
-<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-multicluster.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GameServerAllocationPolicy</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-23.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
-GameServerAllocationPolicySpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>priority</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
-</p>
-<p>
-<p>ClusterConnectionInfo defines the connection information for a cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>clusterName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Optional: the name of the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationEndpoints</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>The endpoints for the allocator service in the targeted cluster.
-If the AllocationEndpoints is not set, the allocation happens on local cluster.
-If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The cluster namespace from which to allocate gameservers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serverCa</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
-</h3>
-<p>
-<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currPriority</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-<p>currPriority Current priority index from the orderedPriorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>orderedPriorities</code></br>
-<em>
-[]int32
-</em>
-</td>
-<td>
-<p>orderedPriorities list of ordered priorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorityToCluster</code></br>
-<em>
-map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
-</em>
-</td>
-<td>
-<p>priorityToCluster Map of priority to cluster-policies map</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>clusterBlackList</code></br>
-<em>
-map[string]bool
-</em>
-</td>
-<td>
-<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
-</p>
-<p>
-<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>priority</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Implements #2794, in three separate commits:

* API changes under `SafeToEvict` feature gate:
  * Add the `eviction` object and `safe` property
  * Implement the defaulting/validation for `eviction.safe` field. In particular, it enshrines the defaulting logic for the somewhat complicated backwards compatibility case (`safe-to-evict=true` is set but `eviction.safe` is not).

* Runs `gen-api-docs`, as a separate commit.

* Then we flow policy from `GameServer.Status.Eviction.Safe`:
  * Following the pattern in #2840, moves the enforcement of cloudproduct specific things up to the controller, adding a new `cloudproduct.SetEviction` hook to handle it.
    * As a result, when the `SafeToEvict` feature flag is on, we disable annotation in gameserver.go and test that we don't set anything (as a change detection test).
  * Adds a generic and GKE Autopilot version of how to set policy from the `eviction.safe` status. In Autopilot, we disallow `eviction.safe: OnUpgrade` - this configuration doesn't make sense since we can't use `safe-to-evict=false` to restrict the Autoscaler. 
