### PR TITLE
Wait on free ports on GKE Autopilot

### DIFF
--- a/pkg/cloudproduct/cloudproduct.go
+++ b/pkg/cloudproduct/cloudproduct.go
@@ -48,6 +48,9 @@ type ControllerHooksInterface interface {
 
 	// NewPortAllocator creates a PortAllocator. See gameservers.NewPortAllocator for parameters.
 	NewPortAllocator(int32, int32, informers.SharedInformerFactory, externalversions.SharedInformerFactory) portallocator.Interface
+
+	// WaitOnFreePorts
+	WaitOnFreePorts() bool
 }
 
 const (

--- a/pkg/cloudproduct/generic/generic.go
+++ b/pkg/cloudproduct/generic/generic.go
@@ -37,3 +37,5 @@ func (*generic) NewPortAllocator(minPort, maxPort int32,
 	agonesInformerFactory externalversions.SharedInformerFactory) portallocator.Interface {
 	return portallocator.New(minPort, maxPort, kubeInformerFactory, agonesInformerFactory)
 }
+
+func (*generic) WaitOnFreePorts() bool { return false }

--- a/pkg/cloudproduct/gke/gke.go
+++ b/pkg/cloudproduct/gke/gke.go
@@ -110,6 +110,8 @@ func (*gkeAutopilot) NewPortAllocator(minPort, maxPort int32,
 	return &autopilotPortAllocator{minPort: minPort, maxPort: maxPort}
 }
 
+func (*gkeAutopilot) WaitOnFreePorts() bool { return true }
+
 func (*gkeAutopilot) ValidateGameServerSpec(gss *agonesv1.GameServerSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	for _, p := range gss.Ports {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -285,7 +285,7 @@ func (f *Framework) WaitForGameServerState(t *testing.T, gs *agonesv1.GameServer
 	})
 
 	return checkGs, errors.Wrapf(err, "waiting for GameServer %v/%v to be %v",
-		state, gs.Namespace, gs.Name)
+		gs.Namespace, gs.Name, state)
 }
 
 // CycleAllocations repeatedly Allocates a GameServer in the Fleet (if one is available), once every specified period.

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -327,7 +327,7 @@ func TestGameServerRestartBeforeReadyCrash(t *testing.T) {
 	defer gsClient.Delete(ctx, newGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	logger.Info("Waiting for us to have an address to send things to")
-	newGs, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateScheduled, time.Minute)
+	newGs, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateScheduled, framework.WaitForState)
 	if err != nil {
 		assert.FailNow(t, "Failed schedule a pod", err.Error())
 	}


### PR DESCRIPTION
On Autopilot, since port assignments are random, port conflicts happen. Just accept it and wait on the autoscaler to kick in - the problem will go away.

We do this by introducing a `WaitOnFreePorts()` cloud product hook to indicate whether we should pay attention to the case where the pod is unschedulable due to free ports.

It is very likely this condition occurs organically in any autoscaling scenario, but the fleet controller also hides the condition by rapidly deleting the Unhealthy GameServer.

Along the way, fix a typo I introduced in the e2e framework.