### PR TITLE
Added back metrics support for extensions

### DIFF
--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -41,6 +41,11 @@ spec:
 {{- if .Values.agones.extensions.generateTLS }}
         revision/tls-cert: {{ .Release.Revision | quote }}
 {{- end }}
+{{- if and (.Values.agones.metrics.prometheusServiceDiscovery) (.Values.agones.metrics.prometheusEnabled) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+{{- end }}
 {{- if .Values.agones.extensions.annotations }}
 {{- toYaml .Values.agones.extensions.annotations | nindent 8 }}
 {{- end }}
@@ -71,6 +76,12 @@ spec:
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.extensions.name}}:{{ default .Values.agones.image.tag .Values.agones.image.extensions.tag }}"
         imagePullPolicy: {{ .Values.agones.image.extensions.pullPolicy }}
         env:
+        - name: PROMETHEUS_EXPORTER
+          value: {{ .Values.agones.metrics.prometheusEnabled | quote }}
+        - name: STACKDRIVER_EXPORTER
+          value: {{ .Values.agones.metrics.stackdriverEnabled | quote }}
+        - name: STACKDRIVER_LABELS
+          value: {{ .Values.agones.metrics.stackdriverLabels | quote }}       
         - name: GCP_PROJECT_ID
           value: {{ .Values.agones.metrics.stackdriverProjectID | quote }}
         - name: NUM_WORKERS


### PR DESCRIPTION
Add back metrics support within extensions

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature

/kind hotfix

**What this PR does / Why we need it**:
This adds back the metrics support within `Extensions` that was removed during the trimming process.

**Which issue(s) this PR fixes**:
Work on https://github.com/googleforgames/agones/issues/2797

**Special notes for your reviewer**:


