### PR TITLE
Allow occasional flakes in SDK conformance tests

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -147,10 +147,14 @@ run-sdk-conformance-no-build: ensure-build-sdk-image
 	--net=host $(sidecar_linux_amd64_tag) --grpc-port $(GRPC_PORT) --http-port $(HTTP_PORT)
 
 # Run SDK conformance test for a specific SDK_FOLDER
+run-sdk-conformance-test: TRIES=5
 run-sdk-conformance-test: ensure-agones-sdk-image
 run-sdk-conformance-test: ensure-build-sdk-image
 	$(MAKE) run-sdk-command COMMAND=build-sdk-test
-	$(MAKE) run-sdk-conformance-no-build
+	for try in `seq 1 $(TRIES)`; do \
+	  $(MAKE) run-sdk-conformance-no-build && echo "+++ Success: $(SDK_FOLDER)" && break || \
+	    status=$$? && echo "*** Failure: $(SDK_FOLDER), try $$try/$(TRIES)"; \
+	done; (exit $$status)
 
 run-sdk-conformance-test-cpp:
 	$(MAKE) run-sdk-conformance-test SDK_FOLDER=cpp GRPC_PORT=9003 HTTP_PORT=9103


### PR DESCRIPTION
Most of the churn is outside the SDK conformance tests, yet they have an outmoded impact on the flakes. Let's go ahead and retry these as well.

This is a bandaid for #2954 - but I'd like to set up some flake reporting at some point as well.