### PR TITLE
controller/extensions: Add explicit requests/limits for ephemeral storage

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -146,9 +146,14 @@ spec:
           periodSeconds: {{ .Values.agones.controller.healthCheck.periodSeconds }}
           failureThreshold: {{ .Values.agones.controller.healthCheck.failureThreshold }}
           timeoutSeconds: {{ .Values.agones.controller.healthCheck.timeoutSeconds }}
-{{- if .Values.agones.controller.resources }}
         resources:
+{{- if .Values.agones.controller.resources }}
 {{ toYaml .Values.agones.controller.resources | indent 10 }}
+{{- else}}
+          limits:
+            ephemeral-storage: {{ add .Values.agones.controller.persistentLogsSizeLimitMB 100 | printf "%dMi" }}
+          requests:
+            ephemeral-storage: {{ add .Values.agones.controller.persistentLogsSizeLimitMB 100 | printf "%dMi" }}
 {{- end }}
         volumeMounts:
         - name: certs

--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -148,9 +148,14 @@ spec:
           periodSeconds: {{ .Values.agones.controller.healthCheck.periodSeconds }}
           failureThreshold: {{ .Values.agones.controller.healthCheck.failureThreshold }}
           timeoutSeconds: {{ .Values.agones.controller.healthCheck.timeoutSeconds }}
-{{- if .Values.agones.controller.resources }}
         resources:
+{{- if .Values.agones.controller.resources }}
 {{ toYaml .Values.agones.controller.resources | indent 10 }}
+{{- else}}
+          limits:
+            ephemeral-storage: {{ add .Values.agones.controller.persistentLogsSizeLimitMB 100 | printf "%dMi" }}
+          requests:
+            ephemeral-storage: {{ add .Values.agones.controller.persistentLogsSizeLimitMB 100 | printf "%dMi" }}
 {{- end }}
         volumeMounts:
         - name: certs

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -15634,6 +15634,11 @@ spec:
           periodSeconds: 3
           failureThreshold: 3
           timeoutSeconds: 1
+        resources:
+          limits:
+            ephemeral-storage: 10100Mi
+          requests:
+            ephemeral-storage: 10100Mi
         volumeMounts:
         - name: certs
           mountPath: /home/agones/certs


### PR DESCRIPTION
On Autopilot, ephemeral storage defaults to a request/limit of 1GiB, but on Agones we assume there's no ephemeral storage limit. The default persistent log limit is 10GB.

In this PR, we add a default `resources.{limits,requests}` block to the controller if the user has not already specified `resources` and set it to the persistent log maximum plus a fudge factor of 100MB to allow for the certs and some overhead. By default this comes out to 10100MB, which slides under the Autopilot 10GiB limit by virtue of GiB/MB differences.

Towards #2777