### PR TITLE
Clarify instructions for Managed Prometheus

### DIFF
--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -226,10 +226,10 @@ kubectl apply -n agones-system -f https://raw.githubusercontent.com/googleforgam
 
 To install Grafana using a Managed Prometheus backend:
 
-* Install the [Standalone Prometheus frontend UI](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#ui-prometheus) - this will act as your authentication proxy for PromQL queries. To group it together with our [Grafana installation](#grafana-installation), install it in the `metrics` namespace.
-
-* [Install Grafana as above](#grafana-installation), but use `-f ./build/grafana-frontend.yaml` instead of `-f ./build/grafana.yaml`.
-
+* Complete the [Before you begin](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#begin). To align with the Agones [Grafana installation](#grafana-installation), we'll be installing in the `metrics` namespace, which you'll need to create.
+  * If your cluster has Workload Identity enabled, which is enabled on GKE Autopilot by default, follow [Configure a service account for Workload Identity](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#gmp-wli-svcacct) to ensure that you have appropriately authorized the default Kubernetes service account in the `metrics` namespace.
+* Install the [Standalone Prometheus frontend UI](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#ui-prometheus) in the `metrics` namespace - this will act as your authentication proxy for PromQL queries.
+* [Install Grafana as above](#grafana-installation), using `-f ./build/grafana-frontend.yaml` instead of `-f ./build/grafana.yaml`.
 
 ### Google Cloud Monitoring installation
 


### PR DESCRIPTION
The instructions linked straight to the installation of the frontend UI, but that skips over the "Before you begin" section of the doc. The "Before you begin" section has a crucial step in it: authorizing the Kubernetes service account to read metrics.
