### PR TITLE
Update examples to use the Dynamic port policy instead of Static

### DIFF
--- a/examples/crd-client/Makefile
+++ b/examples/crd-client/Makefile
@@ -25,7 +25,7 @@
 
 REPOSITORY ?= us-docker.pkg.dev/agones-images/examples
 
-server_tag = $(REPOSITORY)/crd-client:0.7
+server_tag = $(REPOSITORY)/crd-client:0.8
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___

--- a/examples/crd-client/create-gs.yaml
+++ b/examples/crd-client/create-gs.yaml
@@ -16,15 +16,25 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   generateName: create-gs-
+  namespace: agones-system
 spec:
   backoffLimit: 5
-  activeDeadlineSeconds: 100
+  activeDeadlineSeconds: 1000
   template:
     spec:
       serviceAccountName: agones-controller
       containers:
       - name: create-gameserver
-        image: us-docker.pkg.dev/agones-images/examples/crd-client:0.7
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 2Gi
+          requests:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 2Gi
+        image: us-docker.pkg.dev/agones-images/examples/crd-client:0.8
         imagePullPolicy: Always
         env:
         - name: GAMESERVER_IMAGE

--- a/examples/crd-client/main.go
+++ b/examples/crd-client/main.go
@@ -93,9 +93,8 @@ func main() {
 			Container: "simple-game-server",
 			Ports: []agonesv1.GameServerPort{{
 				ContainerPort: 7654,
-				HostPort:      7654,
 				Name:          "gameport",
-				PortPolicy:    agonesv1.Static,
+				PortPolicy:    agonesv1.Dynamic,
 				Protocol:      corev1.ProtocolUDP,
 			}},
 			Template: corev1.PodTemplateSpec{

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -43,13 +43,13 @@ spec:
     # port is available. When static is the policy specified, `hostPort` is required to be populated
     # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
     #      This will mean that users will need to lookup what port has been opened through the server side SDK.
-    portPolicy: Static
+    portPolicy: Dynamic
     # The name of the container to open the port on. Defaults to the game server container if omitted or empty.
     container: simple-game-server
     # the port that is being opened on the game server process
     containerPort: 7654
     # the port exposed on the host, only required when `portPolicy` is "Static". Overwritten when portPolicy is "Dynamic".
-    hostPort: 7777
+    # hostPort: 7777
     # protocol being used. Defaults to UDP. TCP and TCPUDP are other options
     protocol: UDP
   # Health checking for the running game server


### PR DESCRIPTION
Dynamic ports are the default, so this better matches the expected end user configuration.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: These changes allow the examples to run without modification on GKE Autopilot.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**: Once approved, I will push a new version of the crd-example to GAR. 


