### PR TITLE
Update docs for Stable Network ID

### DIFF
--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -135,8 +135,10 @@ The GameServer resource does not support updates. If you need to make regular up
 
 {{< alpha title="Stable Network ID" gate="PodHostname" >}}
 
-Each Pod attached to a `GameServer` derives its hostname from the name of the `GameServer`. 
-A group of `Pods` attached to `GameServers` can use a 
+If you want to connect to a `GameServer` from within your Kubernetes cluster via a convention based
+DNS entry, each Pod attached to a `GameServer` automatically derives its hostname from the name of the `GameServer`.
+
+To create internal DNS entries within the cluster, a group of `Pods` attached to `GameServers` can use a 
 [Headless Service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to control 
 the domain of the Pods, along with providing 
 a [`subdomain` value to the `GameServer` `PodTemplateSpec`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields)
@@ -148,7 +150,7 @@ this for you, as a stable DNS record is not required for all use cases.
 
 To ensure that the `hostName` value matches
 [RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names), any `.` values 
-in the `GameServer` name are replaced by `-` when setting the `hostName` value.
+in the `GameServer` name are replaced by `-` when setting the underlying `Pod.Spec.HostName` value.
 
 ## GameServer State Diagram
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Attempting to alleviate some confusion about Stable Network ID, as it read as if the feature would enable a feature like the `ExternalDNS` provider -- whereas it's actually only for use within the cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:


N/A