### PR TITLE
build: add ltsc2022 target for windows builds

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -50,7 +50,7 @@ WINDOWS_DOCKER_PUSH_ARGS =
 # Versions of Windows Server to support, default is Windows Server 2019.
 # For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
 # GKE-Windows version map: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#version_mapping
-WINDOWS_VERSIONS = ltsc2019
+WINDOWS_VERSIONS = ltsc2019 ltsc2022
 
 # Specify stress test level 1..100
 # STRESS_TEST_LEVEL=n requires capacity between 50*n up to 100*n simple-game-server Game Servers.

--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -28,7 +28,7 @@ BUILDX_WINDOWS_BUILDER = windows-builder
 # Versions of Windows Server to support, default is Windows Server 2019.
 # For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
 # GKE-Windows version map: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#version_mapping
-WINDOWS_VERSIONS = ltsc2019
+WINDOWS_VERSIONS = ltsc2019 ltsc2022
 WINDOWS_DOCKER_PUSH_ARGS = # When pushing set to --push.
 # Build with Windows support
 WITH_WINDOWS=1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Creates Windows container images for Agones on the ltsc2022 Windows base image, which is required to run on Windows Server 2022.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Contributes to https://github.com/googleforgames/agones/issues/54 but does not completely close.

**Special notes for your reviewer**:

I don't have access to GCP-hosted registries, so pushed these to AWS ECR instead. Had issues with the docker manifest not being able to be generated but was not certain that this was not an ECR limitation. Am happy to make further changes if the issues also appear on the registry Agones is using.
