### PR TITLE
Block on Autopilot in CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -323,7 +323,6 @@ steps:
     - 'us-west1'
     - "${_REGISTRY}"
   id: e2e-feature-gates-gke-autopilot
-  allowFailure: true # for now, run the step but don't block on it
   waitFor:
     - e2e-wait-to-become-leader
 
@@ -339,7 +338,6 @@ steps:
     - 'us-west1'
     - "${_REGISTRY}"
   id: e2e-stable-gke-autopilot
-  allowFailure: true # for now, run the step but don't block on it
   waitFor:
     - e2e-feature-gates-gke-autopilot
 


### PR DESCRIPTION
Autopilot has been doing well enough that I think it's worth blocking on it now in CI so we get more obvious coverage (rather than me polling).

