### PR TITLE
Add parametric host address

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "agones"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/googleforgames/agones"
@@ -35,16 +35,9 @@ features = ["sync", "time"]
 [dependencies.tonic]
 version = "0.5"
 default-features = false
-features = [
-    "codegen",
-    "transport",
-    "prost",
-]
+features = ["codegen", "transport", "prost"]
 
 [build-dependencies.tonic-build]
 version = "0.5"
 default-features = false
-features = [
-    "prost",
-    "transport",
-]
+features = ["prost", "transport"]

--- a/sdks/rust/src/sdk.rs
+++ b/sdks/rust/src/sdk.rs
@@ -60,6 +60,35 @@ impl Sdk {
         )
         .parse()?;
 
+        Self::new_internal(addr, keep_alive).await
+    }
+
+    pub async fn new_with_host(
+        host: Option<String>,
+        port: Option<u16>,
+        keep_alive: Option<Duration>,
+    ) -> Result<Self> {
+        let addr: http::Uri = format!(
+            "{}:{}",
+            host.unwrap_or_else(|| {
+                env::var("AGONES_SDK_GRPC_HOST")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or("http://localhost".to_owned())
+            }),
+            port.unwrap_or_else(|| {
+                env::var("AGONES_SDK_GRPC_PORT")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(9357)
+            })
+        )
+        .parse()?;
+
+        Self::new_internal(addr, keep_alive).await
+    }
+
+    async fn new_internal(addr: http::Uri, keep_alive: Option<Duration>) -> Result<Self> {
         let builder = tonic::transport::channel::Channel::builder(addr)
             .connect_timeout(Duration::from_secs(30))
             .keep_alive_timeout(keep_alive.unwrap_or_else(|| Duration::from_secs(30)));


### PR DESCRIPTION
Currently it's only possible to set the port, which is problematic when testing in docker.
This PR replaces the parametric port to URL.