### PR TITLE
Suppress full e2e logs so the per-configuration links are obvious

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -324,9 +324,10 @@ steps:
             testClusterLocation="${region}"
             testCluster="gke-autopilot-e2e-test-cluster-${version//./-}"
           fi
-          { gcloud builds submit . --config=./ci/e2e-test-cloudbuild.yaml \
+          { stdbuf -oL -eL gcloud builds submit . --suppress-logs --config=./ci/e2e-test-cloudbuild.yaml \
             --substitutions _FEATURE_WITH_GATE=$featureWithGate,_FEATURE_WITHOUT_GATE=$featureWithoutGate,_CLOUD_PRODUCT=$cloudProduct,_TEST_CLUSTER_NAME=$testCluster,_TEST_CLUSTER_LOCATION=$testClusterLocation,_REGISTRY=${_REGISTRY},_PARENT_COMMIT_SHA=${COMMIT_SHA},_PARENT_BUILD_ID=${BUILD_ID} \
-            |& sed "s/^/${cloudProduct}-${version}: /"; } &
+            |& stdbuf -i0 -oL -eL grep -v " tarball " \
+            |& stdbuf -i0 -oL -eL sed "s/^/${cloudProduct}-${version}: /"; } &
           pids+=($!)
         done
       done


### PR DESCRIPTION
Suppress `gcloud builds submit` logs - this should make it more obvious where to find the separate e2e logs and which configuration is failing.

Example failure: https://console.cloud.google.com/cloud-build/builds/03e89a9d-2e47-4ce2-8847-29f2f0820b60;step=24?jsmode=o&mods=logs_tg_prod&project=agones-images

Towards #3010 