### PR TITLE
Move the e2e test cluster Consul installation to the top-level gke module

### DIFF
--- a/build/terraform/e2e/module.tf
+++ b/build/terraform/e2e/module.tf
@@ -44,38 +44,10 @@ module "gke_cluster" {
     "initialNodeCount"      = 10
     "enableImageStreaming"  = true
     "project"               = var.project
+    "installConsul"         = true
   }
 
   firewallName = "gke-game-server-firewall"
-}
-
-provider "helm" {
-  kubernetes {
-    host                   = module.gke_cluster.host
-    token                  = module.gke_cluster.token
-    cluster_ca_certificate = module.gke_cluster.cluster_ca_certificate
-  }
-}
-
-resource "helm_release" "consul" {
-  repository = "https://helm.releases.hashicorp.com"
-  chart      = "consul"
-  name       = "consul"
-
-  set {
-    name  = "server.replicas"
-    value = "1"
-  }
-
-  set {
-    name  = "ui.service.type"
-    value = "ClusterIP"
-  }
-
-  set {
-    name  = "client.enabled"
-    value = "false"
-  }
 }
 
 resource "google_compute_firewall" "tcp" {

--- a/install/terraform/modules/gke/variables.tf
+++ b/install/terraform/modules/gke/variables.tf
@@ -43,6 +43,7 @@ variable "cluster" {
     "autoscale"		      = false
     "minNodeCount"	      = "1"
     "maxNodeCount"	      = "5"
+    "installConsul"       = false
   }
 }
 


### PR DESCRIPTION
…dule

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:
Move the e2e test cluster Consul installation to the top-level gke module, so we can mitigate the issue that we cannot use the same Module file to create multiple e2e test cluster since [Terraform with Helm doesn’t support specifying the provider for multiple clusters in a single module file](https://github.com/hashicorp/terraform-provider-helm/issues/539).
Also add a gate variable so by default the Consul is not installed in the cluster.
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


