### PR TITLE
Add Sigterm handler and readiness probe to extensions

### DIFF
--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -71,6 +71,7 @@ spec:
       priorityClassName: {{ .Values.agones.priorityClassName }}
       {{- end }}
       serviceAccountName: {{ .Values.agones.serviceaccount.controller.name }}
+      terminationGracePeriodSeconds: {{ mul .Values.agones.extensions.readiness.periodSeconds .Values.agones.extensions.readiness.failureThreshold 3 }}
       containers:
       - name: agones-extensions
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.extensions.name}}:{{ default .Values.agones.image.tag .Values.agones.image.extensions.tag }}"
@@ -114,6 +115,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONTAINER_NAME
           value: "agones-extensions"
+        - name: READINESS_SHUTDOWN_DURATION
+          value: {{ mul .Values.agones.extensions.readiness.periodSeconds .Values.agones.extensions.readiness.failureThreshold 2 }}s
         ports:
         - name: webhooks
           containerPort: 8081
@@ -127,6 +130,13 @@ spec:
           periodSeconds: {{ .Values.agones.extensions.healthCheck.periodSeconds }}
           failureThreshold: {{ .Values.agones.extensions.healthCheck.failureThreshold }}
           timeoutSeconds: {{ .Values.agones.extensions.healthCheck.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: {{ .Values.agones.extensions.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.agones.extensions.readiness.periodSeconds }}
+          failureThreshold: {{ .Values.agones.extensions.readiness.failureThreshold }}
         resources:
 {{- if .Values.agones.extensions.resources }}
 {{ toYaml .Values.agones.extensions.resources | indent 10 }}

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -99,6 +99,10 @@ agones:
     pdb:
         minAvailable: 1
     replicas: 2
+    readiness:
+      initialDelaySeconds: 3
+      periodSeconds: 3
+      failureThreshold: 3
   ping:
     install: true
     pdb:

--- a/pkg/util/signals/signals.go
+++ b/pkg/util/signals/signals.go
@@ -18,6 +18,7 @@ package signals
 
 import (
 	"context"
+	"os"
 	"os/signal"
 	"syscall"
 )
@@ -26,4 +27,15 @@ import (
 func NewSigKillContext() context.Context {
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	return ctx
+}
+
+// NewSigTermHandler creates a channel to listen to SIGTERM and runs the handle function
+func NewSigTermHandler(handle func()) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM)
+
+	go func() {
+		<-c
+		handle()
+	}()
 }

--- a/test/e2e/extensions/main_test.go
+++ b/test/e2e/extensions/main_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	e2eframework "agones.dev/agones/test/e2e/framework"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,7 +27,7 @@ const defaultNs = "default"
 var framework *e2eframework.Framework
 
 func TestMain(m *testing.M) {
-	logrus.SetFormatter(&logrus.TextFormatter{
+	log.SetFormatter(&log.TextFormatter{
 		EnvironmentOverrideColors: true,
 		FullTimestamp:             true,
 		TimestampFormat:           "2006-01-02 15:04:05.000",

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -239,7 +239,7 @@ func (f *Framework) CreateGameServerAndWaitUntilReady(t *testing.T, ns string, g
 	}
 
 	if len(readyGs.Status.Ports) != expectedPortCount {
-		return nil, fmt.Errorf("Ready GameServer instance has %d port(s), want %d", len(readyGs.Status.Ports), expectedPortCount)
+		return nil, fmt.Errorf("ready GameServer instance has %d port(s), want %d", len(readyGs.Status.Ports), expectedPortCount)
 	}
 
 	logrus.WithField("gs", newGs.ObjectMeta.Name).Info("GameServer Ready")


### PR DESCRIPTION
STILL WIP. Added the original e2e extensions test that was flaky due to not being able to reach the extensions pod. 

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
Ensure that we take care of voluntary extension pod disruption by adding readiness and handler for SIGTERM. 

**Which issue(s) this PR fixes**:
Closes #2999 

**Special notes for your reviewer**:
WIP 

