### PR TITLE
Add tags for cluster, location, commit to e2e-test builds

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -171,7 +171,7 @@ GO_E2E_TEST_ARGS=--kubeconfig /root/.kube/$(kubeconfig_file)
 gotestsum_json=/tmp/agones.gotestsum.json
 ifdef GOTESTSUM_VERBOSE
 gotestsum_format=--format=testname \
-  --post-run-command="sh -c 'echo; echo --- RAW VERBOSE OUTPUT ---; jq -j \"select(.Output != null) | .Output\" < $(gotestsum_json); echo --- END RAW VERBOSE OUTPUT ---'"
+  --post-run-command="sh -c 'echo; echo --- RAW VERBOSE OUTPUT ---; jq -j \"select(.Output != null) | (\\\"VERBOSE: \\\" + .Output)\" < $(gotestsum_json); echo --- END RAW VERBOSE OUTPUT ---'"
 else
 gotestsum_format=--format=standard-quiet
 endif

--- a/ci/e2e-test-cloudbuild.yaml
+++ b/ci/e2e-test-cloudbuild.yaml
@@ -55,11 +55,16 @@ steps:
     - "${_TEST_CLUSTER_NAME}"
     - "${_TEST_CLUSTER_LOCATION}"
     - "${_REGISTRY}"
+    - "${_PARENT_COMMIT_SHA}"
   id: e2e-stable
   waitFor:
     - e2e-feature-gates
 
-tags: ['e2e-test']
+tags:
+  - "e2e-test"
+  - "cluster-${_TEST_CLUSTER_NAME}"
+  - "location-${_TEST_CLUSTER_LOCATION}"
+  - "commit-${_PARENT_COMMIT_SHA}"
 timeout: 5400s # 1.5h
 queueTtl: 7200s # 2h // only one set of e2es should be running at once
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -325,7 +325,7 @@ steps:
             testCluster="gke-autopilot-e2e-test-cluster-${version//./-}"
           fi
           { gcloud builds submit . --config=./ci/e2e-test-cloudbuild.yaml \
-            --substitutions _FEATURE_WITH_GATE=$featureWithGate,_FEATURE_WITHOUT_GATE=$featureWithoutGate,_CLOUD_PRODUCT=$cloudProduct,_TEST_CLUSTER_NAME=$testCluster,_TEST_CLUSTER_LOCATION=$testClusterLocation,_REGISTRY=${_REGISTRY} \
+            --substitutions _FEATURE_WITH_GATE=$featureWithGate,_FEATURE_WITHOUT_GATE=$featureWithoutGate,_CLOUD_PRODUCT=$cloudProduct,_TEST_CLUSTER_NAME=$testCluster,_TEST_CLUSTER_LOCATION=$testClusterLocation,_REGISTRY=${_REGISTRY},_PARENT_COMMIT_SHA=${COMMIT_SHA} \
             |& sed "s/^/${cloudProduct}-${version}: /"; } &
           pids+=($!)
         done


### PR DESCRIPTION
Tags will allow us to slice test failures more easily in Logs Explorer / BigQuery

Adding VERBOSE: allows us to split up the primary and verbose output in the BQ sink more easily.

Together, we should be able to extract test failures more easily, in theory.

Looks similar to this, but I took out the double dashes:

![image](https://user-images.githubusercontent.com/4942464/230509344-0edec5a4-661d-4186-942a-5ff6ab45c13e.png)
