### PR TITLE
Make up{} work with Google Managed Prometheus

### DIFF
--- a/build/grafana/dashboard-status.yaml
+++ b/build/grafana/dashboard-status.yaml
@@ -188,7 +188,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "up{app=\"agones\",kubernetes_pod_name=~\"agones-controller.*\"} OR on() vector(0)",
+              "expr": "up{app=\"agones\",agones_dev_role=\"controller\"} OR on() vector(0)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -360,7 +360,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(up{app=\"agones\",kubernetes_pod_name=~\"agones-allocator.*\"}) OR on() vector(0)",
+              "expr": "sum(up{app=\"agones\",multicluster_agones_dev_role=\"allocator\"}) OR on() vector(0)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,
@@ -449,7 +449,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(up{app=\"agones\",kubernetes_pod_name=~\"agones-allocator.*\"}) OR on() vector(0)",
+              "expr": "count(up{app=\"agones\",multicluster_agones_dev_role=\"allocator\"}) OR on() vector(0)",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,


### PR DESCRIPTION
This is a little fussy, but with GMP, the `up{}` labels are `pod` and `namespace`. I have a label mapping that seems to work for scraped metrics, but `up{}` is a special Prometheus metric and it doesn't seem to respect the label mapping (not clear why, opening an internal bug now).

Instead of `kubernetes_pod_name`, just use the relevant role labels. In general this is probably a better choice, but I don't want to make a wide change.