### PR TITLE
Add e2e test for Extensions

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -311,6 +311,7 @@ test-go: $(ensure-build-image)
 test-e2e:
 	$(MAKE) DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS)" test-e2e-integration
 	$(MAKE) DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS)" test-e2e-failure
+	$(MAKE) DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS)" test-e2e-ha-extensions
 
 
 # e2e test args:
@@ -353,6 +354,24 @@ else
 	    $(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
 endif
 	echo "Finishing e2e controller failure test!"
+
+test-e2e-ha-extensions: FEATURE_GATES ?= $(ALPHA_FEATURE_GATES)
+test-e2e-ha-extensions: CLOUD_PRODUCT ?= generic
+test-e2e-ha-extensions: GO_E2E_TEST_INTEGRATION_ARGS ?=\
+	--cloud-product=$(CLOUD_PRODUCT) \
+	--gameserver-image=$(GS_TEST_IMAGE) \
+	--feature-gates=$(FEATURE_GATES) \
+	--pullsecret=$(IMAGE_PULL_SECRET)
+test-e2e-ha-extensions: $(ensure-build-image)
+	echo "Starting e2e extensions high availability test!"
+ifdef E2E_USE_GOTESTSUM
+	$(GOTESTSUM) --packages=$(agones_package)/test/e2e/extensions -- $(go_test_args) $(ARGS) -parallel=1 -args \
+		$(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
+else
+	$(GO_TEST) $(ARGS) -parallel=1 $(agones_package)/test/e2e/extensions -args \
+	    $(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
+endif
+	echo "Finishing e2e extensions high availability test!"
 
 # Runs end-to-end stress tests on the current configured cluster
 # For minikube user the minikube-stress-test-e2e targets

--- a/test/e2e/extensions/high_availability_test.go
+++ b/test/e2e/extensions/high_availability_test.go
@@ -1,0 +1,96 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"agones.dev/agones/pkg/util/runtime"
+	e2eframework "agones.dev/agones/test/e2e/framework"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Test creating a gameserver when one of the extensions pods is down/deleted
+func TestGameServerHealthyAfterDeletingPodWhileOneExtensionsDown(t *testing.T) {
+	logger := e2eframework.TestLogger(t)
+	ctx := context.Background()
+
+	if !runtime.FeatureEnabled(runtime.FeatureSplitControllerAndExtensions) {
+		t.Skip("Skip test. SplitControllerAndExtensions feature is not enabled")
+	}
+
+	assert.NoError(t, waitForAgonesExtensionsRunning(ctx))
+
+	list, err := getAgoneseExtensionsPods(ctx)
+	logger.Infof("Length of pod list is %v", len(list.Items))
+	assert.NoError(t, err, "Could not get list of Extension pods")
+	assert.Greater(t, len(list.Items), 1, "Cluster has no Extensions pod or has only 1 extensions pod")
+
+	logger.Info("Removing one of the Extensions Pods")
+	deleteAgonesExtensionsPods(ctx, t)
+
+	assert.NoError(t, waitForAgonesExtensionsRunning(ctx))
+
+	logger.Info("Creating default game server")
+	gs := framework.DefaultGameServer(defaultNs)
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, defaultNs, gs)
+	assert.NoError(t, err, "Could not get a GameServer ready")
+	logger.WithField("gsKey", readyGs.ObjectMeta.Name).Info("GameServer Ready")
+
+	assert.NoError(t, framework.AgonesClient.AgonesV1().GameServers(defaultNs).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{})) // nolint: errcheck
+}
+
+// deleteAgonesExtensionsPod deletes one of the extensions pod for the Agones extensions,
+// faking a extensions pod crash.
+func deleteAgonesExtensionsPods(ctx context.Context, t *testing.T) {
+	list, err := getAgoneseExtensionsPods(ctx)
+	assert.NoError(t, err)
+
+	policy := metav1.DeletePropagationBackground
+	err = framework.KubeClient.CoreV1().Pods("agones-system").Delete(ctx, list.Items[1].ObjectMeta.Name,
+		metav1.DeleteOptions{PropagationPolicy: &policy})
+	assert.NoError(t, err)
+}
+
+func waitForAgonesExtensionsRunning(ctx context.Context) error {
+	return wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
+		list, err := getAgoneseExtensionsPods(ctx)
+		if err != nil {
+			return true, err
+		}
+
+		for i := range list.Items {
+			for _, c := range list.Items[i].Status.ContainerStatuses {
+				if c.State.Running == nil {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	})
+}
+
+// getAgonesExtensionsPods returns all the Agones extensions pods
+func getAgoneseExtensionsPods(ctx context.Context) (*corev1.PodList, error) {
+	opts := metav1.ListOptions{LabelSelector: labels.Set{"agones.dev/role": "extensions"}.String()}
+	return framework.KubeClient.CoreV1().Pods("agones-system").List(ctx, opts)
+}

--- a/test/e2e/extensions/main_test.go
+++ b/test/e2e/extensions/main_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"os"
+	"testing"
+
+	e2eframework "agones.dev/agones/test/e2e/framework"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+)
+
+const defaultNs = "default"
+
+var framework *e2eframework.Framework
+
+func TestMain(m *testing.M) {
+	logrus.SetFormatter(&logrus.TextFormatter{
+		EnvironmentOverrideColors: true,
+		FullTimestamp:             true,
+		TimestampFormat:           "2006-01-02 15:04:05.000",
+	})
+
+	var (
+		err      error
+		exitCode int
+	)
+
+	if err = e2eframework.ParseTestFlags(); err != nil {
+		log.WithError(err).Error("failed to parse go test flags")
+		os.Exit(1)
+	}
+
+	if framework, err = e2eframework.NewFromFlags(); err != nil {
+		log.WithError(err).Error("failed to setup framework")
+		os.Exit(1)
+	}
+
+	// run cleanup before tests, to ensure no resources from previous runs exist.
+	err = framework.CleanUp(defaultNs)
+	if err != nil {
+		log.WithError(err).Error("failed to cleanup resources")
+	}
+
+	defer func() {
+		err = framework.CleanUp(defaultNs)
+		if err != nil {
+			log.WithError(err).Error("failed to cleanup resources")
+		}
+		os.Exit(exitCode)
+	}()
+	exitCode = m.Run()
+}


### PR DESCRIPTION
Adds an E2E test for testing high availability extensions. 

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Part of HA Agones. Adds an e2e test that will test high availability by deleting one of the extensions pod and creating a gameserver.

**Which issue(s) this PR fixes**:
Work on https://github.com/googleforgames/agones/issues/2797

**Special notes for your reviewer**:


