### PR TITLE
Flaky: TestAllocatorAllocatePriority

### DIFF
--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -131,6 +131,10 @@ func TestAllocatorAllocate(t *testing.T) {
 func TestAllocatorAllocatePriority(t *testing.T) {
 	t.Parallel()
 
+	// TODO: remove when `CountsAndLists` feature flag is moved to stable.
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
+
 	run := func(t *testing.T, name string, test func(t *testing.T, a *Allocator, gas *allocationv1.GameServerAllocation)) {
 		f, gsList := defaultFixtures(4)
 		a, m := newFakeAllocator()
@@ -442,6 +446,12 @@ func TestAllocationApplyAllocationError(t *testing.T) {
 }
 
 func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
+	t.Parallel()
+
+	// TODO: remove when `CountsAndLists` feature flag is moved to stable.
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
+
 	a, m := newFakeAllocator()
 
 	_, gsList := defaultFixtures(4)
@@ -491,6 +501,10 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 
 func TestAllocatorRunLocalAllocations(t *testing.T) {
 	t.Parallel()
+
+	// TODO: remove when `CountsAndLists` feature flag is moved to stable.
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
 
 	t.Run("no problems", func(t *testing.T) {
 		f, gsList := defaultFixtures(5)

--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -44,6 +44,10 @@ import (
 func TestAllocatorAllocate(t *testing.T) {
 	t.Parallel()
 
+	// TODO: remove when `CountsAndLists` feature flag is moved to stable.
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
+
 	f, gsList := defaultFixtures(4)
 	a, m := newFakeAllocator()
 	n := metav1.Now()

--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -465,7 +465,7 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 		return true, gs, errors.New("failed to update")
 	})
 
-	ctx, cancel := agtesting.StartInformers(m)
+	ctx, cancel := agtesting.StartInformers(m, a.allocationCache.gameServerSynced)
 	defer cancel()
 
 	require.NoError(t, a.Run(ctx))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Fix a flake that would see a feature flag flip _just_ between `ApplyDefaults()` and `Validate()` -- which is more impressive than anything else.

```
--- FAIL: TestAllocatorAllocatePriority (1.18s)
    allocator_test.go:169:
        	Error Trace:	/go/src/agones.dev/agones/pkg/gameserverallocations/allocator_test.go:169
        	            				/go/src/agones.dev/agones/pkg/gameserverallocations/allocator_test.go:176
        	Error:      	"[spec.selectors[0].counters: Forbidden: Feature CountsAndLists must be enabled spec.selectors[0].lists: Forbidden: Feature CountsAndLists must be enabled]" should have 0 item(s), but has 2
        	Test:       	TestAllocatorAllocatePriority
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

