### PR TITLE
Allocation Endpoint: Fix Makefile to correctly call docker build 

### DIFF
--- a/examples/allocation-endpoint/Makefile
+++ b/examples/allocation-endpoint/Makefile
@@ -40,7 +40,7 @@ root_path = $(realpath $(project_path)/../..)
 
 # build the allocation endpoint proxy binary
 build:
-	cd $(root_path) && docker build -f $(project_path)/server/Dockerfile --tag=$(server_tag) .
+	cd $(project_path)/server/ && docker build --tag=$(server_tag) .
 
 run:
 	docker run --network=host $(server_tag) $(args)

--- a/examples/allocation-endpoint/Makefile
+++ b/examples/allocation-endpoint/Makefile
@@ -28,7 +28,7 @@ REPOSITORY = us-docker.pkg.dev/agones-images/examples
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/allocation-endpoint-proxy:0.2
+server_tag = $(REPOSITORY)/allocation-endpoint-proxy:0.3
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/allocation-endpoint/terraform/variable.tf
+++ b/examples/allocation-endpoint/terraform/variable.tf
@@ -20,7 +20,7 @@ variable "project_id" {
 variable "ae_proxy_image" {
   type        = string
   description = "The docker image of the allocation proxy."
-  default     = "us-docker.pkg.dev/agones-images/examples/allocation-endpoint-proxy:0.2"
+  default     = "us-docker.pkg.dev/agones-images/examples/allocation-endpoint-proxy:0.3"
 }
 
 variable "region" {


### PR DESCRIPTION
The Allocation Endpoint [container image](us-docker.pkg.dev/agones-images/examples/allocation-endpoint-proxy:0.2) will not run due to the allocation-endpoint-proxy binary being incompletely built.

When you try to run the container image, the following error occurs:

> exec: "/allocation-endpoint-proxy": permission denied:  

This PR fixes the permission error by modifying the Makefile to include the correct build path when building the allocation-endpoint-proxy binary. 

Once the PR has been merged, an account with the appropriate repository permissions will need to re-publish the Allocation Endpoint [container image](us-docker.pkg.dev/agones-images/examples/allocation-endpoint-proxy:0.2).
