### PR TITLE
Put e2e Cloud Build logs in public bucket

### DIFF
--- a/ci/e2e-test-cloudbuild.yaml
+++ b/ci/e2e-test-cloudbuild.yaml
@@ -69,4 +69,4 @@ tags:
   - "started-by-${_PARENT_BUILD_ID}"
 timeout: 5400s # 1.5h
 queueTtl: 7200s # 2h // only one set of e2es should be running at once
-
+logsBucket: "gs://agones-build-logs"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

The e2e test logs are not accessible to non googlers right now, as they don't get streamed to the `gs://agones-build-logs` bucket, and this fixes that.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Reported in #3239

**Special notes for your reviewer**:

N/A