### PR TITLE
Revert workload separation for Autopilot

### DIFF
--- a/pkg/cloudproduct/gke/gke.go
+++ b/pkg/cloudproduct/gke/gke.go
@@ -131,23 +131,6 @@ func (*gkeAutopilot) ValidateGameServerSpec(gss *agonesv1.GameServerSpec) []meta
 }
 
 func (*gkeAutopilot) MutateGameServerPodSpec(gss *agonesv1.GameServerSpec, podSpec *corev1.PodSpec) error {
-	if gss.Scheduling != apis.Packed {
-		return errors.Errorf("Scheduling strategy %s != Packed, which webhook should have rejected on Autopilot", gss.Scheduling)
-	}
-	if len(podSpec.Tolerations) > 0 || len(podSpec.NodeSelector) > 0 {
-		// If the user has specified tolerations or a node selector already,
-		// we assume they know what they're doing.
-		return nil
-	}
-	podSpec.Tolerations = []corev1.Toleration{{
-		Key:      agonesv1.RoleLabel,
-		Value:    agonesv1.GameServerLabelRole,
-		Operator: corev1.TolerationOpEqual,
-		Effect:   corev1.TaintEffectNoSchedule,
-	}}
-	podSpec.NodeSelector = map[string]string{
-		agonesv1.RoleLabel: agonesv1.GameServerLabelRole,
-	}
 	return nil
 }
 


### PR DESCRIPTION
Workload separation on Autopilot requires 0.5 vCPU per pod vs the 0.25 vCPU per pod normally required (see [minimum](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max) vs
[workload separation](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#workload-separation)). Unfortunately, a lot of users have smaller game server pods. Revert the automatic use of workload separation. I will work internally to figure out how we might change the minimums.

For the time being, I will work towards how we might document this. It's relatively straightforward if a user needs to, as this block was just adding the equivalent of:

```
      tolerations:
      - key: agones.dev/role
        operator: Equal
        value: gameserver
        effect: NoSchedule
      nodeSelector:
        agones.dev/role: gameserver
```

But with documentation, we can show other options as well, i.e. how to have workload separation between different gameserver workloads if desired.

Towards #2777