### PR TITLE
Skip validation errors in mutating webhooks

### DIFF
--- a/pkg/fleetautoscalers/controller.go
+++ b/pkg/fleetautoscalers/controller.go
@@ -198,8 +198,9 @@ func (c *Controller) mutationHandler(review admissionv1.AdmissionReview) (admiss
 	fas := &autoscalingv1.FleetAutoscaler{}
 	err := json.Unmarshal(obj.Raw, fas)
 	if err != nil {
-		c.baseLogger.WithField("review", review).WithError(err).Error("validationHandler")
-		return review, errors.Wrapf(err, "error unmarshalling original FleetAutoscaler json: %s", obj.Raw)
+		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
+		// to proceed, resulting in a more user friendly error message.
+		return review, nil
 	}
 
 	fas.ApplyDefaults()
@@ -234,7 +235,7 @@ func (c *Controller) validationHandler(review admissionv1.AdmissionReview) (admi
 	err := json.Unmarshal(obj.Raw, fas)
 	if err != nil {
 		c.baseLogger.WithField("review", review).WithError(err).Error("validationHandler")
-		return review, errors.Wrapf(err, "error unmarshalling original FleetAutoscaler json: %s", obj.Raw)
+		return review, errors.Wrapf(err, "error unmarshalling FleetAutoscaler json after schema validation: %s", obj.Raw)
 	}
 	fas.ApplyDefaults()
 	var causes []metav1.StatusCause

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -136,7 +136,9 @@ func (c *Controller) creationMutationHandler(review admissionv1.AdmissionReview)
 	fleet := &agonesv1.Fleet{}
 	err := json.Unmarshal(obj.Raw, fleet)
 	if err != nil {
-		return review, errors.Wrapf(err, "error unmarshalling original Fleet json: %s", obj.Raw)
+		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
+		// to proceed, resulting in a more user friendly error message.
+		return review, nil
 	}
 
 	// This is the main logic of this function
@@ -176,7 +178,7 @@ func (c *Controller) creationValidationHandler(review admissionv1.AdmissionRevie
 	fleet := &agonesv1.Fleet{}
 	err := json.Unmarshal(obj.Raw, fleet)
 	if err != nil {
-		return review, errors.Wrapf(err, "error unmarshalling original Fleet json: %s", obj.Raw)
+		return review, errors.Wrapf(err, "error unmarshalling Fleet json after schema validation: %s", obj.Raw)
 	}
 
 	causes, ok := fleet.Validate()

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -418,7 +418,7 @@ func TestControllerCreationValidationHandler(t *testing.T) {
 		review := getAdmissionReview(raw)
 
 		_, err = c.creationValidationHandler(review)
-		assert.EqualError(t, err, "error unmarshalling original Fleet json: \"MQ==\": json: cannot unmarshal string into Go value of type v1.Fleet")
+		assert.EqualError(t, err, "error unmarshalling Fleet json after schema validation: \"MQ==\": json: cannot unmarshal string into Go value of type v1.Fleet")
 	})
 
 	t.Run("invalid fleet", func(t *testing.T) {
@@ -492,8 +492,9 @@ func TestControllerCreationMutationHandler(t *testing.T) {
 		require.NoError(t, err)
 		review := getAdmissionReview(raw)
 
-		_, err = c.creationMutationHandler(review)
-		assert.EqualError(t, err, "error unmarshalling original Fleet json: \"MQ==\": json: cannot unmarshal string into Go value of type v1.Fleet")
+		result, err := c.creationMutationHandler(review)
+		assert.NoError(t, err)
+		require.Nil(t, result.Response.PatchType)
 	})
 }
 

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -232,8 +232,9 @@ func (c *Controller) creationMutationHandler(review admissionv1.AdmissionReview)
 	gs := &agonesv1.GameServer{}
 	err := json.Unmarshal(obj.Raw, gs)
 	if err != nil {
-		c.baseLogger.WithField("review", review).WithError(err).Error("creationMutationHandler failed to unmarshal JSON")
-		return review, errors.Wrapf(err, "error unmarshalling original GameServer json: %s", obj.Raw)
+		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
+		// to proceed, resulting in a more user friendly error message.
+		return review, nil
 	}
 
 	// This is the main logic of this function
@@ -281,8 +282,7 @@ func (c *Controller) creationValidationHandler(review admissionv1.AdmissionRevie
 	gs := &agonesv1.GameServer{}
 	err := json.Unmarshal(obj.Raw, gs)
 	if err != nil {
-		c.baseLogger.WithField("review", review).WithError(err).Error("creationValidationHandler failed to unmarshal JSON")
-		return review, errors.Wrapf(err, "error unmarshalling original GameServer json: %s", obj.Raw)
+		return review, errors.Wrapf(err, "error unmarshalling GameServer json after schema validation: %s", obj.Raw)
 	}
 
 	c.loggerForGameServer(gs).WithField("review", review).Debug("creationValidationHandler")

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -217,7 +217,7 @@ func (c *Controller) creationValidationHandler(review admissionv1.AdmissionRevie
 
 	newObj := review.Request.Object
 	if err := json.Unmarshal(newObj.Raw, newGss); err != nil {
-		return review, errors.Wrapf(err, "error unmarshalling new GameServerSet json: %s", newObj.Raw)
+		return review, errors.Wrapf(err, "error unmarshalling GameServerSet json after schema validation: %s", newObj.Raw)
 	}
 
 	causes, ok := newGss.Validate()

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -928,7 +928,7 @@ func TestCreationValidationHandler(t *testing.T) {
 
 		_, err := c.creationValidationHandler(review)
 		require.Error(t, err)
-		assert.Equal(t, "error unmarshalling new GameServerSet json: : unexpected end of JSON input", err.Error())
+		assert.Equal(t, "error unmarshalling GameServerSet json after schema validation: : unexpected end of JSON input", err.Error())
 	})
 
 	t.Run("invalid gameserverset create", func(t *testing.T) {

--- a/pkg/util/webhooks/webhooks.go
+++ b/pkg/util/webhooks/webhooks.go
@@ -100,13 +100,14 @@ func (wh *WebHook) handle(path string, w http.ResponseWriter, r *http.Request) e
 					Group: review.Request.Kind.Group,
 					Kind:  review.Request.Kind.Kind,
 					Causes: []metav1.StatusCause{{
+						Type:    metav1.CauseType("InternalError"),
 						Message: err.Error(),
 					}},
 				}
 				review.Response.Result = &metav1.Status{
 					Status:  metav1.StatusFailure,
 					Message: err.Error(),
-					Reason:  metav1.StatusReasonInvalid,
+					Reason:  metav1.StatusReasonInternalError,
 					Details: &details,
 				}
 			}


### PR DESCRIPTION
Request processing by kube-apiserver is roughly:
  { mutating webhooks } => { OpenAPI schema validation } => { validating webhooks }

In this PR, we disable validation errors (at least, JSON unmarshalling validation errors) during mutating webhook processing. It seems counter-intuitive not to return an error in mutating webhooks for a serious violation such as invalid JSON, but doing so allows OpenAPI schema validation to proceed. Schema validation gives us nice errors, so e.g.:

instead of:

```
The Fleet "" is invalid
```

we get:

```
The Fleet "fleet-example" is invalid: spec.template.spec.sdkServer.grpcPort: Invalid value: 33332229357: spec.template.spec.sdkServer.grpcPort in body should be less than or equal to 65535
```

This will become all the more important if we eventually move to CEL based validations.

I'm also changing the error in #2863 to an internal error - after this PR, any hard error from a handler (vs a cause) is unexpected.

Fixes #1770 

