### PR TITLE
Allow setting a static NodePort for the ping service

### DIFF
--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -135,6 +135,9 @@ spec:
     - port: {{ .Values.agones.ping.http.port }}
       name: http
       targetPort: 8080
+      {{- if eq .Values.agones.ping.http.serviceType "NodePort" }}
+      nodePort: {{ .Values.agones.ping.http.nodePort }}
+      {{- end }}
       protocol: TCP
   type: {{ .Values.agones.ping.http.serviceType }}
 {{- if eq .Values.agones.ping.http.serviceType "LoadBalancer" }}
@@ -173,6 +176,9 @@ spec:
       name: udp
       targetPort: 8080
       protocol: UDP
+      {{- if eq .Values.agones.ping.udp.serviceType "NodePort" }}
+      nodePort: {{ .Values.agones.ping.udp.nodePort }}
+      {{- end }}
   type: {{ .Values.agones.ping.udp.serviceType }}
 {{- if eq .Values.agones.ping.udp.serviceType "LoadBalancer" }}
   {{- if .Values.agones.ping.udp.loadBalancerIP }}

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -183,6 +183,7 @@ agones:
       expose: true
       response: ok
       port: 80
+      nodePort: 0 # nodePort will be used if the serviceType is set to NodePort
       serviceType: LoadBalancer
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
@@ -191,6 +192,7 @@ agones:
       expose: true
       rateLimit: 20
       port: 50000
+      nodePort: 0 # nodePort will be used if the serviceType is set to NodePort
       serviceType: LoadBalancer
       loadBalancerIP: ""
       loadBalancerSourceRanges: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Similar to the allocator service, which allows setting static nodePorts, we added the same thing to the ping service, which will benefit from having a predictable static NodePort. This is for clusters which do not have access to Service Type: LoadBalancer.