### PR TITLE
cloudproduct: Register API hooks, move validation/mutation to API

### DIFF
--- a/pkg/apis/agones/v1/apihooks.go
+++ b/pkg/apis/agones/v1/apihooks.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// APIHooks is a subset of the cloudproduct.CloudProduct interface for cloud product hooks specific to this package.
+// We use this layering so that cloudproduct can import v1.GameServer (to get e.g. the GameServer type), but
+// also allow the cloud product to override behavior of GameServer.Pod(), etc.
+type APIHooks interface {
+	// ValidateGameServerSpec is called by GameServer.Validate to allow for product specific validation.
+	ValidateGameServerSpec(*GameServerSpec) []metav1.StatusCause
+
+	// MutateGameServerPodSpec is called by createGameServerPod to allow for product specific pod mutation.
+	MutateGameServerPodSpec(*GameServerSpec, *corev1.PodSpec) error
+}
+
+var apiHooks APIHooks = generic{}
+
+func RegisterAPIHooks(hooks APIHooks) {
+	if hooks == nil {
+		hooks = generic{}
+	}
+	apiHooks = hooks
+}
+
+type generic struct{}
+
+func (generic) ValidateGameServerSpec(*GameServerSpec) []metav1.StatusCause    { return nil }
+func (generic) MutateGameServerPodSpec(*GameServerSpec, *corev1.PodSpec) error { return nil }

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -472,7 +472,9 @@ func (gss *GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, bo
 	if len(objMetaCauses) > 0 {
 		causes = append(causes, objMetaCauses...)
 	}
-
+	if productCauses := apiHooks.ValidateGameServerSpec(gss); len(productCauses) > 0 {
+		causes = append(causes, productCauses...)
+	}
 	return causes, len(causes) == 0
 }
 
@@ -619,6 +621,10 @@ func (gs *GameServer) Pod(sidecars ...corev1.Container) (*corev1.Pod, error) {
 	pod.Spec.Containers = containers
 
 	gs.podScheduling(pod)
+
+	if err := apiHooks.MutateGameServerPodSpec(&gs.Spec, &pod.Spec); err != nil {
+		return nil, err
+	}
 
 	return pod, nil
 }

--- a/pkg/cloudproduct/generic/generic.go
+++ b/pkg/cloudproduct/generic/generic.go
@@ -18,11 +18,10 @@ import (
 	"agones.dev/agones/pkg/client/informers/externalversions"
 	"agones.dev/agones/pkg/portallocator"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 )
 
-func New() (*generic, error) { return &generic{}, nil }
+func New() (*generic, agonesv1.APIHooks, error) { return &generic{}, nil, nil }
 
 type generic struct{}
 
@@ -33,7 +32,3 @@ func (*generic) NewPortAllocator(minPort, maxPort int32,
 	agonesInformerFactory externalversions.SharedInformerFactory) portallocator.Interface {
 	return portallocator.New(minPort, maxPort, kubeInformerFactory, agonesInformerFactory)
 }
-
-func (*generic) ValidateGameServer(*agonesv1.GameServer) []metav1.StatusCause { return nil }
-
-func (*generic) MutateGameServerPod(gs *agonesv1.GameServer, pod *corev1.Pod) error { return nil }

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -26,7 +26,6 @@ import (
 
 	"agones.dev/agones/pkg/apis/agones"
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
-	"agones.dev/agones/pkg/cloudproduct"
 	agtesting "agones.dev/agones/pkg/testing"
 	"agones.dev/agones/pkg/util/webhooks"
 	"github.com/heptiolabs/healthcheck"
@@ -1953,7 +1952,7 @@ func newFakeController() (*Controller, agtesting.Mocks) {
 		10, 20, "sidecar:dev", false,
 		resource.MustParse("0.05"), resource.MustParse("0.1"),
 		resource.MustParse("50Mi"), resource.MustParse("100Mi"), "sdk-service-account",
-		m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory, cloudproduct.MustNewGeneric(context.Background()))
+		m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m
 }

--- a/pkg/gameservers/migration_test.go
+++ b/pkg/gameservers/migration_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
-	"agones.dev/agones/pkg/cloudproduct"
 	agtesting "agones.dev/agones/pkg/testing"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/stretchr/testify/assert"
@@ -193,8 +192,7 @@ func TestMigrationControllerSyncGameServer(t *testing.T) {
 	for k, v := range fixtures {
 		t.Run(k, func(t *testing.T) {
 			m := agtesting.NewMocks()
-			c := NewMigrationController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory,
-				cloudproduct.MustNewGeneric(context.Background()))
+			c := NewMigrationController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
 			c.recorder = m.FakeRecorder
 
 			gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
@@ -245,8 +243,7 @@ func TestMigrationControllerSyncGameServer(t *testing.T) {
 
 func TestMigrationControllerRun(t *testing.T) {
 	m := agtesting.NewMocks()
-	c := NewMigrationController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory,
-		cloudproduct.MustNewGeneric(context.Background()))
+	c := NewMigrationController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
 	gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{}}
 	gs.ApplyDefaults()

--- a/site/assets/templates/crd-doc-config.json
+++ b/site/assets/templates/crd-doc-config.json
@@ -4,7 +4,8 @@
     ],
     "hideTypePatterns": [
         "ParseError$",
-        "List$"
+        "List$",
+        "APIHooks$"
     ],
     "externalPackages": [
         {


### PR DESCRIPTION
This commit fixes the fact that currently cloud product specific API validation/mutation is in a weird state where it has to occur outside the pkg/apis/agones layer and instead currently lives in the controller. The mechanical reason for this previously was to avoid an import cycle - pkg/apis/agones/v1 could not import cloudproduct because cloudproduct needs the v1 type definitions.

Instead of shoving everything under one interface, I split CloudProduct up into two interfaces, the "controller hooks" (new port allocator, sync ports back) and the "api hooks". In the process, I ahead and converted the cloud product layer into a global singleton "initialize once" layer so all registration happens together. Now when we initialize, the controller hooks are saved as a singleton, and the API hooks are registered with the API layer. This last step breaks the import cycle, as the API layer can define its own hook interface and the cloud products can provide that.

I then adopted the new pattern in the API layer and moved the logics out of the controller layer. This fixes a latent bug whereby the Fleet and GameServerSet controllers are not currently doing any cloud product specific GameServerSpec validation.

Along the way, I also changed `ValidateGameServer` to `ValidateGameServerSpec` and `MutateGameServerPod` to `MutateGameServerPodSpec` to narrow access in both to the `Spec` rather than the whole object.

**Special notes for your reviewer**:

Let's merge #2866 first, I can rebase after.

This conflicts with #2857 as well, but I do not care which order we merge these in - I'll make it work.
