### PR TITLE
remove old warning of conversion int64 to float64

### DIFF
--- a/site/content/en/docs/Installation/upgrading.md
+++ b/site/content/en/docs/Installation/upgrading.md
@@ -83,12 +83,6 @@ Given the above, the steps for upgrade are simpler:
 6. Close your maintenance window.
 7. Congratulations - you have now upgraded to a new version of Agones! 👍
 
-{{< alert color="warning" title="Warning" >}}
-If you are getting an error of `cannot convert int64 to float64` on `helm upgrade` you will need to `helm uninstall` 
-the original installation and do a full `helm install` to the new version to upgrade Agones. 
-
-This is due to [helm/helm#5806](https://github.com/helm/helm/issues/5806) and will be resolved with Kubernetes 1.20
-{{< /alert >}}
 
 ## Upgrading Kubernetes
 
@@ -98,7 +92,7 @@ They may require adjustment to your particular game architecture but should prov
 The recommended approach is to use [multiple clusters](#multiple-clusters), such that the upgrade can be tested
 gradually with production load and easily rolled back if the need arises.
 
-Agones has [multiple supported Kubernetes versions]({{< relref "_index.md#usage-requirements" >}}) for each version. You can stick with a minor Kubernetes version until it is not supported by Agones, but it is recommended to do supported minor (e.g. 1.12.1 ➡ 1.13.2) Kubernetes version upgrades at the same time as a matching Agones upgrades.
+Agones has [multiple supported Kubernetes versions]({{< relref "_index.md#agones-and-kubernetes-supported-versions" >}}) for each version. You can stick with a minor Kubernetes version until it is not supported by Agones, but it is recommended to do supported minor (e.g. 1.12.1 ➡ 1.13.2) Kubernetes version upgrades at the same time as a matching Agones upgrades.
 
 Patch upgrades (e.g. 1.12.1 ➡ 1.12.3) within the same minor version of Kubernetes can be done at any time. 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
/kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**: Conversion of int64 to float64 warning doesn't require anymore. Since, Tagged issue of helm got closed. According to Agones Version chart [here](https://agones.dev/site/docs/installation/#agones-and-kubernetes-supported-versions) supported version are from 1.21 to 1.26. And officially GKE version 1.21 and earlier have reached end of life and are no longer supported.
Second Change, Pointed ref link directly to the supported version chart link instead of whole window.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


