### PR TITLE
Unity SDK - Switch to using syntax for Webrequests

### DIFF
--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -267,32 +267,32 @@ namespace Agones
             // To prevent that an async method leaks after destroying this gameObject.
             cancellationTokenSource.Token.ThrowIfCancellationRequested();
 
-            var req = new UnityWebRequest(sidecarAddress + api, method)
+            using (UnityWebRequest req = new UnityWebRequest(sidecarAddress + api, method)
+                {
+                    uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(json)),
+                    downloadHandler = new DownloadHandlerBuffer()
+                });
             {
-                uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(json)),
-                downloadHandler = new DownloadHandlerBuffer()
-            };
-            req.SetRequestHeader("Content-Type", "application/json");
+                req.SetRequestHeader("Content-Type", "application/json");
 
-            await new AgonesAsyncOperationWrapper(req.SendWebRequest());
+                await new AgonesAsyncOperationWrapper(req.SendWebRequest());
 
-            var result = new AsyncResult();
+                var result = new AsyncResult();
 
-            result.ok = req.responseCode == (long) HttpStatusCode.OK;
+                result.ok = req.responseCode == (long) HttpStatusCode.OK;
 
-            if (result.ok)
-            {
-                result.json = req.downloadHandler.text;
-                Log($"Agones SendRequest ok: {api} {req.downloadHandler.text}");
+                if (result.ok)
+                {
+                    result.json = req.downloadHandler.text;
+                    Log($"Agones SendRequest ok: {api} {req.downloadHandler.text}");
+                }
+                else
+                {
+                    Log($"Agones SendRequest failed: {api} {req.error}");
+                }
+
+                return result;
             }
-            else
-            {
-                Log($"Agones SendRequest failed: {api} {req.error}");
-            }
-
-            req.Dispose();
-
-            return result;
         }
 
         private void Log(object message)

--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -271,7 +271,7 @@ namespace Agones
                 {
                     uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(json)),
                     downloadHandler = new DownloadHandlerBuffer()
-                });
+                })
             {
                 req.SetRequestHeader("Content-Type", "application/json");
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Follow the unity [document](https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest.Dispose.html) to employ the using statement to ensure that a `UnityWebRequest` is properly cleaned up in case of uncaught exceptions.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2830 

**Special notes for your reviewer**:


