### PR TITLE
lint: Reenable `revive`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,8 +85,6 @@ linters-settings:
       rangeValCopy:
         sizeThreshold: 512
         skipTestFuncs: true
-  revive:
-    confidence: 0.8
 
 issues:
   # This turns off the default excludes - which was causing the linter

--- a/pkg/apis/agones/register.go
+++ b/pkg/apis/agones/register.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package agones implements the agones.dev APIs.
 package agones
 
 const (

--- a/pkg/apis/agones/v1/apihooks.go
+++ b/pkg/apis/agones/v1/apihooks.go
@@ -32,6 +32,8 @@ type APIHooks interface {
 
 var apiHooks APIHooks = generic{}
 
+// RegisterAPIHooks registers API-specific cloud product hooks. It should only be called by
+// the cloudproduct package on initialization.
 func RegisterAPIHooks(hooks APIHooks) {
 	if hooks == nil {
 		hooks = generic{}

--- a/pkg/apis/allocation/register.go
+++ b/pkg/apis/allocation/register.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package allocation implements the allocation.agones.dev APIs.
 package allocation
 
 const (

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package autoscaling implements the autoscaling.agones.dev APIs.
 package autoscaling
 
 const (

--- a/pkg/apis/multicluster/register.go
+++ b/pkg/apis/multicluster/register.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package multicluster implements the multicluster.agones.dev
 package multicluster
 
 const (

--- a/pkg/cloudproduct/generic/generic.go
+++ b/pkg/cloudproduct/generic/generic.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package generic implements generic cloud product hooks
 package generic
 
 import (
@@ -21,6 +23,9 @@ import (
 	"k8s.io/client-go/informers"
 )
 
+// New returns a new generic cloud product
+//
+//nolint:revive // ignore the unexported return; implements ControllerHooksInterface
 func New() (*generic, agonesv1.APIHooks, error) { return &generic{}, nil, nil }
 
 type generic struct{}

--- a/pkg/cloudproduct/gke/gke.go
+++ b/pkg/cloudproduct/gke/gke.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package gke implements the GKE cloud product (specifically Autopilot for now)
 package gke
 
 import (
@@ -53,6 +55,8 @@ type hostPortAssignment struct {
 	PortsAssigned map[int32]int32 `json:"portsAssigned,omitempty"` // old -> new
 }
 
+// Detect whether we're running on GKE and/or Autopilot and return the appropriate
+// cloud product string.
 func Detect(ctx context.Context, kc *kubernetes.Clientset) string {
 	if !metadata.OnGCE() {
 		return ""
@@ -68,6 +72,9 @@ func Detect(ctx context.Context, kc *kubernetes.Clientset) string {
 	return "gke-autopilot"
 }
 
+// Autopilot returns a GKE Autopilot cloud product
+//
+//nolint:revive // ignore the unexported return; implements ControllerHooksInterface
 func Autopilot() (*gkeAutopilot, agonesv1.APIHooks, error) {
 	ap := &gkeAutopilot{}
 	return ap, ap, nil

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package pkg is all Agones libraries.
 package pkg

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1061,7 +1061,7 @@ func TestControllerRollingUpdateDeploymentNegativeReplica(t *testing.T) {
 		assert.Equal(t, int32(4), gsSet.Spec.Replicas)
 		assert.Equal(t, int32(5), f.Spec.Replicas)
 
-		return true, nil, errors.Errorf("error updating replicas for gameserverset for fleet %s:", f.Name)
+		return true, nil, errors.Errorf("error updating replicas for gameserverset for fleet %s", f.Name)
 	})
 
 	// assert the active gameserverset's replicas when active and inactive gameserversets exist

--- a/pkg/metrics/controller_test.go
+++ b/pkg/metrics/controller_test.go
@@ -140,10 +140,9 @@ func TestControllerGameServerCount(t *testing.T) {
 			if m.Descriptor.Name == gameServersCountName {
 				if len(m.TimeSeries) == 4 {
 					return true
-				} else {
-					logrus.WithField("m", m).Info("Metrics")
-					return false
 				}
+				logrus.WithField("m", m).Info("Metrics")
+				return false
 			}
 		}
 

--- a/pkg/portallocator/portallocator.go
+++ b/pkg/portallocator/portallocator.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// portallocator.Interface manages the dynamic port allocation strategy.
+// Interface manages the dynamic port allocation strategy.
 //
 // The portallocator does not currently support mixing static portAllocations (or any pods with defined HostPort)
 // within the dynamic port range other than the ones it coordinates.

--- a/pkg/util/https/https.go
+++ b/pkg/util/https/https.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package https provides HTTPS helpers.
 package https
 
 import (

--- a/pkg/util/logfields/logfields.go
+++ b/pkg/util/logfields/logfields.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package logfields specifies constants for use in logging.
 package logfields
 
 import (

--- a/test/sdk/go/sdk-client-test.go
+++ b/test/sdk/go/sdk-client-test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Binary sdk-client-test tests the Go SDK client.
 package main
 
 import (

--- a/test/sdk/websocket-watch/ws-watch-test.go
+++ b/test/sdk/websocket-watch/ws-watch-test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Binary ws-watch-test tests websocket watch in Go.
 package main
 
 import (


### PR DESCRIPTION
The way `revive` was configured, we configured the confidence interval, but didn't enable any checks, it seems. By deleting the message, it reverts to the default `revive` config, which includes:

* Comments on exported symbols must be of the right form (this was noticed as lacking in #2868)

* Package comments - I'm guessing from the number of changes that we've never had this linter, but given that certain IDEs expect the package to be offset from the header, having this linter enforces it.

Closes #2873