### PR TITLE
require.NoError in fleet tests instead of continuing

### DIFF
--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -780,7 +780,11 @@ func TestReservedGameServerInFleet(t *testing.T) {
 			return true, err
 		}
 		l := len(list)
-		logrus.WithField("len", l).WithField("state", list[0].Status.State).Info("waiting for 1 reserved gs")
+		e := logrus.WithField("len", l)
+		if l >= 1 {
+			e = e.WithField("state", list[0].Status.State)
+		}
+		e.Info("waiting for 1 reserved gs")
 		return l == 1 && list[0].Status.State == agonesv1.GameServerStateReserved, nil
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
When the fleet tests flake, they take out the rest of the test suite:

```
Step #24 - "submit-e2e-test-cloud-build": gke-autopilot-1.24: Step #2 - "e2e-stable": VERBOSE: --- FAIL: TestFleetScaleUpAllocateEditAndScaleDownToZero (163.39s)
Step #24 - "submit-e2e-test-cloud-build": gke-autopilot-1.24: Step #2 - "e2e-stable": VERBOSE: panic: runtime error: index out of range [0] with length 0 [recovered]
Step #24 - "submit-e2e-test-cloud-build": gke-autopilot-1.24: Step #2 - "e2e-stable": VERBOSE:     panic: runtime error: index out of range [0] with length 0
```
