### PR TITLE
Removes explicit versions of Prometheus and Grafana

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -202,7 +202,7 @@ endif
 
 unameprocessor := $(shell uname -p)
 ifeq ($(unameprocessor),arm)
-	DOCKER_BUILD_ARGS += --platform linux/x86_64 
+	DOCKER_BUILD_ARGS += --platform linux/x86_64
 	DOCKER_RUN_ARGS += --platform linux/x86_64
 endif
 
@@ -472,7 +472,7 @@ build-required-src-dist:
 	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/build-required-src-dist.sh
 
 # Create docker builder used in creating arm64 images
-# According to the docker documentation, to build the images for ARM64 arch CPU 
+# According to the docker documentation, to build the images for ARM64 arch CPU
 # we would need to use buildx command which uses builder https://docs.docker.com/desktop/multi-arch/
 # We primarily need this for M1 Macs, see: https://medium.com/geekculture/docker-build-with-mac-m1-d668c802ab96
 # Making this command optional (using - as prefix) because it will fail once built for the first time, so we ignore failures.
@@ -488,7 +488,7 @@ endif
 build-controller-image-amd64: $(ensure-build-image) build-controller-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build controller image in buildx command
-build-controller-image-arm64: $(ensure-build-image) build-controller-binary create-arm64-builder 
+build-controller-image-arm64: $(ensure-build-image) build-controller-binary create-arm64-builder
 	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/controller/ --tag=$(controller_arm64_tag) $(DOCKER_BUILD_ARGS)
 
 # push the gameservers controller image
@@ -507,7 +507,7 @@ push-controller-image-arm64: build-controller-image-arm64
 	$(MAKE) DOCKER_BUILD_ARGS=--push build-controller-image-arm64
 
 # build the static binary for the gameserver sidecar
-build-agones-sdk-binary: $(ensure-build-image) build-agones-sdk-binary-linux-amd64 build-agones-sdk-binary-linux-arm64 build-agones-sdk-binary-windows build-agones-sdk-binary-darwin-amd64 build-agones-sdk-binary-darwin-arm64 
+build-agones-sdk-binary: $(ensure-build-image) build-agones-sdk-binary-linux-amd64 build-agones-sdk-binary-linux-arm64 build-agones-sdk-binary-windows build-agones-sdk-binary-darwin-amd64 build-agones-sdk-binary-darwin-arm64
 	$(ZIP_SDK) \
 		agonessdk-server-$(VERSION).zip sdk-server.darwin.amd64 sdk-server.darwin.arm64 sdk-server.linux.amd64 sdk-server.linux.arm64 sdk-server.windows.amd64.exe
 
@@ -534,7 +534,7 @@ build-agones-sdk-binary-windows: $(ensure-build-image)
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server
 
 ensure-windows-buildx:
-	-docker buildx create --name=$(BUILDX_WINDOWS_BUILDER) 
+	-docker buildx create --name=$(BUILDX_WINDOWS_BUILDER)
 
 # Build the image for the gameserver extensions
 build-extensions-image: build-extensions-image-amd64
@@ -567,7 +567,7 @@ push-extensions-image-arm64: build-extensions-image-arm64
 # Build the image for the gameserver sidecar and SDK binaries
 build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses build-required-src-dist build-agones-sdk-image-amd64
 ifeq ($(WITH_ARM64), 1)
-build-agones-sdk-image: build-agones-sdk-image-arm64 
+build-agones-sdk-image: build-agones-sdk-image-arm64
 endif
 ifeq ($(WITH_WINDOWS), 1)
 build-agones-sdk-image: build-agones-sdk-image-windows
@@ -576,8 +576,8 @@ endif
 build-agones-sdk-image-amd64: $(ensure-build-image) build-agones-sdk-binary-linux-amd64
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build sdk image in buildx command
-build-agones-sdk-image-arm64: $(ensure-build-image) build-agones-sdk-binary-linux-arm64 create-arm64-builder 
-	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_arm64_tag) $(DOCKER_BUILD_ARGS) 
+build-agones-sdk-image-arm64: $(ensure-build-image) build-agones-sdk-binary-linux-arm64 create-arm64-builder
+	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_linux_arm64_tag) $(DOCKER_BUILD_ARGS)
 
 build-agones-sdk-image-windows: build-agones-sdk-binary
 build-agones-sdk-image-windows: $(foreach winver, $(WINDOWS_VERSIONS), build-agones-sdk-image-windows-$(winver))
@@ -619,14 +619,14 @@ push-ping-image-arm64:
 # Build the image for the ping service
 build-ping-image: build-ping-image-amd64
 ifeq ($(WITH_ARM64), 1)
-build-ping-image: build-ping-image-arm64 
+build-ping-image: build-ping-image-arm64
 endif
 
 build-ping-image-amd64: $(ensure-build-image) build-ping-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build ping image in buildx command
-build-ping-image-arm64: $(ensure-build-image) build-ping-binary create-arm64-builder 
-	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/ping/ --tag=$(ping_arm64_tag) $(DOCKER_BUILD_ARGS) 
+build-ping-image-arm64: $(ensure-build-image) build-ping-binary create-arm64-builder
+	docker buildx build --platform linux/arm64 --builder $(BUILDX_ARM64_BUILDER) --build-arg ARCH=arm64 $(agones_path)/cmd/ping/ --tag=$(ping_arm64_tag) $(DOCKER_BUILD_ARGS)
 
 # Build a static binary for the allocator service
 build-allocator-binary: $(ensure-build-image) build-allocator-binary-linux-amd64
@@ -667,8 +667,8 @@ endif
 build-allocator-image-amd64: $(ensure-build-image) build-allocator-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/allocator/ --tag=$(allocator_amd64_tag) $(DOCKER_BUILD_ARGS)
 # creating docker builder and then using that builder to build allocator image in buildx command
-build-allocator-image-arm64: $(ensure-build-image) build-allocator-binary create-arm64-builder 
-	docker buildx build $(agones_path)/cmd/allocator/ --builder $(BUILDX_ARM64_BUILDER) --tag=$(allocator_arm64_tag) --build-arg ARCH=arm64 --platform linux/arm64 $(DOCKER_BUILD_ARGS) 
+build-allocator-image-arm64: $(ensure-build-image) build-allocator-binary create-arm64-builder
+	docker buildx build $(agones_path)/cmd/allocator/ --builder $(BUILDX_ARM64_BUILDER) --tag=$(allocator_arm64_tag) --build-arg ARCH=arm64 --platform linux/arm64 $(DOCKER_BUILD_ARGS)
 
 # push the gameservers sidecar image
 push-agones-sdk-image: push-agones-sdk-linux-image-amd64
@@ -745,7 +745,7 @@ setup-prometheus: SCRAPE_INTERVAL=30s
 setup-prometheus:
 	$(DOCKER_RUN) helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	$(DOCKER_RUN) helm repo update
-	$(DOCKER_RUN) helm upgrade prom prometheus-community/prometheus --install --wait --version 15.9.2 \
+	$(DOCKER_RUN) helm upgrade prom prometheus-community/prometheus --install --wait \
  		--namespace metrics --create-namespace \
 		--set server.global.scrape_interval=$(SCRAPE_INTERVAL),server.persistentVolume.enabled=$(PVC),server.persistentVolume.size=$(PV_SIZE) \
 		$(HELM_ARGS) -f $(mount_path)/build/prometheus.yaml
@@ -763,7 +763,7 @@ setup-grafana:
 	$(DOCKER_RUN) helm repo add grafana https://grafana.github.io/helm-charts
 	$(DOCKER_RUN) helm repo update
 	$(DOCKER_RUN) kubectl apply -f $(mount_path)/build/grafana/
-	$(DOCKER_RUN) helm upgrade grafana grafana/grafana --install --wait --version=6.29.6 \
+	$(DOCKER_RUN) helm upgrade grafana grafana/grafana --install --wait \
 		--namespace metrics --create-namespace \
 		--set persistence.enabled=$(PVC),server.persistentVolume.size=$(PV_SIZE) \
 		--set adminPassword=$(PASSWORD) $(HELM_ARGS) -f $(mount_path)/build/grafana.yaml

--- a/build/README.md
+++ b/build/README.md
@@ -110,6 +110,10 @@ Table of Contents
       * [Error: cluster-admin-binding already exists](#error-cluster-admin-binding-already-exists)
       * [Error: releases do not exist](#error-releases-do-not-exist)
       * [I want to use pprof to profile the controller](#i-want-to-use-pprof-to-profile-the-controller)
+      * [Error: Kubernetes cluster unreachable](#error-kubernetes-cluster-unreachable-invalid-configuration-no-configuration-has-been-provided)
+      * [Error: project: required field is not set](#error-project-required-field-is-not-set-error-invalid-value-for-network-project-required-field-is-not-set)
+      * [Error: could not download chart](#error-could-not-download-chart-failed-to-download-httpsagonesdevchartstableagones-1280tgz)
+      * [Invalid argument "/agones-controller:$(VERSION)" for "-t, --tag" flag: invalid reference format](#invalid-argument-agones-controller1290-961d8ae-amd64-for--t---tag-flag-invalid-reference-format)
 
 ## Building on Different Platforms
 
@@ -158,7 +162,7 @@ free to make cup of tea or coffee at this point. ☕️
 The build image is only created the first time one of the make targets is executed, and will only rebuild if the build
 Dockerfile has changed.
 
-Assuming that the tests all pass, let's go ahead and compile the code and build the Docker images that Agones 
+Assuming that the tests all pass, let's go ahead and compile the code and build the Docker images that Agones
 consists of.
 
 To compile the Agones images, run `make build-images`. This is often all you need for Agones development.
@@ -188,12 +192,13 @@ everything separate (see below for overwriting these config locations). Therefor
 we will need to authenticate our gcloud tooling against it. To do that run `make gcloud-init` and fill in the
 prompts as directed.
 
-Once authenticated, to create the test cluster, run `make gcloud-test-cluster`, which will use the Terraform
-configuration found in the `build/terraform/gke` directory.
+Once authenticated, to create the test cluster, run `make gcloud-test-cluster`
+(or run `make gcloud-e2e-test-cluster` for end to end tests), which will use the Terraform configuration found in the `build/terraform/gke` directory.
 
-You can customize the GKE cluster by appending the following parameters to your make target, via environment 
-variables, or by setting them within your 
-[`local-includes`](#set-local-make-targets-and-variables-with-local-includes) directory.
+You can customize the GKE cluster by appending the following parameters to your make target, via environment
+variables, or by setting them within your
+[`local-includes`](#set-local-make-targets-and-variables-with-local-includes) directory. For end to end tests, update `GCP_CLUSTER_NAME` to e2e-test-cluster
+in the Makefile.
 
 See the table below for available customizations :
 
@@ -246,12 +251,13 @@ Now that the images are pushed, to install the development version (with all ima
 run `make install` and Agones will install the image that you just built and pushed on the test cluster you
 created at the beginning of this section. (if you want to see the resulting installation yaml, you can find it in `build/.install.yaml`)
 
-Finally, to run all the end-to-end tests against your development version previously installed in your test cluster run 
-`make test-e2e` (this can also take a while). This will validate the whole application flow from start to finish. If 
+Finally, to run all the end-to-end tests against your development version previously installed in your test cluster run
+`make test-e2e` (this can also take a while). This will validate the whole application flow from start to finish. If
 you're curious about how they work head to [tests/e2e](../test/e2e/).
 Also [see below](#running-individual-end-to-end-tests) for how to run individual end-to-end tests during development.
 
-When you are finished, you can run `make clean-gcloud-test-cluster` to tear down your cluster.
+When you are finished, you can run `make clean-gcloud-test-cluster` (or
+`make clean-gcloud-e2e-test-cluster`) to tear down your cluster.
 
 ### Running a Test Minikube cluster
 This will setup a [Minikube](https://github.com/kubernetes/minikube) cluster, running on an `agones` profile,
@@ -292,15 +298,15 @@ and makes cross-platform support for the build system much easier.
 To push your own images into the cluster, take a look at Minikube's
 [Pushing Images](https://minikube.sigs.k8s.io/docs/handbook/pushing/) guide.
 
-Running end-to-end tests on Minikube can be done via the `make minikube-test-e2e` target, but this can often overwhelm  
+Running end-to-end tests on Minikube can be done via the `make minikube-test-e2e` target, but this can often overwhelm
 a local minikube cluster, so use at your own risk. Take a look at
-[Running Individual End-to-End Tests](#running-individual-end-to-end-tests) to run individual tests on a case by case 
+[Running Individual End-to-End Tests](#running-individual-end-to-end-tests) to run individual tests on a case by case
 basis.
 
 If you are getting issues connecting to `GameServers` running on minikube, check the
 [Agones minikube](https://agones.dev/site/docs/installation/creating-cluster/minikube/) documentation. You may need to
 change the driver version through the `MINIKUBE_DRIVER` variable. See the
-[local-includes](#set-local-make-targets-and-variables-with-local-includes) on how to change this permanently on 
+[local-includes](#set-local-make-targets-and-variables-with-local-includes) on how to change this permanently on
 your development machine.
 
 ### Running a Test Kind cluster
@@ -374,18 +380,18 @@ You can combine some of the above steps into a single one, for example `make bui
 common flow, to build you changes on Agones, push them to a container registry and install this development
 version to your cluster.
 
-Another would be to run `make lint test-go` to run the golang linter against the Go code, and then run all the unit 
+Another would be to run `make lint test-go` to run the golang linter against the Go code, and then run all the unit
 tests.
 
 ### Set Local Make Targets and Variables with `local-includes`
 
-If you want to permanently set `Makefile` variables or add targets to your local setup, all `local-includes/*.mk` 
-are included into the main `Makefile`, and also ignored by the git repository. 
+If you want to permanently set `Makefile` variables or add targets to your local setup, all `local-includes/*.mk`
+are included into the main `Makefile`, and also ignored by the git repository.
 
-Therefore, you can add your own `.mk` files in the [`local-includes`](./local-includes) directory without affecting 
+Therefore, you can add your own `.mk` files in the [`local-includes`](./local-includes) directory without affecting
 the shared git repository.
 
-For examaple, if I only worked with Linux images for Agones, I could permanently turn off Windows and Arm64 images, 
+For examaple, if I only worked with Linux images for Agones, I could permanently turn off Windows and Arm64 images,
 by writing a `images.mk` within that folder, with the following contents:
 
 ```makefile
@@ -396,11 +402,11 @@ WITH_ARM64=0
 
 ### Running Individual End-to-End Tests
 
-When you are working on an individual feature of Agones, it doesn't make sense to run the entire end-to-end suite of 
+When you are working on an individual feature of Agones, it doesn't make sense to run the entire end-to-end suite of
 tests (and it can take a really long time!).
 
-The end-to-end tests within the [`tests/e2e`](../test/e2e) folder are plain 
-[Go Tests](https://go.dev/doc/tutorial/add-a-test) that will use your local `~/.kube` configuration to connect and 
+The end-to-end tests within the [`tests/e2e`](../test/e2e) folder are plain
+[Go Tests](https://go.dev/doc/tutorial/add-a-test) that will use your local `~/.kube` configuration to connect and
 run against the currently active local cluster.
 
 This means you can run individual e2e tests from within your IDE or as a `go` command.
@@ -412,7 +418,7 @@ go test -race -run ^TestCreateConnect$
 ```
 
 #### Troubleshooting
-If you run into cluster connection issues, this can usually be resolved by running any kind of authenticated `kubectl` 
+If you run into cluster connection issues, this can usually be resolved by running any kind of authenticated `kubectl`
 command from within `make shell` or locally, to refresh your authentication token.
 
 ## Make Variable Reference
@@ -933,3 +939,20 @@ on [http://localhost:6061](http://localhost:6061).
 To view heap metrics, run `make pprof-heap-web`, which will start the web interface with a Heap usage graph.
 on [http://localhost:6062](http://localhost:6062).
 
+#### Error: Kubernetes cluster unreachable: invalid configuration: no configuration has been provided
+
+If you run into this error while creating a test cluster run `make terraform-clean`.
+
+#### Error: project: required field is not set Error: Invalid value for network: project: required field is not set
+
+Run `make gcloud-init`. If you still get the same error, log into the developer
+shell `make shell` and run `gcloud init`.
+
+#### Error: could not download chart: failed to download "https://agones.dev/chart/stable/agones-1.28.0.tgz"
+
+Run `helm repo add agones https://agones.dev/chart/stable` followed by `helm repo update` which will add
+the latest stable version of the agones tar file to your ~/.cache/helm/repository/.
+
+#### Invalid argument "/agones-controller:1.29.0-961d8ae-amd64" for "-t, --tag" flag: invalid reference format
+
+The $(REGISTRY) variable is not set in ~/agones/build/Makefile. For GKE follow instructions under [Running a Test Google Kubernetes Engine Cluster](#running-a-test-google-kubernetes-engine-cluster) for creating a registry and exporting the path to the registry.

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /go/src/k8s.io && cd /go/src/k8s.io && \
     git clone -b kubernetes-${KUBERNETES_VER} --depth=3 https://github.com/kubernetes/code-generator.git
 
 # install Helm package manager
-ENV HELM_VER 3.5.0
+ENV HELM_VER 3.10.3
 ENV HELM_URL https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz
 RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
     && tar -zxvf /tmp/helm.tar.gz -C /tmp \

--- a/build/grafana/dashboard-allocations.yaml
+++ b/build/grafana/dashboard-allocations.yaml
@@ -170,7 +170,6 @@ data:
           "nullPointMode": "connected",
           "nullText": null,
           "options": {},
-          "pluginVersion": "6.2.4",
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",

--- a/build/grafana/dashboard-gameservers.yaml
+++ b/build/grafana/dashboard-gameservers.yaml
@@ -103,7 +103,6 @@ data:
           "links": [],
           "nullPointMode": "connected",
           "pieType": "pie",
-          "pluginVersion": "7.2.1",
           "strokeWidth": 1,
           "targets": [
             {
@@ -167,7 +166,6 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -270,7 +268,6 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -376,7 +373,6 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -477,7 +473,6 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -615,7 +610,6 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -74,8 +74,8 @@ Follow the [Cloud Monitoring Installation steps](#cloud-monitoring-installation)
 
 {{% alpha title="Reset Metric Export on Fleet / Autoscaler deletion" gate="ResetMetricsOnDelete" %}}
 
-When a Fleet or FleetAutoscaler is deleted from the system, Agones will automatically clear metrics that utilise 
-their name as a label from the exported metrics, so the metrics exported do not continuously grow in size over the 
+When a Fleet or FleetAutoscaler is deleted from the system, Agones will automatically clear metrics that utilise
+their name as a label from the exported metrics, so the metrics exported do not continuously grow in size over the
 lifecycle of the Agones installation.
 
 
@@ -131,7 +131,7 @@ Let's install Prometheus using the [Prometheus Community Kubernetes Helm Charts]
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
-helm upgrade --install --wait prom prometheus-community/prometheus --version 11.16.2 --namespace metrics \
+helm upgrade --install --wait prom prometheus-community/prometheus --namespace metrics --create-namespace \
     --set server.global.scrape_interval=30s \
     --set server.persistentVolume.enabled=true \
     --set server.persistentVolume.size=64Gi \
@@ -193,7 +193,7 @@ their repository. (Replace `<your-admin-password>` with the admin password of yo
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
 
-helm upgrade --install --wait grafana grafana/grafana --version=5.7.10 --namespace metrics \
+helm upgrade --install --wait grafana grafana/grafana --namespace metrics \
   --set adminPassword=<your-admin-password> -f ./build/grafana.yaml
 ```
 

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -95,8 +95,6 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.metrics.stackdriverProjectID`                    | This overrides the default gcp project id for use with stackdriver                                                                                                                                                      | \`\`                               |
 | `agones.metrics.stackdriverLabels`                       | A set of default labels to add to all stackdriver metrics generated in form of key value pair (`key=value,key2=value2`). By default metadata are automatically added using Kubernetes API and GCP metadata enpoint.     | \`\`                               |
 | `agones.metrics.serviceMonitor.interval`                 | Default scraping interval for ServiceMonitor                                                                                                                                                                            | `30s`                              |
-| `agones.serviceaccount.controller`                       | Service account name for the controller. **Note**: Will be replaced with `agones.serviceaccount.controller.name` in Agones 1.16                                                                                         | `agones-controller`                |
-| `agones.serviceaccount.sdk`                              | Service account name for the sdk. **Note**: Will be replaced with `agones.serviceaccount.sdk.name` in Agones 1.16                                                                                                       | `agones-sdk`                       | 
 | `agones.serviceaccount.sdk.annotations`                  | A map of namespaces to maps of [Annotations][annotations] added to the Agones SDK service account for the specified namespaces                                                                                          | `{}`                               |
 | `agones.image.registry`                                  | Global image registry for all images                                                                                                                                                                                   | `gcr.io/agones-images`             |
 | `agones.image.tag`                                       | Global image tag for all images                                                                                                                                                                                         | `{{< release-version >}}`          |
@@ -272,7 +270,7 @@ In order to use `helm test` command described in this section you need to set `h
 
 Check the Agones installation by running the following command:
 ```bash
-helm test my-release --cleanup
+helm test my-release -n agones-system
 ```
 ```
 RUNNING: agones-test


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Removes explicit version settings for Grafana and Prometheus, so that the most recent versions are pulled, and we do not need to continually update the versions in the documentation.
Updates the Helm version in the Makefile to >3.10 so that it works with the most recent versions of Grafana and Prometheus. 
Adds Error handling suggestions to the Makefile for easier troubleshooting.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


