### PR TITLE
Use actually distinct webhook for Autopilot

### DIFF
--- a/pkg/cloudproduct/gke/gke.go
+++ b/pkg/cloudproduct/gke/gke.go
@@ -44,7 +44,7 @@ const (
 var (
 	autopilotMutatingWebhooks = []string{
 		"workload-defaulter.config.common-webhooks.networking.gke.io", // pre-1.26
-		"warden-mutating.config.common-webhooks.networking.gke.io",    // 1.26+
+		"sasecret-redacter.config.common-webhooks.networking.gke.io",  // 1.26+
 	}
 	noWorkloadDefaulter = fmt.Sprintf("found no MutatingWebhookConfigurations matching %v", autopilotMutatingWebhooks)
 


### PR DESCRIPTION
The `sasecret-redacter` webhook will be a stable indicator until we have a more robust way.

The webhook I implemented in #3032 is sadly present on GKE Standard as well (my bad).

Replaces #3033
Closes #3034 