### PR TITLE
e2e: Use gotestsum for CI e2e runs, change e2e ARGS handling

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -163,9 +163,20 @@ ifdef NO_RACE_DETECTOR
   RACE_DETECTOR_ARGS=
 endif
 
-go_test_cmd = go test -mod=vendor $(RACE_DETECTOR_ARGS)
+go_test_args = -mod=vendor $(RACE_DETECTOR_ARGS)
+go_test_cmd = go test $(go_test_args)
 GO_TEST=$(DOCKER_RUN) $(go_test_cmd)
 GO_E2E_TEST_ARGS=--kubeconfig /root/.kube/$(kubeconfig_file)
+
+gotestsum_json=/tmp/agones.gotestsum.json
+ifdef GOTESTSUM_VERBOSE
+gotestsum_format=--format=testname \
+  --post-run-command="sh -c 'echo; echo --- RAW VERBOSE OUTPUT ---; jq -j \"select(.Output != null) | .Output\" < $(gotestsum_json); echo --- END RAW VERBOSE OUTPUT ---'"
+else
+gotestsum_format=--format=standard-quiet
+endif
+gotestsum_cmd=gotestsum $(gotestsum_format) --jsonfile=$(gotestsum_json) --hide-summary=skipped --rerun-fails=2 $(GOTESTSUM_ARGS)
+GOTESTSUM=$(DOCKER_RUN) $(gotestsum_cmd)
 
 PERF_OUTPUT_DIR=$(mount_path)/build/.perf
 
@@ -178,6 +189,7 @@ ifdef LOCAL_GO
 	GO_BUILD_WINDOWS_AMD64=GOOS=windows GOARCH=amd64 $(gomod_on) $(go_build_cmd)
 	GO_BUILD_DARWIN_AMD64=GOOS=darwin GOARCH=amd64 $(gomod_on) $(go_build_cmd)
 	GO_TEST=$(go_test_cmd) -v
+	GOTESTSUM=$(gotestsum_cmd)
 	GO_E2E_TEST_ARGS=
 	PERF_OUTPUT_DIR=$(build_path)/.perf
 	go_build_base_path=$(agones_path)
@@ -301,31 +313,51 @@ test-e2e:
 	$(MAKE) DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS)" test-e2e-failure
 
 
+# e2e test args:
+# - Use ARGS to pass args to `go test` (but not the test binary itself)
+# - Use GO_E2E_TEST_ARGS to pass args to the test binary
+# - When E2E_USE_GOTESTSUM is enabled, use GOTESTSUM_ARGS to pass args to gotestsum
 # If GAMESERVERS_NAMESPACE is empty - random namespace will be created
 test-e2e-integration: FEATURE_GATES ?= $(ALPHA_FEATURE_GATES)
 test-e2e-integration: GAMESERVERS_NAMESPACE ?= ""
+test-e2e-integration: GO_E2E_TEST_INTEGRATION_ARGS ?=\
+  --gameserver-image=$(GS_TEST_IMAGE) \
+  --pullsecret=$(IMAGE_PULL_SECRET) \
+  --feature-gates=$(FEATURE_GATES) \
+  --namespace=$(GAMESERVERS_NAMESPACE)
 test-e2e-integration: $(ensure-build-image)
 	echo "Starting e2e integration test!"
-	$(GO_TEST) $(ARGS) -timeout=30m $(agones_package)/test/e2e $(GO_E2E_TEST_ARGS) \
-		--gameserver-image=$(GS_TEST_IMAGE) \
-		--pullsecret=$(IMAGE_PULL_SECRET) \
-		--feature-gates=$(FEATURE_GATES) \
-		--namespace=$(GAMESERVERS_NAMESPACE)
+ifdef E2E_USE_GOTESTSUM
+	$(GOTESTSUM) --packages=$(agones_package)/test/e2e -- $(go_test_args) -timeout=30m $(ARGS) -args \
+		$(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
+else
+	$(GO_TEST) -timeout=30m $(ARGS) $(agones_package)/test/e2e -args \
+	    $(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
+endif
 	echo "Finishing e2e integration test!"
 
+test-e2e-failure: GO_E2E_TEST_INTEGRATION_ARGS ?=\
+	--gameserver-image=$(GS_TEST_IMAGE) \
+	--pullsecret=$(IMAGE_PULL_SECRET)
 test-e2e-failure: $(ensure-build-image)
-	echo "starting e2e controller failure test"
-	$(GO_TEST) -parallel=1 $(agones_package)/test/e2e/controller $(GO_E2E_TEST_ARGS) \
-    	--gameserver-image=$(GS_TEST_IMAGE) \
-    	--pullsecret=$(IMAGE_PULL_SECRET)
+	echo "Starting e2e controller failure test!"
+ifdef E2E_USE_GOTESTSUM
+	$(GOTESTSUM) --packages=$(agones_package)/test/e2e/controller -- $(go_test_args) $(ARGS) -parallel=1 -args \
+		$(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
+else
+	$(GO_TEST) $(ARGS) -parallel=1 $(agones_package)/test/e2e/controller -args \
+	    $(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
+endif
 	echo "Finishing e2e controller failure test!"
 
 # Runs end-to-end stress tests on the current configured cluster
 # For minikube user the minikube-stress-test-e2e targets
 stress-test-e2e: $(ensure-build-image)
-	$(GO_TEST) $(agones_package)/test/e2e $(ARGS) $(GO_E2E_TEST_ARGS) \
+	$(GO_TEST) $(agones_package)/test/e2e $(ARGS) \
 		-timeout 1h \
 		-run '.*StressTest.*' \
+		-args \
+		$(GO_E2E_TEST_ARGS) \
 		--gameserver-image=$(GS_TEST_IMAGE) \
 		--pullsecret=$(IMAGE_PULL_SECRET) \
 		--stress $(STRESS_TEST_LEVEL) \

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -69,6 +69,9 @@ RUN echo "source <(helm completion bash)" >> /root/.bashrc
 # install golang-ci linter
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 
+# install gotestsum test runner
+RUN go install gotest.tools/gotestsum@latest
+
 #
 #  \ \      / /__| |__  ___(_) |_ ___
 #   \ \ /\ / / _ \ '_ \/ __| | __/ _ \

--- a/build/e2e-image/Dockerfile
+++ b/build/e2e-image/Dockerfile
@@ -42,6 +42,9 @@ RUN mkdir -p /tmp/build && \
     # tiny smoke test to ensure the binary we downloaded runs
     consul version
 
+# install gotestsum test runner
+RUN go install gotest.tools/gotestsum@latest
+
 # make sure we keep the path to go
 RUN echo "export PATH=/usr/local/go/bin:/go/bin/:\$PATH" >> /root/.bashrc
 # scripts

--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -23,5 +23,5 @@ set -e
 echo "installing current release"
 DOCKER_RUN= make install FEATURE_GATES='"'$FEATURES'"' REGISTRY='"'$REGISTRY'"'
 echo "starting e2e test"
-DOCKER_RUN= make test-e2e ARGS=-parallel=16 FEATURE_GATES='"'$FEATURES'"'
+DOCKER_RUN= make test-e2e ARGS=-parallel=16 E2E_USE_GOTESTSUM=true GOTESTSUM_VERBOSE=true FEATURE_GATES='"'$FEATURES'"'
 echo "completed e2e test"


### PR DESCRIPTION
The main goal of this PR is to add [`gotestsum`](https://pkg.go.dev/gotest.tools/gotestsum#section-readme) as an optional way to run e2es. `gotestsum` wraps `go test -json` and, aside from some fancy formatting options, allows us to re-run flaky tests. As we start adding more permutations to the test matrix, this will become important. (Also important will become actually monitoring flakes, but that's the next step.)

We do this by:
* Installing `gotestsum` in the build image
* Adding a new `E2E_USE_GOTESTSUM` option to the Makefile that defaults to 2x reruns and super-terse output.
* Also added a `GOTESTSUM_TESTNAME_AND_VERBOSE` option meant for CI that shows the status of all of the tests then dumps the full verbose output for diagnostics.

One thing that changes slightly after this PR is the arguments involved in invoking e2es via `make`. Previously, both `ARGS` and `GO_E2E_TEST_ARGS` were passed to `go test`. In order to hack arguments for re-runs, `gotestsum` requires a delineation between the arguments to `go test` and the arguments to the test binary. However, so that usage is consistent when E2E_USE_GOTESTSUM is present or not, I changed both to do the equivalent of:

```
go test ${ARGS} -args ${GO_E2E_TEST_ARGS}
```

In other words, for the e2e targets:
* Use `ARGS` to pass args to `go test` (e.g. `-parallel 16`)
* Use `GO_E2E_TEST_ARGS` to pass args to the test binary (e.g. `--kubeconfig`)
* If `E2E_USE_GOTESTSUM` is on, use `GOTESTSUM_ARGS` to pass args to `gotestsum` (e.g. `--rerun-fails=5`)

/kind cleanup