### PR TITLE
Disable consul locking if consul is not present

### DIFF
--- a/build/e2e-image/entrypoint.sh
+++ b/build/e2e-image/entrypoint.sh
@@ -32,11 +32,23 @@ then
 fi
 gcloud container clusters get-credentials $TEST_CLUSTER_NAME \
         --zone=${TEST_CLUSTER_LOCATION} --project=agones-images
-kubectl port-forward statefulset/consul-consul-server 8500:8500 &
-echo "Waiting consul port-forward to launch on 8500..."
-timeout 60 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' 127.0.0.1 8500
-echo "consul port-forward launched. Starting e2e tests..."
-echo "consul lock -child-exit-code=true -timeout 90m -verbose LockE2E '/root/e2e.sh "$FEATURES" "$CLOUD_PRODUCT" "$REGISTRY"'"
-consul lock -child-exit-code=true -timeout 90m -verbose LockE2E '/root/e2e.sh "'$FEATURES'" "'$CLOUD_PRODUCT'" "'$REGISTRY'"'
-killall -q kubectl || true
-echo "successfully killed kubectl proxy"
+
+# TODO: Here we're using the presence of consul to dictate whether we use consul
+# port forwarding or whether we rely on Cloud Build serialization from #2932. This
+# allows us to quickly recover (by reinstalling consul) if something breaks.
+# After a few more days of PRs, it should be safe to remove this.
+if kubectl get statefulset/consul-consul-server -oname >& /dev/null
+then
+        echo "Using legacy consul locking"
+        kubectl port-forward statefulset/consul-consul-server 8500:8500 &
+        echo "Waiting consul port-forward to launch on 8500..."
+        timeout 60 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' 127.0.0.1 8500
+        echo "consul port-forward launched. Starting e2e tests..."
+        echo "consul lock -child-exit-code=true -timeout 90m -verbose LockE2E '/root/e2e.sh "$FEATURES" "$CLOUD_PRODUCT" "$REGISTRY"'"
+        consul lock -child-exit-code=true -timeout 90m -verbose LockE2E '/root/e2e.sh "'$FEATURES'" "'$CLOUD_PRODUCT'" "'$REGISTRY'"'
+        killall -q kubectl || true
+        echo "successfully killed kubectl proxy"
+else
+        echo /root/e2e.sh "${FEATURES}" "${CLOUD_PRODUCT}" "${REGISTRY}"
+        /root/e2e.sh "${FEATURES}" "${CLOUD_PRODUCT}" "${REGISTRY}"
+fi


### PR DESCRIPTION
This is a continuation of #2932: The idea here is two-fold:

* Make the use of consul locking conditional on whether consul is present. This lets us stop and/or restart using consul locking out-of-band of a PR, which can prevent us from getting in a funny position of needing to force merge because CI is broken.

* Uninstalling consul has a certain finality to it: It's not uncommon in OSS projects to see PRs that are _very_ out of date. If we were to just stop using consul but leave it installed, those PRs would run through the old locking mechanism unimpeded and likely harm an in-progress e2e. If we instead uninstall consul, stale PRs will just fail CI - a rebase will then pick up the new locking mechanism.

I will test this on the Autopilot CI first, since it's still in "allow failure" mode, making it a perfect canary.