### PR TITLE
Bump the cloud build expiration time, we can no longer retry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -382,7 +382,7 @@ substitutions:
   _REGISTRY: us-docker.pkg.dev/${PROJECT_ID}/ci
 tags: ['ci']
 timeout: 9000s # 2.5h
-queueTtl: 21600s # 6h
+queueTtl: 259200s # 72h
 images:
   - '${_REGISTRY}/agones-controller'
   - '${_REGISTRY}/agones-sdk'

--- a/pkg/metrics/controller_test.go
+++ b/pkg/metrics/controller_test.go
@@ -159,6 +159,8 @@ func TestControllerGameServerCount(t *testing.T) {
 }
 
 func TestControllerGameServerPlayerConnectedCount(t *testing.T) {
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
 	runtime.EnableAllFeatures()
 	resetMetrics()
 	exporter := &metricExporter{}
@@ -205,6 +207,8 @@ func TestControllerGameServerPlayerConnectedCount(t *testing.T) {
 }
 
 func TestControllerGameServerPlayerCapacityCount(t *testing.T) {
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
 	runtime.EnableAllFeatures()
 	resetMetrics()
 	exporter := &metricExporter{}


### PR DESCRIPTION
Along the way: I was trying to audit uses of FeatureTestMutex and noticed that the user of EnableAllFeatures doesn't bother. I think this part of the change is a no-op as these tests aren't marked t.Parallel(), but changed it for consistency in case anyone else does a hand audit.

c.f. #2925 where I lost the ability to retry.