### PR TITLE
Add timeout to SDK k8s client

### DIFF
--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -122,6 +122,13 @@ func main() {
 		if err != nil {
 			logger.WithError(err).Fatal("Could not create in cluster config")
 		}
+		// The SDK client only ever accesses small amounts of data (single object list /
+		// event updates), latency more than a couple of seconds is excessive. We need to
+		// keep a relatively tight timeout during initialization as well to allow the
+		// informer a chance to retry - the SDK won't reply to /healthz checks until the
+		// informer has synced once, and our liveness configuration only allows 9s before
+		// a positive /healthz.
+		config.Timeout = 3 * time.Second
 
 		var kubeClient *kubernetes.Clientset
 		kubeClient, err = kubernetes.NewForConfig(config)


### PR DESCRIPTION
This seems to help with (many of?) the flakes we're seeing in CI by forcing the informer to retry lists, rather than the SDK dying after 30s of hanging.