### PR TITLE
GKE Autopilot: Add primary container annotation for game server container

### DIFF
--- a/pkg/apis/agones/v1/apihooks.go
+++ b/pkg/apis/agones/v1/apihooks.go
@@ -28,7 +28,7 @@ type APIHooks interface {
 	// ValidateScheduling is called by Fleet and GameServerSet Validate() to allow for product specific validation of scheduling strategy.
 	ValidateScheduling(apis.SchedulingStrategy) []metav1.StatusCause
 
-	// MutateGameServerPodc is called by createGameServerPod to allow for product specific pod mutation.
+	// MutateGameServerPod is called by createGameServerPod to allow for product specific pod mutation.
 	MutateGameServerPod(*GameServerSpec, *corev1.Pod) error
 
 	// SetEviction is called by gs.Pod to enforce GameServer.Status.Eviction.

--- a/pkg/apis/agones/v1/apihooks.go
+++ b/pkg/apis/agones/v1/apihooks.go
@@ -28,8 +28,8 @@ type APIHooks interface {
 	// ValidateScheduling is called by Fleet and GameServerSet Validate() to allow for product specific validation of scheduling strategy.
 	ValidateScheduling(apis.SchedulingStrategy) []metav1.StatusCause
 
-	// MutateGameServerPodSpec is called by createGameServerPod to allow for product specific pod mutation.
-	MutateGameServerPodSpec(*GameServerSpec, *corev1.PodSpec) error
+	// MutateGameServerPodc is called by createGameServerPod to allow for product specific pod mutation.
+	MutateGameServerPod(*GameServerSpec, *corev1.Pod) error
 
 	// SetEviction is called by gs.Pod to enforce GameServer.Status.Eviction.
 	SetEviction(*Eviction, *corev1.Pod) error

--- a/pkg/apis/agones/v1/apihooksfake.go
+++ b/pkg/apis/agones/v1/apihooksfake.go
@@ -23,10 +23,10 @@ import (
 // fakeAPIHooks is a stubabble, fake implementation of APIHooks
 // This needs to be private, so it doesn't get picked up by the DeepCopy() generation toolkit.
 type fakeAPIHooks struct {
-	StubValidateGameServerSpec  func(*GameServerSpec) []metav1.StatusCause
-	StubValidateScheduling      func(apis.SchedulingStrategy) []metav1.StatusCause
-	StubMutateGameServerPodSpec func(*GameServerSpec, *corev1.PodSpec) error
-	StubSetEviction             func(*Eviction, *corev1.Pod) error
+	StubValidateGameServerSpec func(*GameServerSpec) []metav1.StatusCause
+	StubValidateScheduling     func(apis.SchedulingStrategy) []metav1.StatusCause
+	StubMutateGameServerPod    func(*GameServerSpec, *corev1.Pod) error
+	StubSetEviction            func(*Eviction, *corev1.Pod) error
 }
 
 var _ APIHooks = fakeAPIHooks{}
@@ -47,10 +47,10 @@ func (f fakeAPIHooks) ValidateScheduling(strategy apis.SchedulingStrategy) []met
 	return nil
 }
 
-// MutateGameServerPodSpec is called by createGameServerPod to allow for product specific pod mutation.
-func (f fakeAPIHooks) MutateGameServerPodSpec(gss *GameServerSpec, podSpec *corev1.PodSpec) error {
-	if f.StubMutateGameServerPodSpec != nil {
-		return f.StubMutateGameServerPodSpec(gss, podSpec)
+// MutateGameServerPod is called by createGameServerPod to allow for product specific pod mutation.
+func (f fakeAPIHooks) MutateGameServerPod(gss *GameServerSpec, pod *corev1.Pod) error {
+	if f.StubMutateGameServerPod != nil {
+		return f.StubMutateGameServerPod(gss, pod)
 	}
 	return nil
 }

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -782,7 +782,7 @@ func (gs *GameServer) Pod(apiHooks APIHooks, sidecars ...corev1.Container) (*cor
 
 	gs.podScheduling(pod)
 
-	if err := apiHooks.MutateGameServerPodSpec(&gs.Spec, &pod.Spec); err != nil {
+	if err := apiHooks.MutateGameServerPod(&gs.Spec, pod); err != nil {
 		return nil, err
 	}
 	if err := apiHooks.SetEviction(gs.Status.Eviction, pod); err != nil {

--- a/pkg/cloudproduct/generic/generic.go
+++ b/pkg/cloudproduct/generic/generic.go
@@ -33,9 +33,9 @@ func New() *generic { return &generic{} }
 
 type generic struct{}
 
-func (*generic) ValidateGameServerSpec(*agonesv1.GameServerSpec) []metav1.StatusCause    { return nil }
-func (*generic) ValidateScheduling(apis.SchedulingStrategy) []metav1.StatusCause         { return nil }
-func (*generic) MutateGameServerPodSpec(*agonesv1.GameServerSpec, *corev1.PodSpec) error { return nil }
+func (*generic) ValidateGameServerSpec(*agonesv1.GameServerSpec) []metav1.StatusCause { return nil }
+func (*generic) ValidateScheduling(apis.SchedulingStrategy) []metav1.StatusCause      { return nil }
+func (*generic) MutateGameServerPod(*agonesv1.GameServerSpec, *corev1.Pod) error      { return nil }
 
 // SetEviction sets disruptions controls based on GameServer.Status.Eviction.
 func (*generic) SetEviction(eviction *agonesv1.Eviction, pod *corev1.Pod) error {

--- a/pkg/testing/apihooks.go
+++ b/pkg/testing/apihooks.go
@@ -37,8 +37,8 @@ func (f FakeAPIHooks) ValidateScheduling(_ apis.SchedulingStrategy) []metav1.Sta
 	return nil
 }
 
-// MutateGameServerPodSpec is called by createGameServerPod to allow for product specific pod mutation.
-func (f FakeAPIHooks) MutateGameServerPodSpec(_ *agonesv1.GameServerSpec, podSpec *corev1.PodSpec) error {
+// MutateGameServerPod is called by createGameServerPod to allow for product specific pod mutation.
+func (f FakeAPIHooks) MutateGameServerPod(_ *agonesv1.GameServerSpec, pod *corev1.Pod) error {
 	return nil
 }
 


### PR DESCRIPTION
`autopilot.gke.io/primary-container` is a new annotation that will be supported by Autopilot ~soon that indicates which container resource defaulting should affect. Prior to this if I were to create a GameServer with no resource requests, Autopilot would default-up the sidecar container, as it occurs first.

The annotation will be supported in 1.27 ~soon, but this change is safe on all versions (just not useful, necessarily).
