### PR TITLE
Fix release tag on Unity SDK installation document page (#2622)

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/unity.md
+++ b/site/content/en/docs/Guides/Client SDKs/unity.md
@@ -48,7 +48,7 @@ It can also be imported into your project via the Unity Package Manager (UPM). T
 
 If you want a specific release, the dependency can be pinned to that version. For example: 
 
-`"com.googleforgames.agones": "https://github.com/googleforgames/agones.git?path=/sdks/unity#1.19.0",`
+`"com.googleforgames.agones": "https://github.com/googleforgames/agones.git?path=/sdks/unity#v{{< release-version >}}",`
 
 ## Download
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind feature
> /kind hotfix

/kind documentation

**What this PR does / Why we need it**:
To fix invalid tag information on Unity SDK installation document page.
Also, it automatically increments the release tag based on the release version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #2622 

**Special notes for your reviewer**:
I checked on Unity 2021.3.16f1 Personal.

