### PR TITLE
Add label changes for service-monitor

### DIFF
--- a/install/helm/agones/templates/service-monitor.yaml
+++ b/install/helm/agones/templates/service-monitor.yaml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- $featureGates := include "agones.featureGates" . | fromYaml }}
 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -19,7 +20,11 @@ metadata:
   name: agones-controller-monitor
   namespace: {{ .Release.Namespace }}
   labels:
+{{- if $featureGates.SplitControllerAndExtensions }}
+    agones.dev/role: extensions
+{{- else}}
     agones.dev/role: controller
+{{- end}}  
     app: {{ template "agones.name" . }}
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
@@ -27,7 +32,11 @@ metadata:
 spec:
   selector:
     matchLabels:
+{{- if $featureGates.SplitControllerAndExtensions }}
+      agones.dev/role: extensions
+{{- else}}
       agones.dev/role: controller
+{{- end}}
   endpoints:
     - port: web
       path: /metrics


### PR DESCRIPTION
This changes service-monitor to match against the "extensions" label when `SplitControllerAndExtensions` is enabled. \

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:
This is potential fix for https://github.com/googleforgames/agones/issues/3190

**Which issue(s) this PR fixes**:
For https://github.com/googleforgames/agones/issues/3190

**Special notes for your reviewer**:


