### PR TITLE
Rework game server health initial delay handling

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -307,10 +307,6 @@ steps:
         for version in "${!versionsAndRegions[@]}"
         do
           region=${versionsAndRegions[$version]}
-          if [ $cloudProduct = gke-autopilot ] && [ $version = 1.26 ]
-          then
-            continue
-          fi
           if [ $cloudProduct = generic ]
           then
             featureWithGate="CustomFasSyncInterval=false&SafeToEvict=false&SDKGracefulTermination=false&StateAllocationFilter=false&PlayerAllocationFilter=true&PlayerTracking=true&ResetMetricsOnDelete=true&PodHostname=true&SplitControllerAndExtensions=true&FleetAllocationOverflow=true&Example=true"

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -705,9 +705,16 @@ func (c *Controller) addGameServerHealthCheck(gs *agonesv1.GameServer, pod *core
 						Port: intstr.FromInt(8080),
 					},
 				},
+				// The sidecar relies on kubelet to delay by InitialDelaySeconds after the
+				// container is started (after image pull, etc), and relies on the kubelet
+				// for PeriodSeconds heartbeats to evaluate health.
 				InitialDelaySeconds: gs.Spec.Health.InitialDelaySeconds,
 				PeriodSeconds:       gs.Spec.Health.PeriodSeconds,
-				FailureThreshold:    gs.Spec.Health.FailureThreshold,
+
+				// By the time /gshealthz returns unhealthy, the sidecar has already evaluated
+				// FailureThreshold in a row failed health checks, so on the kubelet side, one
+				// failure is sufficient to know the game server is unhealthy.
+				FailureThreshold: 1,
 			}
 		}
 

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -1061,7 +1061,7 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			assert.Equal(t, intstr.FromInt(8080), gsContainer.LivenessProbe.HTTPGet.Port)
 			assert.Equal(t, fixture.Spec.Health.InitialDelaySeconds, gsContainer.LivenessProbe.InitialDelaySeconds)
 			assert.Equal(t, fixture.Spec.Health.PeriodSeconds, gsContainer.LivenessProbe.PeriodSeconds)
-			assert.Equal(t, fixture.Spec.Health.FailureThreshold, gsContainer.LivenessProbe.FailureThreshold)
+			assert.Equal(t, int32(1), gsContainer.LivenessProbe.FailureThreshold)
 			assert.Len(t, gsContainer.VolumeMounts, 1)
 			assert.Equal(t, "/var/run/secrets/kubernetes.io/serviceaccount", gsContainer.VolumeMounts[0].MountPath)
 
@@ -1730,7 +1730,7 @@ func TestControllerAddGameServerHealthCheck(t *testing.T) {
 	require.NotNil(t, probe)
 	assert.Equal(t, "/gshealthz", probe.HTTPGet.Path)
 	assert.Equal(t, intstr.IntOrString{IntVal: 8080}, probe.HTTPGet.Port)
-	assert.Equal(t, fixture.Spec.Health.FailureThreshold, probe.FailureThreshold)
+	assert.Equal(t, int32(1), probe.FailureThreshold)
 	assert.Equal(t, fixture.Spec.Health.InitialDelaySeconds, probe.InitialDelaySeconds)
 	assert.Equal(t, fixture.Spec.Health.PeriodSeconds, probe.PeriodSeconds)
 }

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -423,7 +423,10 @@ func (s *SDKServer) updateAnnotations(ctx context.Context) error {
 // workerqueue
 func (s *SDKServer) enqueueState(state agonesv1.GameServerState) {
 	s.gsUpdateMutex.Lock()
-	s.gsState = state
+	// Update cached state, but prevent transitions out of `Unhealthy` by the SDK.
+	if s.gsState != agonesv1.GameServerStateUnhealthy {
+		s.gsState = state
+	}
 	s.gsUpdateMutex.Unlock()
 	s.workerqueue.Enqueue(cache.ExplicitKey(string(updateState)))
 }

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -42,7 +42,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -164,7 +163,7 @@ func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interf
 		}
 	})
 	mux.HandleFunc("/gshealthz", func(w http.ResponseWriter, r *http.Request) {
-		if s.healthy() {
+		if s.runHealth() {
 			_, err := w.Write([]byte("ok"))
 			if err != nil {
 				s.logger.WithError(err).Error("could not send ok response on gshealthz")
@@ -186,12 +185,6 @@ func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interf
 	s.logger.Info("Created GameServer sidecar")
 
 	return s, nil
-}
-
-// initHealthLastUpdated adds the initial delay to now, then it will always be after `now`
-// until the delay passes
-func (s *SDKServer) initHealthLastUpdated(healthInitialDelay time.Duration) {
-	s.healthLastUpdated = s.clock.Now().UTC().Add(healthInitialDelay)
 }
 
 // Run processes the rate limited queue.
@@ -229,7 +222,7 @@ func (s *SDKServer) Run(ctx context.Context) error {
 	s.health = gs.Spec.Health
 	s.logger.WithField("health", s.health).Debug("Setting health configuration")
 	s.healthTimeout = time.Duration(gs.Spec.Health.PeriodSeconds) * time.Second
-	s.initHealthLastUpdated(time.Duration(gs.Spec.Health.InitialDelaySeconds) * time.Second)
+	s.touchHealthLastUpdated()
 
 	if gs.Status.State == agonesv1.GameServerStateReserved && gs.Status.ReservedUntil != nil {
 		s.gsUpdateMutex.Lock()
@@ -240,7 +233,6 @@ func (s *SDKServer) Run(ctx context.Context) error {
 	// start health checking running
 	if !s.health.Disabled {
 		s.logger.Debug("Starting GameServer health checking")
-		go wait.Until(s.runHealth, s.healthTimeout, ctx.Done())
 	}
 
 	// populate player tracking values
@@ -814,15 +806,17 @@ func (s *SDKServer) sendGameServerUpdate(gs *agonesv1.GameServer) {
 	}
 }
 
-// runHealth actively checks the health, and if not
-// healthy will push the Unhealthy state into the queue so
-// it can be updated
-func (s *SDKServer) runHealth() {
+// runHealth checks the health as part of the /gshealthz hook, and if not
+// healthy will push the Unhealthy state into the queue so it can be updated.
+// Returns current health.
+func (s *SDKServer) runHealth() bool {
 	s.checkHealth()
-	if !s.healthy() {
-		s.logger.WithField("gameServerName", s.gameServerName).Warn("GameServer has failed health check")
-		s.enqueueState(agonesv1.GameServerStateUnhealthy)
+	if s.healthy() {
+		return true
 	}
+	s.logger.WithField("gameServerName", s.gameServerName).Warn("GameServer has failed health check")
+	s.enqueueState(agonesv1.GameServerStateUnhealthy)
+	return false
 }
 
 // touchHealthLastUpdated sets the healthLastUpdated
@@ -838,10 +832,11 @@ func (s *SDKServer) touchHealthLastUpdated() {
 // and if it is outside the timeout value, logger and
 // count a failure
 func (s *SDKServer) checkHealth() {
+	s.healthMutex.Lock()
+	defer s.healthMutex.Unlock()
+
 	timeout := s.healthLastUpdated.Add(s.healthTimeout)
 	if timeout.Before(s.clock.Now().UTC()) {
-		s.healthMutex.Lock()
-		defer s.healthMutex.Unlock()
 		s.healthFailureCount++
 		s.logger.WithField("failureCount", s.healthFailureCount).Warn("GameServer Health Check failed")
 	}

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -477,6 +477,12 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 	// manually push through an unhealthy state change
 	sc.enqueueState(agonesv1.GameServerStateUnhealthy)
 	agtesting.AssertEventContains(t, m.FakeRecorder.Events, "Health check failure")
+
+	// try to push back to Ready, enqueueState should block it.
+	sc.enqueueState(agonesv1.GameServerStateRequestReady)
+	sc.gsUpdateMutex.Lock()
+	assert.Equal(t, agonesv1.GameServerStateUnhealthy, sc.gsState)
+	sc.gsUpdateMutex.Unlock()
 }
 
 func TestSidecarHealthy(t *testing.T) {


### PR DESCRIPTION
Implements https://github.com/googleforgames/agones/issues/2966#issuecomment-1492346086:

* We remove any knowledge in the SDK of InitialDelaySeconds
* We remove the runHealth goroutine from main and shift this responsibility to the /gshealthz handler

Along the way:

*  I noted that the FailureThreshold doesn't need to be enforced on both the kubelet and SDK side, so in the injected liveness probe, I dropped that to 1. Previously we were waiting more probes than we needed to. In practice this is not terribly relevant since the SDK pushes it into Unhealthy.

Does not try to fully enforce the SDK start order as noted in the same comment (which may be racy). I researched that more and can't find a way I like - using a command means we have to do something gross to pick between unix/windows, since the SDK is supported for Windows pods as well. Still thinking on this part.

Fixes #2966 
Fixes #3058 