### PR TITLE
Run e2es in fair order, eliminate need for consul

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -246,6 +246,39 @@ steps:
     - GOPATH=/workspace/go
     - GO111MODULE=on
 
+# wait for us to be the oldest ongoing build before we run e2es
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: e2e-wait-to-become-leader
+  waitFor:
+    - push-images
+    - build-e2e
+  script: |
+    #!/usr/bin/env bash
+
+    TS='date --utc +%FT%TZ' # e.g. 2023-01-26T13:30:37Z
+    echo "$(${TS}): Waiting to become oldest running build"
+    while true; do
+      # Filter to running builds within the same TRIGGER_NAME. We use the trigger name to
+      # filter rather than buildTriggerId because there is no substitution available for
+      # buildTriggerId.
+      TRIGGER_FILTER="status=WORKING AND substitutions[TRIGGER_NAME]='${TRIGGER_NAME}'"
+      OLDEST=$(gcloud builds list --filter "${TRIGGER_FILTER}" --format="value(id,startTime)" --sort-by=startTime --limit=1)
+      echo "$(${TS}): Oldest is (id startTime): ${OLDEST}"
+
+      if echo ${OLDEST} | grep -q "${BUILD_ID}"; then
+        echo "$(${TS}): That's us, we're done!"
+        break
+      fi
+
+      sleep 60
+    done
+  timeout: 5400s # 90m - leave an hour for e2es to run on top of the global timeout of 2.5h
+  env:
+  - 'CLOUDSDK_CORE_PROJECT=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
+  - 'TRIGGER_NAME=$TRIGGER_NAME'
+
 #
 # Run the e2e tests with FeatureGates inverted compared to Stable
 #
@@ -260,8 +293,7 @@ steps:
     - "${_REGISTRY}"
   id: e2e-feature-gates
   waitFor:
-    - push-images
-    - build-e2e
+    - e2e-wait-to-become-leader
 
 #
 # Run the e2e tests without FeatureGates
@@ -276,8 +308,7 @@ steps:
     - "${_REGISTRY}"
   id: e2e-stable
   waitFor:
-    - push-images
-    - build-e2e
+    - e2e-feature-gates
 
 #
 # Run the e2e tests on GKE Autopilot with FeatureGates inverted compared to Stable
@@ -294,8 +325,7 @@ steps:
   id: e2e-feature-gates-gke-autopilot
   allowFailure: true # for now, run the step but don't block on it
   waitFor:
-    - push-images
-    - build-e2e
+    - e2e-wait-to-become-leader
 
 #
 # Run the e2e tests on GKE Autopilot without FeatureGates, except SafeToEvict, which we need on Autopilot
@@ -311,8 +341,7 @@ steps:
   id: e2e-stable-gke-autopilot
   allowFailure: true # for now, run the step but don't block on it
   waitFor:
-    - push-images
-    - build-e2e
+    - e2e-feature-gates-gke-autopilot
 
 #
 # SDK conformance tests
@@ -381,7 +410,7 @@ substitutions:
   _RUST_SDK_BUILD_CACHE_KEY: rust-sdk-build
   _REGISTRY: us-docker.pkg.dev/${PROJECT_ID}/ci
 tags: ['ci']
-timeout: 9000s # 2.5h
+timeout: 9000s # 2.5h - if you change this, change e2e-wait-to-become-leader as well
 queueTtl: 259200s # 72h
 images:
   - '${_REGISTRY}/agones-controller'


### PR DESCRIPTION
## The Change

This commit changes the build steps involved in running e2es so that prior to running e2es, the current build is the oldest running build within the same trigger (the agones branch trigger, in our case).

This effectively turns the new `e2e-wait-to-become-leader` step into a custom queuing mechanism. The idea is that all other steps of the build can run in parallel, but only the e2e leader can run e2es, and the e2e leader is always the oldest build in the queue.

I also changed the second test in each config (e2e-stable*) to depends on the first (e2e-feature-gates*). So now the build looks roughly like:

```
become-leader +---> feature-gates-config-1 ----> stable-config-1
               \--> feature-gates-config-2 ----> stable-config-2
```

(where config-1 and config-2 are standard and autopilot right now).

Serializing the builds then the steps will let us remove the use of Consul. I kept it in for now because until this commit is present in every PR, other PRs won't respect the same ordering.

## Why do we need it?

We've been seeing a lot of Consul lock timeouts in e2es, so I started looking into this after #2913, and I think that PR exacerbated the issue even more (it's definitely been happening more frequently). The reason I think this is happening is that by adding more "runs" that a build has to complete (e.g. 2 runs previously (`feature-gates` and `stable`), now 4 runs (x{standard, autopilot}), if there is contention between builds, we're increasing the opportunities for one build to delay another. I thought about various ways to represent this, but I think the _most_ simplistic, and it's not exactly right but it's close, is this:

Imagine each build has to run `C` configurations to succeed. Here we're not going to even talk about the flakiness of that run - assume they're reliable and take a one unit of time. _But_, assume now we start `B` runs at the same time, each of which need to run on `C` configurations.

With this setup, we can roughly (and I mean roughly) model the time it takes a single build to complete as rolling `C` dice numbered `1..B` - each die represents the number of runs (by other builds) that we have to wait, and then taking the maximum of those `C` dice. Not getting into too much math here, but as `C` increases, the expected value of the maximum approaches `B` with some rapidity. #2913 doubled `C` effectively, and with multiple version support, we're talking about tripling it again - we are quite rapidly approaching `B` time units (think of this as "e2e length * builds currently running") as the expected value for every build. And this model assumes you just have `B` simultaneous builds - what we often have is a stream of PRs (and then post-submit builds), which can often result in starvation / timeouts.

If we use a "fair" scheduling approach and handle all configs of one build before moving on to all configs of another, the expected wait time for a given build drops to `(B+1)/2` (/handwave), plus things act "fairer" - old builds finish first, and if new builds pop a timeout, it means we've exceeded bandwidth for a while. It's not perfect - without additional "slots" we may see this condition for sure, but I think this change is considerably better than what we have.