### PR TITLE
Race Flake in TestControllerSyncFleetAutoscaler()

### DIFF
--- a/pkg/fleetautoscalers/controller_test.go
+++ b/pkg/fleetautoscalers/controller_test.go
@@ -756,13 +756,13 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		t.Parallel()
 
 		c, m := newFakeController()
-		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
-		defer cancel()
-
 		m.AgonesClient.AddReactor("get", "fleetautoscalers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ga := action.(k8stesting.GetAction)
 			return true, nil, k8serrors.NewNotFound(corev1.Resource("gameserver"), ga.GetName())
 		})
+
+		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
+		defer cancel()
 
 		require.NoError(t, c.syncFleetAutoscaler(ctx, "default/fas-1"))
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Weird that this has more consistently failed with the Go race condition checker failing on this test recently -- but it's a test we wrote a while ago!

The flake was that the test added a Reactor to the mock _after_ the Informer system had been started - which caused a race condition inside the Fake client system as different systems interacted with the mock.

Changing the order fixes the issue!

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Helps #3211 move forward.

**Special notes for your reviewer**:


N/A