### PR TITLE
Bump example image versions

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -61,7 +61,7 @@ KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
-GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
 
 # Enable all alpha feature gates. Keep in sync with `false` (alpha) entries in pkg/util/runtime/features.go:featureDefaults
 ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&PlayerTracking=true&ResetMetricsOnDelete=true&SplitControllerAndExtensions=true&CountsAndLists=true&FleetAllocationOverflow=true&Example=true"

--- a/build/includes/examples.mk
+++ b/build/includes/examples.mk
@@ -23,7 +23,7 @@
 #    |_|\__,_|_|  \__, |\___|\__|___/
 #                 |___/
 
-# test all example images exist on Google Artifact Registry
+# test all example images exist on Google Artifact Registry (GAR)
 test-examples-on-gar: example-image-test.allocation-endpoint
 test-examples-on-gar: example-image-test.autoscaler-webhook
 test-examples-on-gar: example-image-test.cpp-simple
@@ -38,8 +38,9 @@ test-examples-on-gar: example-image-test.simple-game-server
 push-example-golang-images: example-image-push.allocation-endpoint
 push-example-golang-images: example-image-push.autoscaler-webhook
 push-example-golang-images: example-image-push.crd-client
-push-example-golang-images: example-image-push.supertuxkart
 push-example-golang-images: example-image-push.simple-game-server
+push-example-golang-images: example-image-push.supertuxkart
+push-example-golang-images: example-image-push.xonotic
 
 # Test to ensure the example image found in the % folder is on GAR. Fails if it is not.
 example-image-test.%:
@@ -48,3 +49,44 @@ example-image-test.%:
 example-image-push.%:
 	$(DOCKER_RUN) bash -c "cd examples/$* && make push"
 
+# Perform make build for golang examples
+build-go-examples: build-example-allocation-endpoint build-example-autoscaler-webhook build-example-crd-client build-example-simple-game-server build-example-supertuxkart build-example-xonotic
+
+# Perform make build for all examples
+build-examples: build-example-allocation-endpoint build-example-autoscaler-webhook build-example-cpp-simple build-example-crd-client build-example-nodejs-simple build-example-rust-simple build-example-simple-game-server build-example-supertuxkart build-example-xonotic
+
+# Run "make build" command for one example directory
+build-example:
+	cd  $(examples_folder)/$(EXAMPLE); \
+	if [ -f Makefile ] ; then \
+		make build; \
+	else \
+		echo "Makefile was not found in "/examples/$(EXAMPLE)" directory - nothing to execute" ; \
+	fi
+
+build-example-allocation-endpoint:
+	$(MAKE) build-example EXAMPLE=allocation-endpoint
+
+build-example-autoscaler-webhook:
+	$(MAKE) build-example EXAMPLE=autoscaler-webhook
+
+build-example-cpp-simple:
+	$(MAKE) build-example EXAMPLE=cpp-simple
+
+build-example-crd-client:
+	$(MAKE) build-example EXAMPLE=crd-client
+
+build-example-nodejs-simple:
+	$(MAKE) build-example EXAMPLE=nodejs-simple
+
+build-example-rust-simple:
+	$(MAKE) build-example EXAMPLE=rust-simple
+
+build-example-simple-game-server:
+	$(MAKE) build-example EXAMPLE=simple-game-server
+
+build-example-supertuxkart:
+	$(MAKE) build-example EXAMPLE=supertuxkart
+
+build-example-xonotic:
+	$(MAKE) build-example EXAMPLE=xonotic

--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -213,30 +213,3 @@ sdk-shell-csharp:
 sdk-publish-csharp: RELEASE_VERSION ?= $(base_version)
 sdk-publish-csharp:
 	$(MAKE) run-sdk-command-csharp COMMAND=publish VERSION=$(RELEASE_VERSION) DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS) -it"
-
-# Perform make build for all examples
-build-examples: build-example-xonotic build-example-cpp-simple build-example-autoscaler-webhook build-example-nodejs-simple
-
-# Run "make build" command for one example directory
-build-example:
-	cd  $(examples_folder)/$(EXAMPLE); \
-	if [ -f Makefile ] ; then \
-		make build; \
-	else \
-		echo "Makefile was not found in "/examples/$(EXAMPLE)" directory - nothing to execute" ; \
-	fi
-
-build-example-xonotic:
-	$(MAKE) build-example EXAMPLE=xonotic
-
-build-example-cpp-simple:
-	$(MAKE) build-example EXAMPLE=cpp-simple
-
-build-example-rust-simple:
-	$(MAKE) build-example EXAMPLE=rust-simple
-
-build-example-autoscaler-webhook:
-	$(MAKE) build-example EXAMPLE=autoscaler-webhook
-
-build-example-nodejs-simple:
-	$(MAKE) build-example EXAMPLE=nodejs-simple

--- a/examples/allocation-endpoint/terraform/variable.tf
+++ b/examples/allocation-endpoint/terraform/variable.tf
@@ -20,7 +20,7 @@ variable "project_id" {
 variable "ae_proxy_image" {
   type        = string
   description = "The docker image of the allocation proxy."
-  default     = "us-docker.pkg.dev/agones-images/examples/allocation-endpoint-proxy:0.4"
+  default     = "us-docker.pkg.dev/agones-images/examples/allocation-endpoint-proxy:0.5"
 }
 
 variable "region" {

--- a/examples/autoscaler-webhook/autoscaler-service-tls.yaml
+++ b/examples/autoscaler-webhook/autoscaler-service-tls.yaml
@@ -27,7 +27,7 @@ spec:
   - port: 8000
     protocol: TCP
     name: https
-    targetPort: autoscaler 
+    targetPort: autoscaler
 ---
 # Deploy a pod to run the autoscaler-webhook code
 apiVersion: apps/v1
@@ -54,7 +54,7 @@ spec:
           secretName: autoscalersecret
       containers:
       - name: autoscaler-webhook
-        image: us-docker.pkg.dev/agones-images/examples/autoscaler-webhook:0.5
+        image: us-docker.pkg.dev/agones-images/examples/autoscaler-webhook:0.6
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /home/service/certs

--- a/examples/autoscaler-webhook/autoscaler-service.yaml
+++ b/examples/autoscaler-webhook/autoscaler-service.yaml
@@ -27,7 +27,7 @@ spec:
   - port: 8000
     protocol: TCP
     name: https
-    targetPort: autoscaler 
+    targetPort: autoscaler
 ---
 # Deploy a pod to run the autoscaler-webhook code
 apiVersion: apps/v1
@@ -50,7 +50,7 @@ spec:
       #serviceAccount: autoscaler-webhook
       containers:
       - name: autoscaler-webhook
-        image: us-docker.pkg.dev/agones-images/examples/autoscaler-webhook:0.5
+        image: us-docker.pkg.dev/agones-images/examples/autoscaler-webhook:0.6
         imagePullPolicy: Always
         ports:
         - name: autoscaler

--- a/examples/crd-client/create-gs.yaml
+++ b/examples/crd-client/create-gs.yaml
@@ -34,9 +34,9 @@ spec:
             cpu: 500m
             ephemeral-storage: 1Gi
             memory: 2Gi
-        image: us-docker.pkg.dev/agones-images/examples/crd-client:0.8
+        image: us-docker.pkg.dev/agones-images/examples/crd-client:0.9
         imagePullPolicy: Always
         env:
         - name: GAMESERVER_IMAGE
-          value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15"
+          value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16"
       restartPolicy: Never

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -87,4 +87,4 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -116,7 +116,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image:  us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+        image:  us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
         imagePullPolicy: Always
       # nodeSelector is a label that can be used to tell Kubernetes which host
       # OS to use. For Windows game servers uncomment the nodeSelector

--- a/examples/simple-game-server/dev-gameserver.yaml
+++ b/examples/simple-game-server/dev-gameserver.yaml
@@ -31,4 +31,4 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16

--- a/examples/simple-game-server/fleet-distributed.yaml
+++ b/examples/simple-game-server/fleet-distributed.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
             resources:
               requests:
                 memory: "64Mi"

--- a/examples/simple-game-server/fleet-tcp.yaml
+++ b/examples/simple-game-server/fleet-tcp.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
             env:
             # Disables the UDP listener (Enabled by default)
             - name: "UDP"

--- a/examples/simple-game-server/fleet.yaml
+++ b/examples/simple-game-server/fleet.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
           - name: simple-game-server
-            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
             resources:
               requests:
                 memory: "64Mi"

--- a/examples/simple-game-server/gameserver-passthrough.yaml
+++ b/examples/simple-game-server/gameserver-passthrough.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
         env:
           - name: "PASSTHROUGH"
             value: "TRUE"

--- a/examples/simple-game-server/gameserver-windows.yaml
+++ b/examples/simple-game-server/gameserver-windows.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
         resources:
           requests:
             memory: "64Mi"

--- a/examples/simple-game-server/gameserver.yaml
+++ b/examples/simple-game-server/gameserver.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: simple-game-server
-        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+        image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
         resources:
           requests:
             memory: "64Mi"

--- a/examples/supertuxkart/fleet.yaml
+++ b/examples/supertuxkart/fleet.yaml
@@ -32,4 +32,4 @@ spec:
         spec:
           containers:
           - name: supertuxkart
-            image: us-docker.pkg.dev/agones-images/examples/supertuxkart-example:0.7
+            image: us-docker.pkg.dev/agones-images/examples/supertuxkart-example:0.8

--- a/examples/supertuxkart/gameserver.yaml
+++ b/examples/supertuxkart/gameserver.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: supertuxkart
-        image: us-docker.pkg.dev/agones-images/examples/supertuxkart-example:0.7
+        image: us-docker.pkg.dev/agones-images/examples/supertuxkart-example:0.8
         # imagePullPolicy: Always # add for development
         env:
           - name: ENABLE_PLAYER_TRACKING

--- a/examples/xonotic/fleet.yaml
+++ b/examples/xonotic/fleet.yaml
@@ -35,4 +35,4 @@ spec:
         spec:
           containers:
           - name: xonotic
-            image: us-docker.pkg.dev/agones-images/examples/xonotic-example:1.0
+            image: us-docker.pkg.dev/agones-images/examples/xonotic-example:1.1

--- a/install/helm/agones/templates/tests/test-runner.yaml
+++ b/install/helm/agones/templates/tests/test-runner.yaml
@@ -25,11 +25,11 @@ spec:
   serviceAccountName: agones-controller
   containers:
   - name: create-gameserver
-    image: us-docker.pkg.dev/agones-images/examples/crd-client:0.7
+    image: us-docker.pkg.dev/agones-images/examples/crd-client:0.9
     imagePullPolicy: Always
     env:
     - name: GAMESERVER_IMAGE
-      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15"
+      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16"
     - name: IS_HELM_TEST
       value: "true"
     - name: GAMESERVERS_NAMESPACE

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -163,7 +163,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 							"template": {
 								"spec": {
 									"containers": [{
-										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15",
+										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16",
 										"name": false
 									}]
 								}

--- a/site/config.toml
+++ b/site/config.toml
@@ -102,7 +102,7 @@ dev_eks_example_cluster_version = "1.25"
 dev_minikube_example_cluster_version = "1.25.7"
 
 # example tag
-example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15"
+example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16"
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = true

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -717,7 +717,7 @@ func defaultAutoscalerWebhook(namespace string) (*corev1.Pod, *corev1.Service) {
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "webhook",
-				Image:           "us-docker.pkg.dev/agones-images/examples/autoscaler-webhook:0.5",
+				Image:           "us-docker.pkg.dev/agones-images/examples/autoscaler-webhook:0.6",
 				ImagePullPolicy: corev1.PullAlways,
 				Ports: []corev1.ContainerPort{{
 					ContainerPort: 8000,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -149,7 +149,7 @@ func NewFromFlags() (*Framework, error) {
 	}
 
 	viper.SetDefault(kubeconfigFlag, filepath.Join(usr.HomeDir, ".kube", "config"))
-	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15")
+	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16")
 	viper.SetDefault(pullSecretFlag, "")
 	viper.SetDefault(stressTestLevelFlag, 0)
 	viper.SetDefault(perfOutputDirFlag, "")

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -982,7 +982,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution: ERROR
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
 `
 	err := os.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0o644)
 	require.NoError(t, err)

--- a/test/load/allocation/fleet.yaml
+++ b/test/load/allocation/fleet.yaml
@@ -35,7 +35,7 @@ spec:
                 - args:
                   # We setup the simple-game-server server to shutdown 10 mins after allocation
                   - -automaticShutdownDelaySec=600
-                  image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+                  image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
                   name: simple-game-server
                   resources:
                     limits:

--- a/test/load/allocation/scenario-fleet.yaml
+++ b/test/load/allocation/scenario-fleet.yaml
@@ -38,7 +38,7 @@ spec:
             value: 'true'
           containers:
           - name: simple-game-server
-            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.15
+            image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.16
             args:
             - -automaticShutdownDelaySec=60
             - -readyIterations=10


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Continues #3137 upgrading to Golang 1.20.4 by bumping up the example version numbers.
Also moves build example commands from the SDK Makefile to the Example Makefile.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


