### PR TITLE
Add Cloud Best Practices guide, add guide on Release Channels

### DIFF
--- a/site/content/en/docs/Advanced/controlling-disruption.md
+++ b/site/content/en/docs/Advanced/controlling-disruption.md
@@ -74,26 +74,7 @@ GKE Autopilot supports only `Never` and `Always`, not `OnUpgrade`.
 
 ## Considerations for long sessions
 
-Outside of Cluster Autoscaler, the main source of disruption for long sessions is node upgrade. On some cloud products, such as GKE Standard, node upgrades are entirely within your control. On others, such as GKE Autopilot, node upgrade is automatic. Typical node upgrades use an eviction based, rolling recreate strategy, and may not honor `PodDisruptionBudget` for longer than an hour. Here we document strategies you can use for your cloud product to support long sessions.
-
-### On GKE
-
-On GKE, there are currently two possible approaches to manage disruption for session lengths longer than an hour:
-
-* (GKE Standard/Autopilot) [Blue/green deployment](https://martinfowler.com/bliki/BlueGreenDeployment.html) at the cluster level: If you are using an automated deployment process, you can:
-  * create a new, `green` cluster within a release channel e.g. every week,
-  * use [maintenance exclusions](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#exclusions) to prevent node upgrades for 30d, and
-  * scale the `Fleet` on the old, `blue` cluster down to 0, and
-  * use [multi-cluster allocation]({{< relref "multi-cluster-allocation.md" >}}) on Agones, which will then direct new allocations to the new `green` cluster (since `blue` has 0 desired), then
-  * delete the old, `blue` cluster when the `Fleet` successfully scales down.
-
-* (GKE Standard only) Use [node pool blue/green upgrades](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pool-upgrade-strategies#blue-green-upgrade-strategy)
-
-### Other cloud products
-
-The blue/green cluster strategy described for GKE is likely applicable to your cloud product.
-
-We welcome contributions to this section for other products!
+Outside of Cluster Autoscaler, the main source of disruption for long sessions is node upgrade. On some cloud products, such as GKE Standard, node upgrades are entirely within your control. On others, such as GKE Autopilot, node upgrade is automatic. Typical node upgrades use an eviction based, rolling recreate strategy, and may not honor `PodDisruptionBudget` for longer than an hour. See [Best Practices]({{< relref "Best Practices" >}}) for information specific to your cloud product.
 
 ## Implementation / Under the hood
 

--- a/site/content/en/docs/Guides/Best Practices/_index.md
+++ b/site/content/en/docs/Guides/Best Practices/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Cloud Best Practices" 
-linkTitle: "Cloud Best Practices"
+title: "Best Practices" 
+linkTitle: "Best Practices"
 date: 2023-05-12T00:00:00Z
 weight: 9
 description: "Best practices for running Agones in production."
@@ -16,14 +16,16 @@ some general best practices. We also have cloud specific pages for:
 
 If you are interested in submitting best practices for your cloud prodiver / on-prem, [please contribute!]({{< relref "/Contribute" >}})
 
-## Separate game servers from other workloads
+## Separation of Agones from GameServer nodes
 
-We recommend using [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to ensure that your game servers are running separate from Agones controllers. There are many ways to accomplish this, here we discuss one:
+When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers
+are scheduled for better isolation and resiliency. By default Agones prefers to be scheduled on nodes labeled with
+`agones.dev/agones-system=true` and tolerates the node taint `agones.dev/agones-system=true:NoExecute`.
+If no dedicated nodes are available, Agones will run on regular nodes. See [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+for more information about Kubernetes taints and tolerations.
 
-* Label a group of nodes `agones.dev/agones-system=true`
-* Taint the same group of nodes with `agones.dev/agones-system=true:NoExecute`
-
-If you are collecting [Metrics]({{< relref "metrics" >}}) using our standard Prometheus installation, consider isolating the `agones-metrics` namespace as well.
+If you are collecting [Metrics]({{< relref "metrics" >}}) using our standard Prometheus installation, see
+[the installation guide]({{< relref "metrics#prometheus-installation" >}}) for instructions on configuring a separate node pool for the `agones.dev/agones-metrics=true` taint.
 
 See [Creating a Cluster]({{< relref "Creating Cluster" >}}) for initial set up on your cloud provider.
 

--- a/site/content/en/docs/Guides/Best Practices/_index.md
+++ b/site/content/en/docs/Guides/Best Practices/_index.md
@@ -1,0 +1,43 @@
+---
+title: "Cloud Best Practices" 
+linkTitle: "Cloud Best Practices"
+date: 2023-05-12T00:00:00Z
+weight: 9
+description: "Best practices for running Agones in production."
+---
+
+## Overview
+
+Running Agones in production takes consideration, from planning your launch to figuring
+out the best course of action for cluster and Agones upgrades. On this page, we've collected
+some general best practices. We also have cloud specific pages for:
+
+* [Google Kubernetes Engine (GKE)]({{< relref "gke.md" >}})
+
+If you are interested in submitting best practices for your cloud prodiver / on-prem, [please contribute!]({{< relref "/Contribute" >}})
+
+## Separate game servers from other workloads
+
+We recommend using [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to ensure that your game servers are running separate from Agones controllers. There are many ways to accomplish this, here we discuss one:
+
+* Label a group of nodes `agones.dev/agones-system=true`
+* Taint the same group of nodes with `agones.dev/agones-system=true:NoExecute`
+
+If you are collecting [Metrics]({{< relref "metrics" >}}) using our standard Prometheus installation, consider isolating the `agones-metrics` namespace as well.
+
+See [Creating a Cluster]({{< relref "Creating Cluster" >}}) for initial set up on your cloud provider.
+
+## Redundant Clusters
+
+### Allocate Across Clusters
+
+Agones supports [Multi-cluster Allocation]({{< relref "multi-cluster-allocation" >}}), allowing you to allocate from a set of clusters, versus a single point of potential failure. There are several other options for multi-cluster allocation:
+* [Anthos Service Mesh](https://cloud.google.com/anthos/service-mesh) can be used to route allocation traffic to different clusters based on arbitrary criteria. See [Global Multiplayer Demo](https://github.com/googleforgames/global-multiplayer-demo) for an example where the match maker influences which cluster the allocation is routed to.
+* [Allocation Endpoint](https://github.com/googleforgames/agones/tree/main/examples/allocation-endpoint) can be used in Cloud Run to proxy allocation requests.
+* Or peruse the [Third Party Examples]({{< relref "../../Third Party Content/libraries-tools.md/#allocation" >}})
+
+### Spread
+
+You should consider spreading your game servers in two ways:
+* **Across geographic fault domains** ([GCP regions](https://cloud.google.com/compute/docs/regions-zones), [AWS availability zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html), separate datacenters, etc.): This is desirable for geographic fault isolation, but also for optimizing client latency to the game server.
+* **Within a fault domain**: Kubernetes Clusters are single points of failure. A single misconfigured RBAC rule, an overloaded Kubernetes Control Plane, etc. can prevent new game server allocations, or worse, disrupt existing sessions. Running multiple clusters within a fault domain also allows for [easier upgrades]({{< relref "Upgrading#upgrading-agones-multiple-clusters" >}}).

--- a/site/content/en/docs/Guides/Best Practices/gke.md
+++ b/site/content/en/docs/Guides/Best Practices/gke.md
@@ -1,13 +1,13 @@
 ---
-title: "GKE Best Practices"
-linkTitle: "GKE"
+title: "Google Kubernetes Engine Best Practices"
+linkTitle: "Google Cloud"
 date: 2023-05-12T00:00:00Z
-description: "Best practices for running Agones on GKE."
+description: "Best practices for running Agones on Google Kubernetes Engine (GKE)."
 ---
 
 ## Overview
 
-On this page, we've collected several GKE best practices.
+On this page, we've collected several [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/) best practices.
 
 ## Release Channels
 
@@ -30,7 +30,7 @@ If you need to disallow minor version upgrades for more than 6 months, consider 
 
 ### What versions are available on a given channel?
 
-You can query the versions available across different channels using `gcloud` using:
+You can query the versions available across different channels using `gcloud`:
 
 ```
 gcloud container get-server-config \
@@ -42,7 +42,7 @@ Replace the following:
 
 * **COMPUTE_REGION**: the
 [Google Cloud region](https://cloud.google.com/compute/docs/regions-zones#available)
-for the cluster.
+where you will create the cluster.
 
 ## Managing Game Server Disruption on GKE
 

--- a/site/content/en/docs/Guides/Best Practices/gke.md
+++ b/site/content/en/docs/Guides/Best Practices/gke.md
@@ -1,0 +1,60 @@
+---
+title: "GKE Best Practices"
+linkTitle: "GKE"
+date: 2023-05-12T00:00:00Z
+description: "Best practices for running Agones on GKE."
+---
+
+## Overview
+
+On this page, we've collected several GKE best practices.
+
+## Release Channels
+
+### Why?
+
+We recommned using [Release Channels](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) for all GKE clusters. Using Release Channels has several advantages:
+* Google automatically manages the version and upgrade cadence for your Kubernetes Control Plane and its nodes.
+* Clusters on a Release Channel are allowed to use the `No minor upgrades` and `No minor or node upgrades` [scope of maintenance exclusions](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#limitations-maint-exclusions) - in other words, enrolling a cluster in a Release Channel gives you _more control_ over node upgrades.
+* Clusters enrolled in `rapid` channel have access to the newest Kubernetes version first. Agones strives to [support the newest release in `rapid` channel]({{< relref "Installation#agones-and-kubernetes-supported-versions" >}}) to allow you to test the newest Kubernetes soon after it's available in GKE.
+
+{{< alert title="Note" color="info" >}}
+GKE Autopilot clusters must be on Release Channels.
+{{< /alert >}}
+
+### What channel should I use?
+
+We recommend the `regular` channel, which offers a balance between stability and freshness. See [this guide](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels#what_channel_should_i_use) for more discussion.
+
+If you need to disallow minor version upgrades for more than 6 months, consider choosing the freshest Kubernetes version possible: Choosing the freshest version on `rapid` or `regular` will extend the amount of time before your cluster reaches [end of life](https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule-for-release-channels).
+
+### What versions are available on a given channel?
+
+You can query the versions available across different channels using `gcloud` using:
+
+```
+gcloud container get-server-config \
+  --region=[COMPUTE_REGION] \
+  --flatten="channels" \
+  --format="yaml(channels)"
+```
+Replace the following:
+
+* **COMPUTE_REGION**: the
+[Google Cloud region](https://cloud.google.com/compute/docs/regions-zones#available)
+for the cluster.
+
+## Managing Game Server Disruption on GKE
+
+If your game session length is less than an hour, use the `eviction` API to configure your game servers appropriately - see [Controlling Disruption]({{< relref "controlling-disruption" >}}).
+
+For sessions longer than an hour, there are currently two possible approaches to manage disruption:
+
+* (GKE Standard/Autopilot) [Blue/green deployment](https://martinfowler.com/bliki/BlueGreenDeployment.html) at the cluster level: If you are using an automated deployment process, you can:
+  * create a new, `green` cluster within a release channel e.g. every week,
+  * use [maintenance exclusions](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#exclusions) to prevent node upgrades for 30d, and
+  * scale the `Fleet` on the old, `blue` cluster down to 0, and
+  * use [multi-cluster allocation]({{< relref "multi-cluster-allocation.md" >}}) on Agones, which will then direct new allocations to the new `green` cluster (since `blue` has 0 desired), then
+  * delete the old, `blue` cluster when the `Fleet` successfully scales down.
+
+* (GKE Standard only) Use [node pool blue/green upgrades](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pool-upgrade-strategies#blue-green-upgrade-strategy)

--- a/site/content/en/docs/Installation/Creating Cluster/gke.md
+++ b/site/content/en/docs/Installation/Creating Cluster/gke.md
@@ -279,7 +279,7 @@ Flag explanations:
     gcloud container clusters create-auto [CLUSTER_NAME] \
       --region=[COMPUTE_REGION] \
       --release-channel=[RELEASE_CHANNEL] \
-      --autoprovisioning-network-tags=game-server \
+      --autoprovisioning-network-tags=game-server
     ```
 
 Replace the following:

--- a/site/content/en/docs/Installation/Creating Cluster/gke.md
+++ b/site/content/en/docs/Installation/Creating Cluster/gke.md
@@ -41,13 +41,8 @@ To launch Cloud Shell, perform the following steps:
 1. From the top-right corner of the console, click the
    **Activate Google Cloud Shell** button: ![cloud shell](../../../../images/cloud-shell.png)
 1. A Cloud Shell session opens inside a frame at the bottom of the console. Use this shell to run `gcloud` and `kubectl` commands.
-1. Set a compute zone in your geographical region with the following command. An example compute zone is `us-west1-a`. A full list can be found at [Available regions and zones][zones].
-   ```bash
-   gcloud config set compute/zone [COMPUTE_ZONE]
-   ```
 
 [cloud]: https://console.cloud.google.com/home/dashboard
-[zones]: https://cloud.google.com/compute/docs/regions-zones/#available
 
 #### Local shell
 
@@ -66,15 +61,39 @@ To install `gcloud` and `kubectl`, perform the following steps:
 
 [gcloud-install]: https://cloud.google.com/sdk/docs/quickstarts
 
+### Choosing a Regional or Zonal Cluster
+
+You will need to pick a geographical region or zone where you want to deploy your cluster, and whether to
+create a [regional or zonal cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters).
+We recommend using a Regional cluster, as the zonal GKE control plane can go down temporarily to adjust for cluster resizing,
+[automatic upgrades](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-upgrades) and
+[repairs](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#repairs).
+
+After choosing a cluster type, [choose a region or zone][regions]. The region you chose is `COMPUTE_REGION` below.
+(Note that if you chose a zone, replace `--region=[COMPUTE_REGION]` with `--zone=[COMPUTE_ZONE]` in commands below.)
+
+[regions]: https://cloud.google.com/compute/docs/regions-zones/#available
+
+### Choosing a Release Channel and Optional Version
+
+We recommend using the `regular` release channel, which offers a balance between stability and freshness.
+If you'd like to read more, see our guide on [Release Channels]({{< ref "/docs/Guides/Best Practices/gke.md#release-channels" >}}).
+The release channel you chose is `RELEASE_CHANNEL` below.
+
+(Optional) During cluster creation, to set a specific available version in the release channel, use the `--cluster-version=[VERSION]` flag, e.g. `--cluster-version={{% gke-example-cluster-version %}}`. Be sure to choose a [version supported by Agones]({{< relref "../../Installation/#usage-requirements" >}}). (If you rely on release channels, the latest Agones release [should be supported]({{< relref "../../Installation/#agones-and-kubernetes-supported-versions" >}}) by the default versions of all channels.)
+
 ### Choosing a GKE cluster mode
 
 A [cluster][cluster] consists of at least one *control plane* machine and multiple worker machines called *nodes*. In Google Kubernetes Engine, nodes are [Compute Engine virtual machine][vms] instances that run the Kubernetes processes necessary to make them part of the cluster.
 
-Agones supports GKE Standard mode and has alpha support for GKE Autopilot mode.
+Agones supports both GKE Standard mode and GKE Autopilot mode. 
 Agones `GameServer` and `Fleet` manifests that work on Standard are compatible
-on Autopilot with some constraints, described in the following section. You
-can't convert existing Standard clusters to Autopilot; create new Autopilot
+on Autopilot with some constraints, described in the following section. We recommend
+running GKE Autopilot clusters, if you meet the constraints.
+
+You can't convert existing Standard clusters to Autopilot; create new Autopilot
 clusters instead.
+
 
 #### Agones on GKE Autopilot
 
@@ -133,35 +152,35 @@ gcloud compute firewall-rules create game-server-firewall \
 
 Create a GKE cluster in which you'll install Agones. You can use
 [GKE Standard mode](#create-a-standard-mode-cluster-for-agones)
-or [GKE Autopilot mode](#create-an-autopilot-mode-cluster-for-agones)
-(Alpha).
+or [GKE Autopilot mode](#create-an-autopilot-mode-cluster-for-agones).
 
 ### Create a Standard mode cluster for Agones
 
+Create the cluster:
 ```bash
-gcloud container clusters create [CLUSTER_NAME] --cluster-version={{% gke-example-cluster-version %}} \
+gcloud container clusters create [CLUSTER_NAME] \
+  --region=[COMPUTE_REGION] \
+  --release-channel=[RELEASE_CHANNEL] \
   --tags=game-server \
   --scopes=gke-default \
   --num-nodes=4 \
-  --no-enable-autoupgrade \
   --enable-image-streaming \
   --machine-type=e2-standard-4
 ```
 
-{{< alert title="Note" color="info">}}
-If you're creating a cluster to run Windows game servers, you need to add the `--enable-ip-alias` flag to create the cluster with [Alias IP ranges](https://cloud.google.com/vpc/docs/alias-ip) instead of routes-based networking.
-{{< /alert >}}
+Replace the following:
+* `[CLUSTER_NAME]`: The name of the cluster you want to create
+* `[COMPUTE_REGION]`: The GCP region to create the cluster in, [chosen above](#choosing-a-gke-cluster-mode)
+* `[RELEASE_CHANNEL]`: The GKE release channel, [chosen above](#choosing-a-release-channel-and-optional-version)
 
 Flag explanations:
-
-* cluster-version: Agones requires a
-  [supported Kubernetes version]({{<ref "/docs/Installation#usage-requirements">}}).
-* tags: Defines the tags that will be attached to new nodes in the cluster. This is to grant access through ports via the firewall created in the next step.
-* scopes: Defines the Oauth scopes required by the nodes.
-* num-nodes: The number of nodes to be created in each of the cluster's zones. Default: 4. Depending on the needs of your game, this parameter should be adjusted.
-* no-enable-autoupgrade: Disable automatic upgrades for nodes to reduce the likelihood of in-use games being disrupted.
-* enable-image-streaming: Use [Image streaming](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming) to pull container images, which leads to significant improvements in initialization times. [Limitations](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#limitations) apply to enable this feature.
-* machine-type: The type of machine to use for nodes. Default: e2-standard-4. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
+* `--region`: The compute region [you chose above](#choosing-a-gke-cluster-mode).
+* `--release-channel`: The release channel [you chose above](#choosing-a-release-channel-and-optional-version).
+* `--tags`: Defines the tags that will be attached to new nodes in the cluster. This is to grant access through ports via the [firewall created above](#creating-the-firewall).
+* `--scopes`: Defines the Oauth scopes required by the nodes.
+* `--num-nodes`: The number of nodes to be created in each of the cluster's zones. Default: 4. Depending on the needs of your game, this parameter should be adjusted.
+* `--enable-image-streaming`: Use [Image streaming](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming) to pull container images, which leads to significant improvements in initialization times. [Limitations](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#limitations) apply to enable this feature.
+* `--machine-type`: The type of machine to use for nodes. Default: `e2-standard-4`. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
 
 #### (Optional) Creating a dedicated node pool
 
@@ -173,12 +192,24 @@ recommended for a production deployment.
 ```bash
 gcloud container node-pools create agones-system \
   --cluster=[CLUSTER_NAME] \
-  --no-enable-autoupgrade \
+  --region=[COMPUTE_REGION] \
   --node-taints agones.dev/agones-system=true:NoExecute \
   --node-labels agones.dev/agones-system=true \
-  --num-nodes=1
+  --num-nodes=1 \
+  --machine-type=e2-standard-4
 ```
-where [CLUSTER_NAME] is the name of the cluster you created.
+
+Replace the following:
+* `[CLUSTER_NAME]`: The name of the cluster you created
+* `[COMPUTE_REGION]`: The GCP region to create the cluster in, [chosen above](#choosing-a-gke-cluster-mode)
+
+Flag explanations:
+* `--cluster`: The name of the cluster you created.
+* `--region`: The compute region [you chose above](#choosing-a-gke-cluster-mode).
+* `--node-taints`: The Kubernetes taints to automatically apply to nodes in this node pool.
+* `--node-labels`: The Kubernetes labels to automatically apply to nodes in this node pool.
+* `--num-nodes`: The number of nodes per cluster zone. For regional clusters, `--num-nodes=1` creates one node in 3 separate zones in the region, giving you faster recovery time in the event of a node failure.
+* `--machine-type`: The type of machine to use for nodes. Default: `e2-standard-4`. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
 
 #### (Optional) Creating a metrics node pool
 
@@ -188,20 +219,24 @@ Create a node pool for [Metrics]({{< relref "../../Guides/metrics.md" >}}) if yo
 ```bash
 gcloud container node-pools create agones-metrics \
   --cluster=[CLUSTER_NAME] \
-  --no-enable-autoupgrade \
+  --region=[COMPUTE_REGION] \
   --node-taints agones.dev/agones-metrics=true:NoExecute \
   --node-labels agones.dev/agones-metrics=true \
   --num-nodes=1 \
   --machine-type=e2-standard-4
 ```
 
-Flag explanations:
+Replace the following:
+* `[CLUSTER_NAME]`: The name of the cluster you created
+* `[COMPUTE_REGION]`: The GCP region to create the cluster in, [chosen above](#choosing-a-gke-cluster-mode)
 
-* cluster: The name of your existing cluster in which the node pool is created.
-* no-enable-autoupgrade: Disable automatic upgrades for nodes to reduce the likelihood of in-use games being disrupted.
-* node-taints: The Kubernetes taints to automatically apply to nodes in this node pool.
-* node-labels: The Kubernetes labels to automatically apply to nodes in this node pool.
-* num-nodes: The Agones system controllers only require a single node of capacity to run. For faster recovery time in the event of a node failure, you can increase the size to 2.
+Flag explanations:
+* `--cluster`: The name of the cluster you created.
+* `--region`: The compute region [you chose above](#choosing-a-gke-cluster-mode).
+* `--node-taints`: The Kubernetes taints to automatically apply to nodes in this node pool.
+* `--node-labels`: The Kubernetes labels to automatically apply to nodes in this node pool.
+* `--num-nodes`: The number of nodes per cluster zone. For regional clusters, `--num-nodes=1` creates one node in 3 separate zones in the region, giving you faster recovery time in the event of a node failure.
+* `--machine-type`: The type of machine to use for nodes. Default: `e2-standard-4`. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
 
 #### (Optional) Creating a node pool for Windows
 
@@ -217,37 +252,26 @@ through [Github issues](https://github.com/googleforgames/agones/issues).
 ```bash
 gcloud container node-pools create windows \
   --cluster=[CLUSTER_NAME] \
-  --no-enable-autoupgrade \
+  --region=[COMPUTE_REGION] \
   --image-type WINDOWS_LTSC_CONTAINERD \
   --machine-type e2-standard-4 \
   --num-nodes=4
 ```
 
-where [CLUSTER_NAME] is the name of the cluster you created.
+Replace the following:
+* `[CLUSTER_NAME]`: The name of the cluster you created
+* `[COMPUTE_REGION]`: The GCP region to create the cluster in, [chosen above](#choosing-a-gke-cluster-mode)
+
+Flag explanations:
+* `--cluster`: The name of the cluster you created.
+* `--region`: The compute region [you chose above](#choosing-a-gke-cluster-mode).
+* `--image-type`: The image type of the instances in the node pool - `WINDOWS_LTSC_CONTAINERD` in this case.
+* `--machine-type`: The type of machine to use for nodes. Default: `e2-standard-4`. Depending on the needs of your game, you may wish to [have smaller or larger machines](https://cloud.google.com/compute/docs/machine-types).
+* `--num-nodes`: The number of nodes per cluster zone. For regional clusters, `--num-nodes=1` creates one node in 3 separate zones in the region, giving you faster recovery time in the event of a node failure.
 
 ### Create an Autopilot mode cluster for Agones
 
-Agones supports Autopilot clusters in [alpha]({{<ref "/docs/Guides/feature-stages#alpha">}}).
-
-1. Find a release channel that has a supported Kubernetes version for Agones:
-
-   ```
-   gcloud container get-server-config \
-     --region=[COMPUTE_REGION] \
-     --flatten="channels" \
-     --format="yaml(channels)" \
-     --filter="channels.channel~[RELEASE_CHANNEL]"
-   ```
-   Replace the following:
-
-   * **COMPUTE_REGION**: the
-   [Google Cloud region](https://cloud.google.com/compute/docs/regions-zones#available)
-   for the cluster.
-   * **RELEASE_CHANNEL**: the name of the release channel. Can be `RAPID`,
-     `REGULAR`, or `STABLE`. Omit the `--filter` flag to view all channels.
-  
-   The output shows the default and available versions in the specified
-   channel.
+1. Choose a [Release Channel]({{<ref "/docs/Guides/Best Practices/gke.md#release-channels" >}}) (Autopilot clusters must be on a Release Channel).
 
 1. Create the cluster:
 
@@ -257,37 +281,27 @@ Agones supports Autopilot clusters in [alpha]({{<ref "/docs/Guides/feature-stage
       --release-channel=[RELEASE_CHANNEL] \
       --autoprovisioning-network-tags=game-server \
     ```
-    Replace the following:
 
-* **CLUSTER_NAME**: the name of your cluster.
-* **RELEASE_CHANNEL**: one of
-  `rapid`, `regular`, or `stable`. The default is `regular`. To set a specific
-  available version in the release channel, use the
-  `--cluster-version=[VERSION]` flag.
+Replace the following:
+* `[CLUSTER_NAME]`: The name of your cluster.
+* `[COMPUTE_REGION]`: the GCP region to create the cluster in.
+* `[RELEASE_CHANNEL]`: one of `rapid`, `regular`, or `stable`, chosen [above](#choosing-a-release-channel-and-optional-version). The default is `regular`.
+
+Flag explanations:
+* `--region`: The compute region [you chose above](#choosing-a-gke-cluster-mode).
+* `--release-channel`: The release channel [you chose above](#choosing-a-release-channel-and-optional-version).
+* `--autoprovisioning-network-tags`: Defines the tags that will be attached to new nodes in the cluster. This is to grant access through ports via the [firewall created above](#creating-the-firewall).
 
 ## Setting up cluster credentials
 
-Finally, let's tell `gcloud` that we are speaking with this cluster, and get auth credentials for `kubectl` to use.
+`gcloud container clusters create` configurates credentials for `kubectl` automatically. If you ever lose those, run:
 
 ```bash
-gcloud config set container/cluster [CLUSTER_NAME]
-gcloud container clusters get-credentials [CLUSTER_NAME]
+gcloud container clusters get-credentials [CLUSTER_NAME] --region=[COMPUTE_REGION]
 ```
 
 [cluster]: https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture
 [vms]: https://cloud.google.com/compute/docs/instances/
-
-
-{{< alert title="Note" color="info">}}
-Before planning your production GKE infrastructure, it is worth reviewing the
-[different types of GKE clusters that can be created](https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters),
-such as Zonal or Regional, as each has different reliability and cost values, and ensuring this aligns with your
-Service Level Objectives or Agreements.
-
-This is particularly true for a zonal GKE control plane, which can go down temporarily to adjust for cluster resizing,
-[automatic upgrades](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-upgrades) and
-[repairs](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#repairs).
-{{< /alert >}}
 
 ## Next Steps
 
@@ -298,7 +312,7 @@ If you created a GKE Standard cluster, continue to [Install Agones]({{< relref "
 ### GKE Autopilot
 
 {{<alert title="Note" color="info">}}
-These installation instructions apply to Agones 1.30.
+These installation instructions apply to Agones 1.30+
 {{</alert>}}
 
 If you created a GKE Autopilot cluster:

--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -57,13 +57,7 @@ The following table lists recent Agones versions and their corresponding require
 | 1.22           | 1.21                  |
 | 1.21           | 1.21                  |
 
-## Best Practices
+## Best Practices {#separation-of-agones-from-gameserver-nodes}
+{{/* keep installation/#separation-of-agones-from-gameserver-nodes permalink */}}
 
-### Separation of Agones from GameServer nodes
-
-When running in production, Agones should be scheduled on a dedicated pool of nodes, distinct from where Game Servers
-are scheduled for better isolation and resiliency. By default Agones prefers to be scheduled on nodes labeled with
-`agones.dev/agones-system=true` and tolerates the node taint `agones.dev/agones-system=true:NoExecute`.
-If no dedicated nodes are available, Agones will run on regular nodes.
-
-[windows]: {{% ref "/docs/Guides/windows-gameservers.md" %}}
+For detailed guides on best practices running Agones in production, see [Best Practices]({{< relref "../Guides/Best Practices" >}}).

--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -37,6 +37,8 @@ The following container operating systems and architectures can be utilised with
 
 For all the platforms in Alpha, we would appreciate testing and bug reports on any issue found.
 
+[windows]: {{% relref "windows-gameservers.md" %}}
+
 ## Agones and Kubernetes Supported Versions
 
 Agones will support 3 releases of Kubernetes, targeting the newest version as being the [latest available version in the GKE Rapid channel](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions). However, we will ensure that at least one of the 3 versions chosen for each Agones release is supported by each of the major cloud providers (EKS and AKS). The vendored version of client-go will be aligned with the middle of the three supported Kubernetes versions. When a new version of Agones supports new versions of Kubernetes, it is explicitly called out in the [release notes](https://agones.dev/site/blog/releases/).
@@ -58,6 +60,6 @@ The following table lists recent Agones versions and their corresponding require
 | 1.21           | 1.21                  |
 
 ## Best Practices {#separation-of-agones-from-gameserver-nodes}
-{{/* keep installation/#separation-of-agones-from-gameserver-nodes permalink */}}
+<!-- keep installation/#separation-of-agones-from-gameserver-nodes permalink -->
 
 For detailed guides on best practices running Agones in production, see [Best Practices]({{< relref "../Guides/Best Practices" >}}).


### PR DESCRIPTION
* Adds a "Best Practices" section to the sidebar
  * Adds some generic Best Practices
  * And a GKE section that discussed Release Channels
* Move the GKE-specific "long-session" discussion out of "Controlling Disruption" and into GKE.

* Refactor the GKE getting started page considerably:
  * Add a section on choosing a release channel that calls out to the guide but otherwise suggests using `regular`.
  * Move discussion of zonal/regional to top - current instructions lean towards a zonal cluster but there is really no disadvantage to defaulting to regional.
  * Along the way, remove `gcloud config set` references. We strongly encourage multiple clusters, it's not clear to me why the instructions lean so heavily on changing your global gcloud config.
  * Assume that the `SplitControllerAndExtensions` gate is getting graduated, remove reference to Alpha support for Autopilot. (Does not remove feature flag, will leave for graduation.)

