### PR TITLE
Don't run cloud product GameServerSpec validation on development GameServers

### DIFF
--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -535,13 +535,13 @@ func (gss *GameServerSpec) Validate(devAddress string) ([]metav1.StatusCause, bo
 				})
 			}
 		}
+		if productCauses := apiHooks.ValidateGameServerSpec(gss); len(productCauses) > 0 {
+			causes = append(causes, productCauses...)
+		}
 	}
 	objMetaCauses := validateObjectMeta(&gss.Template.ObjectMeta)
 	if len(objMetaCauses) > 0 {
 		causes = append(causes, objMetaCauses...)
-	}
-	if productCauses := apiHooks.ValidateGameServerSpec(gss); len(productCauses) > 0 {
-		causes = append(causes, productCauses...)
 	}
 	return causes, len(causes) == 0
 }

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -849,9 +849,7 @@ func TestFleetGSSpecValidation(t *testing.T) {
 	assert.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, agonesv1.ErrHostPort, statusErr.Status().Details.Causes[0].Message)
 
-	fltPort.Spec.Template.Spec.Ports[0].PortPolicy = agonesv1.Static
-	fltPort.Spec.Template.Spec.Ports[0].HostPort = 0
-	fltPort.Spec.Template.Spec.Ports[0].ContainerPort = 5555
+	fltPort.Spec.Template.Spec.Ports[0].HostPort = 0 // validation fails above because the HostPort is specified, make it good.
 	_, err = client.Fleets(framework.Namespace).Create(ctx, fltPort, metav1.CreateOptions{})
 	if assert.Nil(t, err) {
 		defer client.Fleets(framework.Namespace).Delete(ctx, fltPort.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck


### PR DESCRIPTION
Development GameServers are basically just metadata placeholders and need no cloud-product-specific validation.

Fixes TestDevelopmentGameServerLifecycle e2e on Autopilot

Along the way: Fix TestFleetGSSpecValidation e2e on Autopilot. The intent of the last test is a success case, which we can achieve more simply than using a Static port. Leave the rest to unit tests.

/kind feature