### PR TITLE
Removing dzlier-gcp from approvers list.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - cyriltovena
-  - dzlier-gcp
   - EricFortin
   - markmandel
   - roberthbailey


### PR DESCRIPTION
/kind cleanup

**What this PR does / Why we need it**:
I no longer work on Agones and shouldn't be on the approvers list.