### PR TITLE
GKE Autopilot: Add terraform module, users

### DIFF
--- a/build/terraform/e2e/gke-autopilot/module.tf
+++ b/build/terraform/e2e/gke-autopilot/module.tf
@@ -42,7 +42,7 @@ module "gke_cluster" {
     "location" = "us-west1"
   }
 
-  ports = "" // firewall is created at the project module level
+  udpFirewall = false // firewall is created at the project module level
 }
 
 provider "helm" {

--- a/build/terraform/e2e/gke-autopilot/module.tf
+++ b/build/terraform/e2e/gke-autopilot/module.tf
@@ -1,0 +1,80 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Run:
+//  terraform apply -var project="<YOUR_GCP_ProjectID>"
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.25.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+  }
+}
+
+variable "project" {}
+variable "kubernetesVersion" {}
+
+module "gke_cluster" {
+  source = "../../../../install/terraform/modules/gke-autopilot"
+
+  cluster = {
+    "name"     = format("gke-autopilot-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
+    "project"  = var.project
+    "location" = "us-west1"
+  }
+
+  ports = "" // firewall is created at the project module level
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.gke_cluster.host
+    token                  = module.gke_cluster.token
+    cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
+  }
+}
+
+resource "helm_release" "consul" {
+  repository = "https://helm.releases.hashicorp.com"
+  chart      = "consul"
+  name       = "consul"
+
+  set {
+    name  = "server.replicas"
+    value = "1"
+  }
+
+  set {
+    name  = "server.affinity"
+    value = "null"
+  }
+
+  set {
+    name  = "ui.service.type"
+    value = "ClusterIP"
+  }
+
+  set {
+    name  = "client.enabled"
+    value = "false"
+  }
+}

--- a/build/terraform/e2e/gke-standard/module.tf
+++ b/build/terraform/e2e/gke-standard/module.tf
@@ -1,0 +1,82 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Run:
+//  terraform apply -var project="<YOUR_GCP_ProjectID>"
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.25.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+  }
+}
+
+variable "project" {}
+variable "kubernetesVersion" {}
+
+variable "overrideName" {
+  default = ""
+}
+
+module "gke_cluster" {
+  source = "../../../../install/terraform/modules/gke"
+
+  cluster = {
+    "name"                 = var.overrideName != "" ? var.overrideName : format("gke-standard-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
+    "zone"                 = "us-west1-c"
+    "machineType"          = "e2-standard-4"
+    "initialNodeCount"     = 10
+    "enableImageStreaming" = true
+    "project"              = var.project
+  }
+
+  ports = "" // firewall is created at the project module level
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.gke_cluster.host
+    token                  = module.gke_cluster.token
+    cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
+  }
+}
+
+resource "helm_release" "consul" {
+  repository = "https://helm.releases.hashicorp.com"
+  chart      = "consul"
+  name       = "consul"
+
+  set {
+    name  = "server.replicas"
+    value = "1"
+  }
+
+  set {
+    name  = "ui.service.type"
+    value = "ClusterIP"
+  }
+
+  set {
+    name  = "client.enabled"
+    value = "false"
+  }
+}

--- a/build/terraform/e2e/gke-standard/module.tf
+++ b/build/terraform/e2e/gke-standard/module.tf
@@ -49,7 +49,7 @@ module "gke_cluster" {
     "project"              = var.project
   }
 
-  ports = "" // firewall is created at the project module level
+  udpFirewall = false // firewall is created at the project module level
 }
 
 provider "helm" {

--- a/build/terraform/e2e/module.tf
+++ b/build/terraform/e2e/module.tf
@@ -30,52 +30,33 @@ terraform {
   }
 }
 
-variable "project" {
-  default = ""
+variable "project" {}
+
+module "gke_standard_cluster" {
+  source = "./gke-standard"
+  project = var.project
+  kubernetesVersion = "1.24"
+  overrideName = "e2e-test-cluster"
 }
 
-module "gke_cluster" {
-  source = "../../../install/terraform/modules/gke"
-
-  cluster = {
-    "name"                  = "e2e-test-cluster"
-    "zone"                  = "us-west1-c"
-    "machineType"           = "e2-standard-4"
-    "initialNodeCount"      = 10
-    "enableImageStreaming"  = true
-    "project"               = var.project
-  }
-
-  firewallName = "gke-game-server-firewall"
+module "gke_autopilot_cluster" {
+  source = "./gke-autopilot"
+  project = var.project
+  kubernetesVersion = "1.24"
 }
 
-provider "helm" {
-  kubernetes {
-    host                   = module.gke_cluster.host
-    token                  = module.gke_cluster.token
-    cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
-  }
-}
+resource "google_compute_firewall" "udp" {
+  name    = "gke-game-server-firewall"
+  project = var.project
+  network = "default"
 
-resource "helm_release" "consul" {
-  repository = "https://helm.releases.hashicorp.com"
-  chart      = "consul"
-  name       = "consul"
-
-  set {
-    name  = "server.replicas"
-    value = "1"
+  allow {
+    protocol = "udp"
+    ports    = ["7000-8000"]
   }
 
-  set {
-    name  = "ui.service.type"
-    value = "ClusterIP"
-  }
-
-  set {
-    name  = "client.enabled"
-    value = "false"
-  }
+  target_tags = ["game-server"]
+  source_ranges = ["0.0.0.0/0"]
 }
 
 resource "google_compute_firewall" "tcp" {

--- a/build/terraform/gke-autopilot/module.tf
+++ b/build/terraform/gke-autopilot/module.tf
@@ -1,0 +1,135 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Run:
+//  terraform apply -var project="<YOUR_GCP_ProjectID>" [-var agones_version="1.17.0"]
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.25.0"
+    }
+  }
+}
+
+/////////////////////
+// Cluster parameters
+
+variable "name" {
+  default = "agones-tf-cluster"
+}
+
+variable "project" {
+  default = ""
+}
+
+variable "location" {
+  default     = "us-west1"
+  description = "The GCP location to create the cluster in"
+}
+
+variable "network" {
+  default     = "default"
+  description = "The name of the VPC network to attach the cluster and firewall rule to"
+}
+
+////////////////////
+// Agones parameters
+
+// Install latest version of agones
+variable "agones_version" {
+  default = ""
+}
+
+variable "values_file" {
+  default = "../../../install/helm/agones/values.yaml"
+}
+
+variable "chart" {
+  default = "agones"
+}
+
+variable "crd_cleanup" {
+  default = "true"
+}
+
+variable "ping_service_type" {
+  default = "LoadBalancer"
+}
+
+variable "pull_policy" {
+  default = "Always"
+}
+
+variable "image_registry" {
+  default = "us-docker.pkg.dev/agones-images/release"
+}
+
+variable "always_pull_sidecar" {
+  default = "true"
+}
+
+variable "image_pull_secret" {
+  default = ""
+}
+
+variable "log_level" {
+  default = "info"
+}
+
+variable "feature_gates" {
+  default = ""
+}
+
+module "gke_autopilot_cluster" {
+  source = "../../../install/terraform/modules/gke-autopilot"
+
+  cluster = {
+    "name"     = var.name
+    "project"  = var.project
+    "location" = var.location
+    "network"  = var.network
+  }
+}
+
+module "helm_agones" {
+  source = "../../../install/terraform/modules/helm3"
+
+  agones_version         = var.agones_version
+  values_file            = var.values_file
+  chart                  = var.chart
+  feature_gates          = var.feature_gates
+  host                   = module.gke_autopilot_cluster.host
+  token                  = module.gke_autopilot_cluster.token
+  cluster_ca_certificate = module.gke_autopilot_cluster.cluster_ca_certificate
+  image_registry         = var.image_registry
+  image_pull_secret      = var.image_pull_secret
+  crd_cleanup            = var.crd_cleanup
+  ping_service_type      = var.ping_service_type
+  log_level              = var.log_level
+}
+
+output "host" {
+  value = module.gke_autopilot_cluster.host
+}
+output "token" {
+  value     = module.gke_autopilot_cluster.token
+  sensitive = true
+}
+output "cluster_ca_certificate" {
+  value = module.gke_autopilot_cluster.cluster_ca_certificate
+}

--- a/build/terraform/gke/module.tf
+++ b/build/terraform/gke/module.tf
@@ -20,7 +20,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~> 4.25.0"
     }
   }
@@ -133,7 +133,7 @@ module "gke_cluster" {
 
   cluster = {
     "name"                    = var.name
-    "location"		      = var.location
+    "location"                = var.location
     "zone"                    = var.zone
     "machineType"             = var.machine_type
     "initialNodeCount"        = var.node_count
@@ -142,9 +142,9 @@ module "gke_cluster" {
     "windowsInitialNodeCount" = var.windows_node_count
     "project"                 = var.project
     "network"                 = var.network
-    "autoscale"		      = var.autoscale
-    "minNodeCount"	      = var.min_node_count
-    "maxNodeCount"	      = var.max_node_count
+    "autoscale"               = var.autoscale
+    "minNodeCount"            = var.min_node_count
+    "maxNodeCount"            = var.max_node_count
   }
 }
 
@@ -169,7 +169,7 @@ output "host" {
   value = module.gke_cluster.host
 }
 output "token" {
-  value = module.gke_cluster.token
+  value     = module.gke_cluster.token
   sensitive = true
 }
 output "cluster_ca_certificate" {

--- a/examples/terraform-submodules/gke-autopilot/module.tf
+++ b/examples/terraform-submodules/gke-autopilot/module.tf
@@ -1,0 +1,112 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Run:
+//  terraform apply -var project="<YOUR_GCP_ProjectID>" [-var agones_version="1.30.0"]
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.25.0"
+    }
+  }
+}
+
+/////////////////////
+// Cluster parameters
+
+variable "name" {
+  default = "agones-terraform-example"
+}
+
+variable "project" {
+  default = ""
+}
+
+variable "location" {
+  default     = "us-west1-c"
+  description = "The GCP location to create the cluster in"
+}
+
+variable "network" {
+  default     = "default"
+  description = "The name of the VPC network to attach the cluster and firewall rule to"
+}
+
+variable "subnetwork" {
+  default     = ""
+  description = "The subnetwork to host the cluster in. Required field if network value isn't 'default'."
+}
+
+////////////////////
+// Agones parameters
+
+// Install latest version of agones
+variable "agones_version" {
+  default = ""
+}
+
+variable "log_level" {
+  default = "info"
+}
+
+variable "feature_gates" {
+  default = ""
+}
+
+module "gke_cluster" {
+  // ***************************************************************************************************
+  // Update ?ref= to the agones release you are installing. For example, ?ref=release-1.17.0 corresponds
+  // to Agones version 1.17.0
+  // ***************************************************************************************************
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=main"
+
+  cluster = {
+    "name"       = var.name
+    "project"    = var.project
+    "location"   = var.location
+    "network"    = var.network
+    "subnetwork" = var.subnetwork
+  }
+}
+
+module "helm_agones" {
+  // ***************************************************************************************************
+  // Update ?ref= to the agones release you are installing. For example, ?ref=release-1.17.0 corresponds
+  // to Agones version 1.17.0
+  // ***************************************************************************************************
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=main"
+
+  agones_version         = var.agones_version
+  values_file            = ""
+  feature_gates          = var.feature_gates
+  host                   = module.gke_cluster.host
+  token                  = module.gke_cluster.token
+  cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
+  log_level              = var.log_level
+}
+
+output "host" {
+  value = module.gke_cluster.host
+}
+output "token" {
+  value     = module.gke_cluster.token
+  sensitive = true
+}
+output "cluster_ca_certificate" {
+  value = module.gke_cluster.cluster_ca_certificate
+}

--- a/install/terraform/modules/gke-autopilot/cluster.tf
+++ b/install/terraform/modules/gke-autopilot/cluster.tf
@@ -1,0 +1,94 @@
+# Copyright 2023 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+terraform {
+  required_version = ">= 1.0.0"
+}
+
+data "google_client_config" "default" {}
+
+# A list of all parameters used in interpolation var.cluster
+# Set values to default if not key was not set in original map
+locals {
+  name              = lookup(var.cluster, "name", "test-cluster")
+  project           = lookup(var.cluster, "project", "agones")
+  location          = lookup(var.cluster, "location", "us-west1")
+  network           = lookup(var.cluster, "network", "default")
+  subnetwork        = lookup(var.cluster, "subnetwork", "")
+  releaseChannel    = lookup(var.cluster, "releaseChannel", "REGULAR")
+  kubernetesVersion = lookup(var.cluster, "kubernetesVersion", "1.24")
+}
+
+# echo command used for debugging purpose
+# Run `terraform taint null_resource.test-setting-variables` before second execution
+resource "null_resource" "test-setting-variables" {
+  provisioner "local-exec" {
+    command = <<EOT
+    ${format("echo Current variables set as following - name: %s, project: %s, location: %s, network: %s, subnetwork: %s, releaseChannel: %s, kubernetesVersion: %s",
+    local.name,
+    local.project,
+    local.location,
+    local.network,
+    local.subnetwork,
+    local.releaseChannel,
+    local.kubernetesVersion,
+)}
+    EOT
+}
+}
+
+resource "google_container_cluster" "primary" {
+  provider = google-beta # required for node_pool_auto_config.network_tags
+
+  name       = local.name
+  project    = local.project
+  location   = local.location
+  network    = local.network
+  subnetwork = local.subnetwork
+
+  release_channel {
+    channel = local.releaseChannel != "" ? local.releaseChannel : "UNSPECIFIED"
+  }
+  min_master_version = local.kubernetesVersion
+
+  enable_autopilot = true
+  ip_allocation_policy {} # https://github.com/hashicorp/terraform-provider-google/issues/10782#issuecomment-1024488630
+
+  node_pool_auto_config {
+    network_tags {
+      tags = ["game-server"]
+    }
+  }
+
+  timeouts {
+    create = "40m"
+    update = "60m"
+  }
+}
+
+resource "google_compute_firewall" "default" {
+  count   = var.ports != "" ? 1 : 0
+  name    = length(var.firewallName) == 0 ? "game-server-firewall-${local.name}" : var.firewallName
+  project = local.project
+  network = local.network
+
+  allow {
+    protocol = "udp"
+    ports    = [var.ports]
+  }
+
+  target_tags   = ["game-server"]
+  source_ranges = [var.sourceRanges]
+}

--- a/install/terraform/modules/gke-autopilot/cluster.tf
+++ b/install/terraform/modules/gke-autopilot/cluster.tf
@@ -79,7 +79,7 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_compute_firewall" "default" {
-  count   = var.ports != "" ? 1 : 0
+  count   = var.udpFirewall ? 1 : 0
   name    = length(var.firewallName) == 0 ? "game-server-firewall-${local.name}" : var.firewallName
   project = local.project
   network = local.network

--- a/install/terraform/modules/gke-autopilot/outputs.tf
+++ b/install/terraform/modules/gke-autopilot/outputs.tf
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_ca_certificate" {
+  value = base64decode(google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+}
+
+output "host" {
+  value = "https://${google_container_cluster.primary.endpoint}"
+}
+
+output "token" {
+  value = data.google_client_config.default.access_token
+}

--- a/install/terraform/modules/gke-autopilot/variables.tf
+++ b/install/terraform/modules/gke-autopilot/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2023 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ports can be overriden using tfvars file. If ports is empty, no firewall is declared.
+variable "ports" {
+  default = "7000-8000"
+}
+
+# SourceRanges can be overriden using tfvars file
+variable "sourceRanges" {
+  default = "0.0.0.0/0"
+}
+
+# Set of GKE cluster parameters which defines its name, zone
+# and primary node pool configuration.
+# It is crucial to set valid ProjectID for "project".
+variable "cluster" {
+  description = "Set of GKE cluster parameters."
+  type        = map(any)
+
+  default = {
+    "name"                    = "test-cluster"
+    "project"                 = "agones"
+    "location"                = "us-west1"
+    "network"                 = "default"
+    "subnetwork"              = ""
+    "releaseChannel"          = "REGULAR"
+    "kubernetesVersion"       = "1.24"
+  }
+}
+
+variable "firewallName" {
+  description = "name for the cluster firewall. Defaults to 'game-server-firewall-{local.name}' if not set."
+  type        = string
+  default     = ""
+}

--- a/install/terraform/modules/gke-autopilot/variables.tf
+++ b/install/terraform/modules/gke-autopilot/variables.tf
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ports can be overriden using tfvars file. If ports is empty, no firewall is declared.
-variable "ports" {
-  default = "7000-8000"
-}
-
-# SourceRanges can be overriden using tfvars file
-variable "sourceRanges" {
-  default = "0.0.0.0/0"
-}
-
 # Set of GKE cluster parameters which defines its name, zone
 # and primary node pool configuration.
 # It is crucial to set valid ProjectID for "project".
@@ -30,14 +20,30 @@ variable "cluster" {
   type        = map(any)
 
   default = {
-    "name"                    = "test-cluster"
-    "project"                 = "agones"
-    "location"                = "us-west1"
-    "network"                 = "default"
-    "subnetwork"              = ""
-    "releaseChannel"          = "REGULAR"
-    "kubernetesVersion"       = "1.24"
+    "name"              = "test-cluster"
+    "project"           = "agones"
+    "location"          = "us-west1"
+    "network"           = "default"
+    "subnetwork"        = ""
+    "releaseChannel"    = "REGULAR"
+    "kubernetesVersion" = "1.24"
   }
+}
+
+# udpFirewall specifies whether to create a UDP firewall named
+# `firewallName` with port range `ports`, source range `sourceRanges` 
+variable "udpFirewall" {
+  default = true
+}
+
+# Ports can be overriden using tfvars file
+variable "ports" {
+  default = "7000-8000"
+}
+
+# SourceRanges can be overriden using tfvars file
+variable "sourceRanges" {
+  default = "0.0.0.0/0"
 }
 
 variable "firewallName" {

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -23,7 +23,7 @@ data "google_client_config" "default" {}
 # Set values to default if not key was not set in original map
 locals {
   project                 = lookup(var.cluster, "project", "agones")
-  location		  = lookup(var.cluster, "location", "us-west1-c")
+  location                = lookup(var.cluster, "location", "us-west1-c")
   zone                    = lookup(var.cluster, "zone", "")
   name                    = lookup(var.cluster, "name", "test-cluster")
   machineType             = lookup(var.cluster, "machineType", "e2-standard-4")
@@ -34,9 +34,9 @@ locals {
   kubernetesVersion       = lookup(var.cluster, "kubernetesVersion", "1.24")
   windowsInitialNodeCount = lookup(var.cluster, "windowsInitialNodeCount", "0")
   windowsMachineType      = lookup(var.cluster, "windowsMachineType", "e2-standard-4")
-  autoscale 		  = lookup(var.cluster, "autoscale", false)
-  minNodeCount		  = lookup(var.cluster, "minNodeCount", "1")
-  maxNodeCount		  = lookup(var.cluster, "maxNodeCount", "5")
+  autoscale               = lookup(var.cluster, "autoscale", false)
+  minNodeCount            = lookup(var.cluster, "minNodeCount", "1")
+  maxNodeCount            = lookup(var.cluster, "maxNodeCount", "5")
 }
 
 # echo command used for debugging purpose
@@ -75,8 +75,8 @@ resource "google_container_cluster" "primary" {
     dynamic "autoscaling" {
       for_each = local.autoscale ? [1] : []
       content {
-      	min_node_count = local.minNodeCount
-	max_node_count = local.maxNodeCount
+        min_node_count = local.minNodeCount
+        max_node_count = local.maxNodeCount
       }
     }
 
@@ -218,6 +218,7 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_compute_firewall" "default" {
+  count   = var.ports != "" ? 1 : 0
   name    = length(var.firewallName) == 0 ? "game-server-firewall-${local.name}" : var.firewallName
   project = local.project
   network = local.network
@@ -227,6 +228,6 @@ resource "google_compute_firewall" "default" {
     ports    = [var.ports]
   }
 
-  target_tags = ["game-server"]
+  target_tags   = ["game-server"]
   source_ranges = [var.sourceRanges]
 }

--- a/install/terraform/modules/gke/cluster.tf
+++ b/install/terraform/modules/gke/cluster.tf
@@ -218,7 +218,7 @@ resource "google_container_cluster" "primary" {
 }
 
 resource "google_compute_firewall" "default" {
-  count   = var.ports != "" ? 1 : 0
+  count   = var.udpFirewall ? 1 : 0
   name    = length(var.firewallName) == 0 ? "game-server-firewall-${local.name}" : var.firewallName
   project = local.project
   network = local.network

--- a/install/terraform/modules/gke/variables.tf
+++ b/install/terraform/modules/gke/variables.tf
@@ -12,25 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ports can be overriden using tfvars file
-variable "ports" {
-  default = "7000-8000"
-}
-
-# SourceRanges can be overriden using tfvars file
-variable "sourceRanges" {
-  default = "0.0.0.0/0"
-}
-
 # Set of GKE cluster parameters which defines its name, zone
 # and primary node pool configuration.
 # It is crucial to set valid ProjectID for "project".
 variable "cluster" {
   description = "Set of GKE cluster parameters."
-  type        = map
+  type        = map(any)
 
   default = {
-    "location"		      = "us-west1-c"
+    "location"                = "us-west1-c"
     "name"                    = "test-cluster"
     "machineType"             = "e2-standard-4"
     "initialNodeCount"        = "4"
@@ -40,10 +30,26 @@ variable "cluster" {
     "kubernetesVersion"       = "1.24"
     "windowsInitialNodeCount" = "0"
     "windowsMachineType"      = "e2-standard-4"
-    "autoscale"		      = false
-    "minNodeCount"	      = "1"
-    "maxNodeCount"	      = "5"
+    "autoscale"               = false
+    "minNodeCount"            = "1"
+    "maxNodeCount"            = "5"
   }
+}
+
+# udpFirewall specifies whether to create a UDP firewall named
+# `firewallName` with port range `ports`, source range `sourceRanges` 
+variable "udpFirewall" {
+  default = true
+}
+
+# Ports can be overriden using tfvars file
+variable "ports" {
+  default = "7000-8000"
+}
+
+# SourceRanges can be overriden using tfvars file
+variable "sourceRanges" {
+  default = "0.0.0.0/0"
 }
 
 variable "firewallName" {


### PR DESCRIPTION
This adds an install/terraform module names `gke-autopilot`, example terraform submodule, build submodule, e2e submodule and e2e Makefile targets for GKE Autopilot.

I did not add additional Makefile targets - we can do those as needed, but there do seem to be a group of other targets that use the `gke` module.

Towards #2777 
