### PR TITLE
DO NOT SUBMIT, running e2es with debug SDK logging

### DIFF
--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -205,7 +205,9 @@ func (s *SDKServer) Run(ctx context.Context) error {
 		return err
 	}
 
-	logLevel := agonesv1.SdkServerLogLevelInfo
+	// XXXZML DO NOT SUBMIT
+	// logLevel := agonesv1.SdkServerLogLevelInfo
+	logLevel := agonesv1.SdkServerLogLevelDebug
 	// grab configuration details
 	if gs.Spec.SdkServer.LogLevel != "" {
 		logLevel = gs.Spec.SdkServer.LogLevel


### PR DESCRIPTION
I'm tracking an issue where the SDK `/healthz` seems to be failing, want a whole e2e run with the SDK at debug (also trying locally).


