### PR TITLE
Make Alpha & Beta CRD declaration consistent.

### DIFF
--- a/install/helm/agones/templates/crds/_gameserverspecschema.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecschema.yaml
@@ -153,7 +153,6 @@ properties:
             type: integer
             title: The initial player capacity of this Game Server
             minimum: 0
-{{- if .featureCountsAndLists }}
       counters:
         type: object
         title: Map of player, room, session, etc. counters
@@ -162,11 +161,13 @@ properties:
         additionalProperties:
           type: object
           properties:
-            count: # initial count
+            count:
+              title: Initial count value
               type: integer
               default: 0
               minimum: 0
-            capacity: # max capacity of the counter
+            capacity:
+              title: Max capacity of the counter
               type: integer
               minimum: 0
       lists:
@@ -177,18 +178,18 @@ properties:
         additionalProperties:
           type: object
           properties:
-            capacity: # max capacity of the array (can be less than or equal to value of maxItems)
+            capacity:
               type: integer
+              title: Max capacity of the array (can be less than or equal to value of maxItems)
               minimum: 0
               maximum: 1000 # must be equal to values.maxItems
             values:
+              title: set of all the items in the list
               type: array
               x-kubernetes-list-type: set # Requires items in the array to be unique
               maxItems: 1000 # max possible size of the value array (cannot be updated)
               items: # name of the item (player1, session1, room1, etc.)
                 type: string
-{{- end }}
-{{- if .featureSafeToEvict }}
       eviction:
         type: object
         title: Eviction tolerance of the game server
@@ -210,5 +211,4 @@ properties:
         default: 1
         minimum: 1
         maximum: 1
-{{- end }}
 {{- end }}

--- a/install/helm/agones/templates/crds/_gameserverstatus.yaml
+++ b/install/helm/agones/templates/crds/_gameserverstatus.yaml
@@ -65,7 +65,6 @@ status:
           nullable: true
           items:
             type: string
-{{- if .featureCountsAndLists }}
     counters:
       type: object
       title: Map of player, room, session, etc. counters
@@ -74,11 +73,12 @@ status:
       additionalProperties:
         type: object
         properties:
-          count: # initial count
+          count:
+            title: The current count
             type: integer
             default: 0
             minimum: 0
-          capacity: # max capacity of the counter
+          capacity:
             type: integer
             minimum: 0
     lists:
@@ -89,18 +89,18 @@ status:
       additionalProperties:
         type: object
         properties:
-          capacity: # max capacity of the array (can be less than or equal to value of values.maxItems)
+          capacity:
+            title: Max capacity of the array (can be less than or equal to value of values.maxItems)
             type: integer
             minimum: 0
             maximum: 1000 # must be equal to values.maxItems
           values:
+            title: Set of all the items in the list
             type: array
             x-kubernetes-list-type: set # Requires items in the array to be unique
             maxItems: 1000 # max possible size of the value array (cannot be updated)
             items: # name of the item (player1, session1, room1, etc.)
               type: string
-{{- end }}
-{{- if .featureSafeToEvict }}
     eviction:
       type: object
       properties:
@@ -116,5 +116,4 @@ status:
       default: 1
       minimum: 1
       maximum: 1
-{{- end}}
 {{- end}}

--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -56,7 +56,7 @@ spec:
           type: date
       schema:
         openAPIV3Schema:
-          {{- $data := dict "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields "featureSafeToEvict" $featureGates.SafeToEvict "featureCountsAndLists" $featureGates.CountsAndLists }}
+          {{- $data := dict "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields }}
           {{- include "gameserver.schema" $data | indent 9 }}{{- /* include the schema then status, as it's easier to align */ -}}
           {{- include "gameserver.status" $data | indent 11 }}
 {{- if $featureGates.SafeToEvict }}

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -5099,6 +5099,43 @@ spec:
                              type: integer
                              title: The initial player capacity of this Game Server
                              minimum: 0
+                       counters:
+                         type: object
+                         title: Map of player, room, session, etc. counters
+                         nullable: true
+                         maxProperties: 1000
+                         additionalProperties:
+                           type: object
+                           properties:
+                             count:
+                               title: Initial count value
+                               type: integer
+                               default: 0
+                               minimum: 0
+                             capacity:
+                               title: Max capacity of the counter
+                               type: integer
+                               minimum: 0
+                       lists:
+                         type: object
+                         title: Map of player, room, session, etc. lists
+                         nullable: true
+                         maxProperties: 1000
+                         additionalProperties:
+                           type: object
+                           properties:
+                             capacity:
+                               type: integer
+                               title: Max capacity of the array (can be less than or equal to value of maxItems)
+                               minimum: 0
+                               maximum: 1000 # must be equal to values.maxItems
+                             values:
+                               title: set of all the items in the list
+                               type: array
+                               x-kubernetes-list-type: set # Requires items in the array to be unique
+                               maxItems: 1000 # max possible size of the value array (cannot be updated)
+                               items: # name of the item (player1, session1, room1, etc.)
+                                 type: string
                        eviction:
                          type: object
                          title: Eviction tolerance of the game server
@@ -10083,6 +10120,43 @@ spec:
                      type: integer
                      title: The initial player capacity of this Game Server
                      minimum: 0
+               counters:
+                 type: object
+                 title: Map of player, room, session, etc. counters
+                 nullable: true
+                 maxProperties: 1000
+                 additionalProperties:
+                   type: object
+                   properties:
+                     count:
+                       title: Initial count value
+                       type: integer
+                       default: 0
+                       minimum: 0
+                     capacity:
+                       title: Max capacity of the counter
+                       type: integer
+                       minimum: 0
+               lists:
+                 type: object
+                 title: Map of player, room, session, etc. lists
+                 nullable: true
+                 maxProperties: 1000
+                 additionalProperties:
+                   type: object
+                   properties:
+                     capacity:
+                       type: integer
+                       title: Max capacity of the array (can be less than or equal to value of maxItems)
+                       minimum: 0
+                       maximum: 1000 # must be equal to values.maxItems
+                     values:
+                       title: set of all the items in the list
+                       type: array
+                       x-kubernetes-list-type: set # Requires items in the array to be unique
+                       maxItems: 1000 # max possible size of the value array (cannot be updated)
+                       items: # name of the item (player1, session1, room1, etc.)
+                         type: string
                eviction:
                  type: object
                  title: Eviction tolerance of the game server
@@ -10155,6 +10229,42 @@ spec:
                      nullable: true
                      items:
                        type: string
+               counters:
+                 type: object
+                 title: Map of player, room, session, etc. counters
+                 nullable: true
+                 maxProperties: 1000
+                 additionalProperties:
+                   type: object
+                   properties:
+                     count:
+                       title: The current count
+                       type: integer
+                       default: 0
+                       minimum: 0
+                     capacity:
+                       type: integer
+                       minimum: 0
+               lists:
+                 type: object
+                 title: Map of player, room, session, etc. lists
+                 nullable: true
+                 maxProperties: 1000
+                 additionalProperties:
+                   type: object
+                   properties:
+                     capacity:
+                       title: Max capacity of the array (can be less than or equal to value of values.maxItems)
+                       type: integer
+                       minimum: 0
+                       maximum: 1000 # must be equal to values.maxItems
+                     values:
+                       title: Set of all the items in the list
+                       type: array
+                       x-kubernetes-list-type: set # Requires items in the array to be unique
+                       maxItems: 1000 # max possible size of the value array (cannot be updated)
+                       items: # name of the item (player1, session1, room1, etc.)
+                         type: string
                eviction:
                  type: object
                  properties:
@@ -15197,6 +15307,43 @@ spec:
                               type: integer
                               title: The initial player capacity of this Game Server
                               minimum: 0
+                        counters:
+                          type: object
+                          title: Map of player, room, session, etc. counters
+                          nullable: true
+                          maxProperties: 1000
+                          additionalProperties:
+                            type: object
+                            properties:
+                              count:
+                                title: Initial count value
+                                type: integer
+                                default: 0
+                                minimum: 0
+                              capacity:
+                                title: Max capacity of the counter
+                                type: integer
+                                minimum: 0
+                        lists:
+                          type: object
+                          title: Map of player, room, session, etc. lists
+                          nullable: true
+                          maxProperties: 1000
+                          additionalProperties:
+                            type: object
+                            properties:
+                              capacity:
+                                type: integer
+                                title: Max capacity of the array (can be less than or equal to value of maxItems)
+                                minimum: 0
+                                maximum: 1000 # must be equal to values.maxItems
+                              values:
+                                title: set of all the items in the list
+                                type: array
+                                x-kubernetes-list-type: set # Requires items in the array to be unique
+                                maxItems: 1000 # max possible size of the value array (cannot be updated)
+                                items: # name of the item (player1, session1, room1, etc.)
+                                  type: string
                         eviction:
                           type: object
                           title: Eviction tolerance of the game server

--- a/pkg/apis/agones/v1/apihooks.go
+++ b/pkg/apis/agones/v1/apihooks.go
@@ -32,5 +32,5 @@ type APIHooks interface {
 	MutateGameServerPodSpec(*GameServerSpec, *corev1.PodSpec) error
 
 	// SetEviction is called by gs.Pod to enforce GameServer.Status.Eviction.
-	SetEviction(EvictionSafe, *corev1.Pod) error
+	SetEviction(*Eviction, *corev1.Pod) error
 }

--- a/pkg/apis/agones/v1/apihooksfake.go
+++ b/pkg/apis/agones/v1/apihooksfake.go
@@ -26,7 +26,7 @@ type fakeAPIHooks struct {
 	StubValidateGameServerSpec  func(*GameServerSpec) []metav1.StatusCause
 	StubValidateScheduling      func(apis.SchedulingStrategy) []metav1.StatusCause
 	StubMutateGameServerPodSpec func(*GameServerSpec, *corev1.PodSpec) error
-	StubSetEviction             func(EvictionSafe, *corev1.Pod) error
+	StubSetEviction             func(*Eviction, *corev1.Pod) error
 }
 
 var _ APIHooks = fakeAPIHooks{}
@@ -56,9 +56,9 @@ func (f fakeAPIHooks) MutateGameServerPodSpec(gss *GameServerSpec, podSpec *core
 }
 
 // SetEviction is called by gs.Pod to enforce GameServer.Status.Eviction.
-func (f fakeAPIHooks) SetEviction(safe EvictionSafe, pod *corev1.Pod) error {
+func (f fakeAPIHooks) SetEviction(eviction *Eviction, pod *corev1.Pod) error {
 	if f.StubSetEviction != nil {
-		return f.StubSetEviction(safe, pod)
+		return f.StubSetEviction(eviction, pod)
 	}
 	return nil
 }

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -320,7 +320,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 		},
 		"eviction.safe: Always": {
 			gameServer: defaultGameServerAnd(func(gss *GameServerSpec) {
-				gss.Eviction.Safe = EvictionSafeAlways
+				gss.Eviction = &Eviction{Safe: EvictionSafeAlways}
 			}),
 			expected: wantDefaultAnd(func(e *expected) {
 				e.evictionSafeSpec = EvictionSafeAlways
@@ -329,7 +329,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 		},
 		"eviction.safe: OnUpgrade": {
 			gameServer: defaultGameServerAnd(func(gss *GameServerSpec) {
-				gss.Eviction.Safe = EvictionSafeOnUpgrade
+				gss.Eviction = &Eviction{Safe: EvictionSafeOnUpgrade}
 			}),
 			expected: wantDefaultAnd(func(e *expected) {
 				e.evictionSafeSpec = EvictionSafeOnUpgrade
@@ -338,7 +338,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 		},
 		"eviction.safe: Never": {
 			gameServer: defaultGameServerAnd(func(gss *GameServerSpec) {
-				gss.Eviction.Safe = EvictionSafeNever
+				gss.Eviction = &Eviction{Safe: EvictionSafeNever}
 			}),
 			expected: wantDefaultAnd(func(e *expected) {
 				e.evictionSafeSpec = EvictionSafeNever
@@ -365,7 +365,7 @@ func TestGameServerApplyDefaults(t *testing.T) {
 		},
 		"safe-to-evict=false AND eviction.safe: Always => eviction.safe: Always": {
 			gameServer: defaultGameServerAnd(func(gss *GameServerSpec) {
-				gss.Eviction.Safe = EvictionSafeAlways
+				gss.Eviction = &Eviction{Safe: EvictionSafeAlways}
 				gss.Template.ObjectMeta.Annotations = map[string]string{PodSafeToEvictAnnotation: "false"}
 			}),
 			expected: wantDefaultAnd(func(e *expected) {
@@ -401,8 +401,17 @@ func TestGameServerApplyDefaults(t *testing.T) {
 				assert.Nil(t, test.gameServer.Spec.Players)
 				assert.Nil(t, test.gameServer.Status.Players)
 			}
-			assert.Equal(t, test.expected.evictionSafeSpec, spec.Eviction.Safe)
-			assert.Equal(t, test.expected.evictionSafeStatus, test.gameServer.Status.Eviction.Safe)
+			if len(test.expected.evictionSafeSpec) > 0 {
+				assert.Equal(t, test.expected.evictionSafeSpec, spec.Eviction.Safe)
+			} else {
+				assert.Nil(t, spec.Eviction)
+			}
+
+			if len(test.expected.evictionSafeStatus) > 0 {
+				assert.Equal(t, test.expected.evictionSafeStatus, test.gameServer.Status.Eviction.Safe)
+			} else {
+				assert.Nil(t, test.gameServer.Status.Eviction)
+			}
 		})
 	}
 }

--- a/pkg/apis/agones/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/agones/v1/zz_generated.deepcopy.go
@@ -386,7 +386,11 @@ func (in *GameServerSpec) DeepCopyInto(out *GameServerSpec) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	out.Eviction = in.Eviction
+	if in.Eviction != nil {
+		in, out := &in.Eviction, &out.Eviction
+		*out = new(Eviction)
+		**out = **in
+	}
 	return
 }
 
@@ -417,7 +421,11 @@ func (in *GameServerStatus) DeepCopyInto(out *GameServerStatus) {
 		*out = new(PlayerStatus)
 		(*in).DeepCopyInto(*out)
 	}
-	out.Eviction = in.Eviction
+	if in.Eviction != nil {
+		in, out := &in.Eviction, &out.Eviction
+		*out = new(Eviction)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cloudproduct/generic/generic_test.go
+++ b/pkg/cloudproduct/generic/generic_test.go
@@ -41,7 +41,7 @@ func TestSetEviction(t *testing.T) {
 	}
 	for desc, tc := range map[string]struct {
 		featureFlags string
-		safeToEvict  agonesv1.EvictionSafe
+		eviction     *agonesv1.Eviction
 		pod          *corev1.Pod
 		wantPod      *corev1.Pod
 	}{
@@ -51,7 +51,7 @@ func TestSetEviction(t *testing.T) {
 		},
 		"SafeToEvict: Always, no incoming labels/annotations": {
 			featureFlags: "SafeToEvict=true",
-			safeToEvict:  agonesv1.EvictionSafeAlways,
+			eviction:     &agonesv1.Eviction{Safe: agonesv1.EvictionSafeAlways},
 			pod:          emptyPodAnd(func(*corev1.Pod) {}),
 			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
 				pod.ObjectMeta.Annotations[agonesv1.PodSafeToEvictAnnotation] = agonesv1.True
@@ -60,7 +60,7 @@ func TestSetEviction(t *testing.T) {
 		},
 		"SafeToEvict: OnUpgrade, no incoming labels/annotations": {
 			featureFlags: "SafeToEvict=true",
-			safeToEvict:  agonesv1.EvictionSafeOnUpgrade,
+			eviction:     &agonesv1.Eviction{Safe: agonesv1.EvictionSafeOnUpgrade},
 			pod:          emptyPodAnd(func(*corev1.Pod) {}),
 			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
 				pod.ObjectMeta.Annotations[agonesv1.PodSafeToEvictAnnotation] = agonesv1.False
@@ -69,7 +69,7 @@ func TestSetEviction(t *testing.T) {
 		},
 		"SafeToEvict: Never, no incoming labels/annotations": {
 			featureFlags: "SafeToEvict=true",
-			safeToEvict:  agonesv1.EvictionSafeNever,
+			eviction:     &agonesv1.Eviction{Safe: agonesv1.EvictionSafeNever},
 			pod:          emptyPodAnd(func(*corev1.Pod) {}),
 			wantPod: emptyPodAnd(func(pod *corev1.Pod) {
 				pod.ObjectMeta.Annotations[agonesv1.PodSafeToEvictAnnotation] = agonesv1.False
@@ -78,7 +78,7 @@ func TestSetEviction(t *testing.T) {
 		},
 		"SafeToEvict: Always, incoming labels/annotations": {
 			featureFlags: "SafeToEvict=true",
-			safeToEvict:  agonesv1.EvictionSafeAlways,
+			eviction:     &agonesv1.Eviction{Safe: agonesv1.EvictionSafeAlways},
 			pod: emptyPodAnd(func(pod *corev1.Pod) {
 				pod.ObjectMeta.Annotations[agonesv1.PodSafeToEvictAnnotation] = "just don't touch, ok?"
 				pod.ObjectMeta.Labels[agonesv1.SafeToEvictLabel] = "seriously, leave it"
@@ -90,7 +90,7 @@ func TestSetEviction(t *testing.T) {
 		},
 		"SafeToEvict: OnUpgrade, incoming labels/annotations": {
 			featureFlags: "SafeToEvict=true",
-			safeToEvict:  agonesv1.EvictionSafeOnUpgrade,
+			eviction:     &agonesv1.Eviction{Safe: agonesv1.EvictionSafeOnUpgrade},
 			pod: emptyPodAnd(func(pod *corev1.Pod) {
 				pod.ObjectMeta.Annotations[agonesv1.PodSafeToEvictAnnotation] = "better not touch"
 				pod.ObjectMeta.Labels[agonesv1.SafeToEvictLabel] = "not another one"
@@ -102,7 +102,7 @@ func TestSetEviction(t *testing.T) {
 		},
 		"SafeToEvict: Never, incoming labels/annotations": {
 			featureFlags: "SafeToEvict=true",
-			safeToEvict:  agonesv1.EvictionSafeNever,
+			eviction:     &agonesv1.Eviction{Safe: agonesv1.EvictionSafeNever},
 			pod: emptyPodAnd(func(pod *corev1.Pod) {
 				pod.ObjectMeta.Annotations[agonesv1.PodSafeToEvictAnnotation] = "a passthrough"
 				pod.ObjectMeta.Labels[agonesv1.SafeToEvictLabel] = "or is it passthru?"
@@ -117,7 +117,7 @@ func TestSetEviction(t *testing.T) {
 			err := runtime.ParseFeatures(tc.featureFlags)
 			assert.NoError(t, err)
 
-			err = (&generic{}).SetEviction(tc.safeToEvict, tc.pod)
+			err = (&generic{}).SetEviction(tc.eviction, tc.pod)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantPod, tc.pod)
 		})
@@ -192,7 +192,7 @@ func TestGameServerPodAutoscalerAnnotations(t *testing.T) {
 	fixture := &agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "logan"},
 		Spec:       agonesv1.GameServerSpec{Container: "sheep"},
-		Status:     agonesv1.GameServerStatus{Eviction: agonesv1.Eviction{Safe: agonesv1.EvictionSafeNever}},
+		Status:     agonesv1.GameServerStatus{Eviction: &agonesv1.Eviction{Safe: agonesv1.EvictionSafeNever}},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {

--- a/pkg/testing/apihooks.go
+++ b/pkg/testing/apihooks.go
@@ -43,6 +43,6 @@ func (f FakeAPIHooks) MutateGameServerPodSpec(_ *agonesv1.GameServerSpec, podSpe
 }
 
 // SetEviction is called by gs.Pod to enforce GameServer.Status.Eviction.
-func (f FakeAPIHooks) SetEviction(_ agonesv1.EvictionSafe, pod *corev1.Pod) error {
+func (f FakeAPIHooks) SetEviction(_ *agonesv1.Eviction, pod *corev1.Pod) error {
 	return nil
 }

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -4379,6 +4379,7 @@ Eviction
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>(Alpha, SafeToEvict feature flag) Eviction specifies the eviction tolerance of the GameServer.</p>
 </td>
 </tr>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

We realised that with the CRD schema application being hidden behind a feature flag in the helm CRD yaml, then if the feature flag was turned off, an end user wouldn't get a validation error since the values passed in would be pruned by the K8s control plane.

To make thins consistent across Alpha CRD values:

* Alpha & Beta schemas are always available within the CRD definitions.
* Validation checks are in place for the feature flag (no change needed)
* Alpha & Beta CRD values are pointers, so they can be nullable (this required a change in Eviction handling and ApiHooks interface)
* Some general cleanup of comments and descriptions in the schema.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

**Special notes for your reviewer**:


