### PR TITLE
Alpine ➡️ Distroless as Agones base image

### DIFF
--- a/cmd/allocator/Dockerfile
+++ b/cmd/allocator/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.14
+FROM gcr.io/distroless/static-debian11:nonroot
 
 ARG ARCH=amd64
-RUN apk --update add ca-certificates && \
-    adduser -D -u 1000 agones
+WORKDIR /
 
-COPY --chown=agones:agones ./bin/allocator.linux.$ARCH /home/agones/allocator
-COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY ./bin/allocator.linux.$ARCH /allocator
+COPY ./bin/LICENSES .
+COPY ./bin/dependencies-src.tgz .
 
-USER 1000
-ENTRYPOINT ["/home/agones/allocator"]
+USER nonroot:nonroot
+ENTRYPOINT ["/allocator"]

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.14
+FROM gcr.io/distroless/static-debian11:nonroot
 
 ARG ARCH=amd64
-RUN apk --update add ca-certificates && \
-    adduser -D -u 1000 agones
+WORKDIR /
 
-COPY --chown=agones:agones ./bin/controller.linux.$ARCH /home/agones/controller
-COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY ./bin/controller.linux.$ARCH /controller
+COPY ./bin/LICENSES .
+COPY ./bin/dependencies-src.tgz .
 
-USER 1000
-ENTRYPOINT ["/home/agones/controller"]
+USER nonroot:nonroot
+ENTRYPOINT ["/controller"]

--- a/cmd/extensions/Dockerfile
+++ b/cmd/extensions/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.14
+FROM gcr.io/distroless/static-debian11:nonroot
 
 ARG ARCH=amd64
-RUN apk --update add ca-certificates && \
-    adduser -D -u 1000 agones
+WORKDIR /
 
-COPY --chown=agones:agones ./bin/extensions.linux.$ARCH /home/agones/extensions
-COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY ./bin/extensions.linux.$ARCH /extensions
+COPY ./bin/LICENSES .
+COPY ./bin/dependencies-src.tgz .
 
-USER 1000
-ENTRYPOINT ["/home/agones/extensions"]
+USER nonroot:nonroot
+ENTRYPOINT ["/extensions"]

--- a/cmd/ping/Dockerfile
+++ b/cmd/ping/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.14
+FROM gcr.io/distroless/static-debian11:nonroot
 
 ARG ARCH=amd64
-RUN apk --update add ca-certificates && \
-    adduser -D -u 1000 agones
+WORKDIR /
 
-COPY --chown=agones:agones ./bin/ping.linux.$ARCH /home/agones/ping
-COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY ./bin/ping.linux.$ARCH /ping
+COPY ./bin/LICENSES .
+COPY ./bin/dependencies-src.tgz .
 
-USER 1000
-ENTRYPOINT ["/home/agones/ping"]
+USER nonroot:nonroot
+ENTRYPOINT ["/ping"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.14
+FROM gcr.io/distroless/static-debian11:nonroot
+
 ARG ARCH=amd64
-RUN apk --update add ca-certificates && \
-    adduser -D -u 1000 agones
+WORKDIR /
 
-COPY --chown=agones:agones ./bin/sdk-server.linux.$ARCH /home/agones/sdk-server
-COPY --chown=agones:agones ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
+COPY ./bin/sdk-server.linux.$ARCH /sdk-server
+COPY ./bin/LICENSES .
+COPY ./bin/dependencies-src.tgz .
 
-USER 1000
-ENTRYPOINT ["/home/agones/sdk-server"]
+USER nonroot:nonroot
+ENTRYPOINT ["/sdk-server"]

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -148,7 +148,7 @@ spec:
           value: {{ .Values.agones.cloudProduct | quote }}
 {{- if .Values.agones.controller.persistentLogs }}
         - name: LOG_DIR
-          value: "/home/agones/logs"
+          value: "/logs"
         - name: LOG_SIZE_LIMIT_MB
           value: {{ .Values.agones.controller.persistentLogsSizeLimitMB | quote }}
 {{- end }}
@@ -190,11 +190,11 @@ spec:
 {{- end }}
         volumeMounts:
         - name: certs
-          mountPath: /home/agones/certs
+          mountPath: /certs
           readOnly: true
 {{- if .Values.agones.controller.persistentLogs }}
         - name: logs
-          mountPath: /home/agones/logs
+          mountPath: /logs
           readOnly: false
 {{- end }}
       volumes:

--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -120,7 +120,7 @@ spec:
           value: {{ .Values.agones.cloudProduct | quote }}
 {{- if .Values.agones.extensions.persistentLogs }}
         - name: LOG_DIR
-          value: "/home/agones/logs"
+          value: "/logs"
         - name: LOG_SIZE_LIMIT_MB
           value: {{ .Values.agones.extensions.persistentLogsSizeLimitMB | quote }}
 {{- end }}
@@ -167,11 +167,11 @@ spec:
 {{- end }}
         volumeMounts:
         - name: certs
-          mountPath: /home/agones/certs
+          mountPath: /certs
           readOnly: true
 {{- if .Values.agones.extensions.persistentLogs }}
         - name: logs
-          mountPath: /home/agones/logs
+          mountPath: /logs
           readOnly: false
 {{- end }}
       volumes:

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -16448,7 +16448,7 @@ spec:
         - name: CLOUD_PRODUCT
           value: "auto"
         - name: LOG_DIR
-          value: "/home/agones/logs"
+          value: "/logs"
         - name: LOG_SIZE_LIMIT_MB
           value: "10000"
         - name: POD_NAME
@@ -16483,10 +16483,10 @@ spec:
             ephemeral-storage: 10100Mi
         volumeMounts:
         - name: certs
-          mountPath: /home/agones/certs
+          mountPath: /certs
           readOnly: true
         - name: logs
-          mountPath: /home/agones/logs
+          mountPath: /logs
           readOnly: false
       volumes:
       - name: certs
@@ -16587,7 +16587,7 @@ spec:
         - name: CLOUD_PRODUCT
           value: "auto"
         - name: LOG_DIR
-          value: "/home/agones/logs"
+          value: "/logs"
         - name: LOG_SIZE_LIMIT_MB
           value: "10000"
         - name: POD_NAME
@@ -16629,10 +16629,10 @@ spec:
             ephemeral-storage: 10100Mi
         volumeMounts:
         - name: certs
-          mountPath: /home/agones/certs
+          mountPath: /certs
           readOnly: true
         - name: logs
-          mountPath: /home/agones/logs
+          mountPath: /logs
           readOnly: false
       volumes:
       - name: certs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Alpine 3.14 stopped getting security updates back in May of this year, so we needed to update things anyway. Seemed like a good time to move over to the Google supported base container image.

Also since we're always building off distroless' latest image, we don't need to update version numbers to make sure releases always have the latest version, so we always get ongoing security updates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #909

**Special notes for your reviewer**:

Next step to close out #909 would be to update the examples as well (particularly simple-game-server).
