### PR TITLE
sdkserver: When waitForConnection fails, container should restart quickly

### DIFF
--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -97,7 +97,7 @@ func main() {
 	case ctlConf.IsLocal:
 		cancel, err := registerLocal(grpcServer, ctlConf)
 		if err != nil {
-			logger.WithError(err).Fatal("Could not start local sdk server")
+			logger.WithError(err).Fatal("Could not start local SDK server")
 		}
 		defer cancel()
 
@@ -108,7 +108,7 @@ func main() {
 	case ctlConf.Test != "":
 		cancel, err := registerTestSdkServer(grpcServer, ctlConf)
 		if err != nil {
-			logger.WithError(err).Fatal("Could not start test sdk server")
+			logger.WithError(err).Fatal("Could not start test SDK server")
 		}
 		defer cancel()
 
@@ -141,6 +141,11 @@ func main() {
 		if err != nil {
 			logger.WithError(err).Fatalf("Could not start sidecar")
 		}
+		// wait for networking prior to replacing context, otherwise we'll
+		// end up waiting the full grace period if it fails.
+		if err := s.WaitForConnection(ctx); err != nil {
+			logger.WithError(err).Fatalf("Sidecar networking failure")
+		}
 		if runtime.FeatureEnabled(runtime.FeatureSDKGracefulTermination) {
 			ctx = s.NewSDKServerContext(ctx)
 		}
@@ -160,7 +165,7 @@ func main() {
 	go runGateway(ctx, grpcEndpoint, mux, httpServer)
 
 	<-ctx.Done()
-	logger.Info("shutting down sdk server")
+	logger.Info("Shutting down SDK server")
 }
 
 // registerLocal registers the local SDK servers, and returns a cancel func that

--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -20,5 +20,6 @@ CheckExternal: true
 ExternalTimeout: 60
 IgnoreURLs:
   - http://localhost
+  - https://twitter.com/agonesdev
 HTTPHeaders:
   User-Agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"


### PR DESCRIPTION
* waitForConnection is using the context provided by NewSDKServerContext, but that context isn't closed until we see a Shutdown(). That's not right - we want to restart the SDK server quickly, which might save the game server in this odd case. So, move waitForConnection up into main so that we can use the "normal" context.

* Additionally, I noticed that when we went into graceful termination, the liveness probes stopped! Agghhh. So, this reverts part of #3072: instead of using /gshealthz as our heartbeat, fall back to using a go routine. But we still honor the intent of #3072: health checks should start when we see the first /gshealthz.

* Along the way, add some logging, and make it consistently "SDK" in logging.