### PR TITLE
Refactor: Modify logger implementation and log level

### DIFF
--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -212,8 +212,7 @@ func (ext *Extensions) creationValidationHandler(review admissionv1.AdmissionRev
 			Details: &details,
 		}
 
-		loggerForFleet(fleet, ext.baseLogger).WithField("review", review).Warn("Invalid Fleet")
-		return review, nil
+		loggerForFleet(fleet, ext.baseLogger).WithField("review", review).Debug("Invalid Fleet")
 	}
 
 	return review, nil


### PR DESCRIPTION
admission webhook "validations.agones.dev" denied the request: FleetAutoscaler is invalid
I encountered this error in my use and did not return any details to me, I would like to see him in the agones log

Signed-off-by: aimuz <mr.imuz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

/kind cleanup

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


