### PR TITLE
GameServerAllocation to sort Priorities by Allocated Capacity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/joonix/log v0.0.0-20180502111528-d2d3f2f4a806
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/mennanov/fmutils v0.2.0
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -312,6 +312,8 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/pkg/gameserverallocations/allocation_cache.go
+++ b/pkg/gameserverallocations/allocation_cache.go
@@ -285,7 +285,7 @@ func compareGameServers(p *agonesv1.Priority, gs1, gs2 *agonesv1.GameServer) int
 				return 1
 			}
 			if availCapacity1 == availCapacity2 {
-				return 0 // TODO: Should we tie-break on Capacity and/or Count?
+				return 0
 			}
 		}
 		gs1ok = ok1

--- a/pkg/gameserverallocations/allocation_cache.go
+++ b/pkg/gameserverallocations/allocation_cache.go
@@ -262,7 +262,8 @@ func (c *AllocationCache) ListSortedGameServers(gsa *allocationv1.GameServerAllo
 	return list
 }
 
-// compareGameServers compares two game servers based on a CountsAndLists Priority
+// compareGameServers compares two game servers based on a CountsAndLists Priority using available
+// capacity (Capacity - Count for Counters, and Capacity - len(Values) for Lists) as the comparison.
 // Returns -1 if gs1 < gs2; 1 if gs1 > gs2; 0 if gs1 == gs2; 0 if neither gamer server has the Priority.
 // If only one game server has the Priority, prefer that server. I.e. nil < gsX when Priority
 // Order is Descending (3, 2, 1, 0, nil), and nil > gsX when Order is Ascending (0, 1, 2, 3, nil).
@@ -275,14 +276,16 @@ func compareGameServers(p *agonesv1.Priority, gs1, gs2 *agonesv1.GameServer) int
 		counter2, ok2 := gs2.Status.Counters[p.Key]
 		// If both game servers have the Counter
 		if ok1 && ok2 {
-			if counter1.Count < counter2.Count {
+			availCapacity1 := counter1.Capacity - counter1.Count
+			availCapacity2 := counter2.Capacity - counter2.Count
+			if availCapacity1 < availCapacity2 {
 				return -1
 			}
-			if counter1.Count > counter2.Count {
+			if availCapacity1 > availCapacity2 {
 				return 1
 			}
-			if counter1.Count == counter2.Count {
-				return 0
+			if availCapacity1 == availCapacity2 {
+				return 0 // TODO: Should we tie-break on Capacity and/or Count?
 			}
 		}
 		gs1ok = ok1
@@ -293,13 +296,15 @@ func compareGameServers(p *agonesv1.Priority, gs1, gs2 *agonesv1.GameServer) int
 		list2, ok2 := gs2.Status.Lists[p.Key]
 		// If both game servers have the List
 		if ok1 && ok2 {
-			if len(list1.Values) < len(list2.Values) {
+			availCapacity1 := list1.Capacity - int64(len(list1.Values))
+			availCapacity2 := list2.Capacity - int64(len(list2.Values))
+			if availCapacity1 < availCapacity2 {
 				return -1
 			}
-			if len(list1.Values) > len(list2.Values) {
+			if availCapacity1 > availCapacity2 {
 				return 1
 			}
-			if len(list1.Values) == len(list2.Values) {
+			if availCapacity1 == availCapacity2 {
 				return 0
 			}
 		}
@@ -309,13 +314,11 @@ func compareGameServers(p *agonesv1.Priority, gs1, gs2 *agonesv1.GameServer) int
 	// If only one game server has the Priority, prefer that server. I.e. nil < gsX when Order is
 	// Descending (3, 2, 1, 0, nil), and nil > gsX when Order is Ascending (0, 1, 2, 3, nil).
 	if (gs1ok && p.Order == agonesv1.GameServerPriorityDescending) ||
-		(gs1ok && p.Order == "") ||
 		(gs2ok && p.Order == agonesv1.GameServerPriorityAscending) {
 		return 1
 	}
 	if (gs1ok && p.Order == agonesv1.GameServerPriorityAscending) ||
-		(gs2ok && p.Order == agonesv1.GameServerPriorityDescending) ||
-		(gs2ok && p.Order == "") {
+		(gs2ok && p.Order == agonesv1.GameServerPriorityDescending) {
 		return -1
 	}
 	// If neither game server has the Priority

--- a/pkg/gameserverallocations/allocation_cache_test.go
+++ b/pkg/gameserverallocations/allocation_cache_test.go
@@ -57,7 +57,7 @@ func TestAllocationCacheListSortedGameServers(t *testing.T) {
 			Counters: map[string]agonesv1.CounterStatus{
 				"players": {
 					Count:    4,
-					Capacity: 40,
+					Capacity: 40, // Available Capacity == 36
 				},
 			}},
 	}
@@ -69,7 +69,7 @@ func TestAllocationCacheListSortedGameServers(t *testing.T) {
 			Counters: map[string]agonesv1.CounterStatus{
 				"players": {
 					Count:    14,
-					Capacity: 40,
+					Capacity: 40, // Available Capacity == 26
 				},
 			}},
 	}
@@ -154,7 +154,7 @@ func TestAllocationCacheListSortedGameServers(t *testing.T) {
 			},
 			test: func(t *testing.T, list []*agonesv1.GameServer) {
 				assert.Len(t, list, 6)
-				if !assert.Equal(t, []*agonesv1.GameServer{&gs3, &gs6, &gs5, &gs1, &gs2, &gs4}, list) {
+				if !assert.Equal(t, []*agonesv1.GameServer{&gs3, &gs5, &gs6, &gs1, &gs2, &gs4}, list) {
 					for _, gs := range list {
 						logrus.WithField("game", gs.Name).Info("game server")
 					}
@@ -177,7 +177,7 @@ func TestAllocationCacheListSortedGameServers(t *testing.T) {
 			},
 			test: func(t *testing.T, list []*agonesv1.GameServer) {
 				assert.Len(t, list, 6)
-				if !assert.Equal(t, []*agonesv1.GameServer{&gs3, &gs5, &gs6, &gs1, &gs2, &gs4}, list) {
+				if !assert.Equal(t, []*agonesv1.GameServer{&gs3, &gs6, &gs5, &gs1, &gs2, &gs4}, list) {
 					for _, gs := range list {
 						logrus.WithField("game", gs.Name).Info("game server")
 					}
@@ -232,24 +232,24 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 			Lists: map[string]agonesv1.ListStatus{
 				"players": {
 					Values:   []string{"player1"},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 99
 				},
 				"layers": {
 					Values:   []string{"layer1", "layer2", "layer3"},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 97
 				}}}}
 	gs2 := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs2", Namespace: defaultNs, UID: "2"},
 		Status: agonesv1.GameServerStatus{NodeName: "node1", State: agonesv1.GameServerStateReady,
 			Lists: map[string]agonesv1.ListStatus{
 				"players": {
 					Values:   []string{},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 100
 				},
 			},
 			Counters: map[string]agonesv1.CounterStatus{
 				"assets": {
 					Count:    101,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity = 899
 				},
 			}}}
 	gs3 := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs3", Namespace: defaultNs, UID: "3"},
@@ -257,16 +257,16 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 			Lists: map[string]agonesv1.ListStatus{
 				"players": {
 					Values:   []string{"player2", "player3"},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 98
 				}},
 			Counters: map[string]agonesv1.CounterStatus{
 				"sessions": {
 					Count:    9,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity == 991
 				},
 				"assets": {
 					Count:    100,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity == 900
 				},
 			}}}
 	gs4 := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs4", Namespace: defaultNs, UID: "4"},
@@ -274,41 +274,41 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 			Counters: map[string]agonesv1.CounterStatus{
 				"sessions": {
 					Count:    99,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity == 901
 				},
 			},
 			Lists: map[string]agonesv1.ListStatus{
 				"players": {
 					Values:   []string{"player4"},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 99
 				},
 				"layers": {
 					Values:   []string{"layer4, layer5"},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 98
 				}}}}
 	gs5 := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs5", Namespace: defaultNs, UID: "5"},
 		Status: agonesv1.GameServerStatus{NodeName: "node1", State: agonesv1.GameServerStateReady,
 			Counters: map[string]agonesv1.CounterStatus{
 				"sessions": {
 					Count:    9,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity == 991
 				},
 				"assets": {
 					Count:    99,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity == 901
 				},
 			},
 			Lists: map[string]agonesv1.ListStatus{
 				"layers": {
 					Values:   []string{},
-					Capacity: 100,
+					Capacity: 100, // Available Capacity == 100
 				}}}}
 	gs6 := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "gs6", Namespace: defaultNs, UID: "6"},
 		Status: agonesv1.GameServerStatus{NodeName: "node1", State: agonesv1.GameServerStateReady,
 			Counters: map[string]agonesv1.CounterStatus{
 				"sessions": {
 					Count:    999,
-					Capacity: 1000,
+					Capacity: 1000, // Available Capacity == 1
 				},
 			}}}
 
@@ -330,7 +330,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs5, &gs4, &gs6},
+			want: []*agonesv1.GameServer{&gs6, &gs4, &gs5},
 		},
 		"Sort by one Priority Counter Descending": {
 			list: []agonesv1.GameServer{gs4, gs5, gs6},
@@ -345,7 +345,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs6, &gs4, &gs5},
+			want: []*agonesv1.GameServer{&gs5, &gs4, &gs6},
 		},
 		"Sort by two Priority Counter Ascending and Ascending": {
 			list: []agonesv1.GameServer{gs3, gs5, gs6, gs4, gs1, gs2},
@@ -365,7 +365,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs5, &gs3, &gs4, &gs6, &gs2, &gs1},
+			want: []*agonesv1.GameServer{&gs6, &gs4, &gs3, &gs5, &gs2, &gs1},
 		},
 		"Sort by two Priority Counter Ascending and Descending": {
 			list: []agonesv1.GameServer{gs3, gs5, gs6, gs4, gs1, gs2},
@@ -385,7 +385,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs3, &gs5, &gs4, &gs6, &gs2, &gs1},
+			want: []*agonesv1.GameServer{&gs6, &gs4, &gs5, &gs3, &gs2, &gs1},
 		},
 		"Sort by one Priority Counter game server without Counter": {
 			list: []agonesv1.GameServer{gs1, gs5, gs6, gs4},
@@ -400,7 +400,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs5, &gs4, &gs6, &gs1},
+			want: []*agonesv1.GameServer{&gs6, &gs4, &gs5, &gs1},
 		},
 		"Sort by one Priority List Ascending": {
 			list: []agonesv1.GameServer{gs3, gs2, gs1},
@@ -415,7 +415,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs2, &gs1, &gs3},
+			want: []*agonesv1.GameServer{&gs3, &gs1, &gs2},
 		},
 		"Sort by one Priority List Descending": {
 			list: []agonesv1.GameServer{gs3, gs2, gs1},
@@ -430,7 +430,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs3, &gs1, &gs2},
+			want: []*agonesv1.GameServer{&gs2, &gs1, &gs3},
 		},
 		"Sort by two Priority List Descending and Ascending": {
 			list: []agonesv1.GameServer{gs1, gs2, gs3, gs4},
@@ -450,7 +450,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs3, &gs4, &gs1, &gs2},
+			want: []*agonesv1.GameServer{&gs2, &gs1, &gs4, &gs3},
 		},
 		"Sort by two Priority List Descending and Descending": {
 			list: []agonesv1.GameServer{gs6, gs5, gs4, gs3, gs2, gs1},
@@ -470,7 +470,7 @@ func TestAllocationCacheCompareGameServers(t *testing.T) {
 					},
 				},
 			},
-			want: []*agonesv1.GameServer{&gs3, &gs1, &gs4, &gs2, &gs5, &gs6},
+			want: []*agonesv1.GameServer{&gs2, &gs4, &gs1, &gs3, &gs5, &gs6},
 		},
 	}
 

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -4180,1194 +4180,18 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
-</li>
-<li>
-<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
-</li>
-<li>
 <a href="#agones.dev%2fv1">agones.dev/v1</a>
 </li>
 <li>
 <a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
 </li>
+<li>
+<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
+</li>
+<li>
+<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
+</li>
 </ul>
-<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
-</li></ul>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
-</h3>
-<p>
-<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-autoscaling.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>FleetAutoscaler</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
-FleetAutoscalerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>fleetName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Autoscaling policy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sync</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
-FleetAutoscalerSync
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sync defines when FleetAutoscalers runs autoscaling</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
-FleetAutoscalerStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>maxReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
-It must be bigger than both MinReplicas and BufferSize</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>MinReplicas is the minimum amount of replicas that the fleet must have
-If zero, it is ignored.
-If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code></br>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
-Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
-Absolute number is calculated from percentage by rounding up.
-Example: when this is set to 20%, the autoscaler will make sure that 20%
-of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
-the autoscaler will make sure that there are 20 available game servers
-Must be bigger than 0
-Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
-and computation stability in different edge case (fleet just created, not enough
-capacity in the cluster etc)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.CounterPolicy">CounterPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>CounterPolicy controls the desired behavior of the Counter autoscaler policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>key</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Key is the name of the Counter. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxCapacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MaxCapacity is the maximum aggregate Counter total capacity across the fleet.
-MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minCapacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MinCapacity is the minimum aggregate Counter total capacity across the fleet.
-If zero, MinCapacity is ignored.
-If non zero, MinCapacity must be smaller than MaxCapacity and bigger than BufferSize.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code></br>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize is the size of a buffer of counted items that are available in the Fleet (available
-capacity). Value can be an absolute number (ex: 5) or a percentage of desired gs instances
-(ex: 5%). An absolute number is calculated from percentage by rounding up.
-Must be bigger than 0. Required field.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FixedIntervalSync">FixedIntervalSync
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
-</p>
-<p>
-<p>FixedIntervalSync controls the desired behavior of the fixed interval based sync.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>seconds</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Seconds defines how often we run fleet autoscaling in seconds</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
-</p>
-<p>
-<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
-otherwise identical (parallel requests, requests when earlier requests did not modify etc)
-The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
-It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the Fleet being scaled</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Namespace is the namespace associated with the request (if any).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#agones.dev/v1.FleetStatus">
-FleetStatus
-</a>
-</em>
-</td>
-<td>
-<p>The Fleet&rsquo;s status values</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
-</p>
-<p>
-<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<p>UID is an identifier for the individual request/response.
-This should be copied over from the corresponding FleetAutoscaleRequest.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scale</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Set to false if no scaling should occur to the Fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>The targeted replica count</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
-</h3>
-<p>
-<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
-and then returned with a populated Response.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>request</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
-FleetAutoscaleRequest
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>response</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
-FleetAutoscaleResponse
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
-</p>
-<p>
-<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
-FleetAutoscalerPolicyType
-</a>
-</em>
-</td>
-<td>
-<p>Type of autoscaling policy.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>buffer</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.BufferPolicy">
-BufferPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>webhook</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.WebhookPolicy">
-WebhookPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counter</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.CounterPolicy">
-CounterPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:CountsAndLists]
-Counter policy config params. Present only if FleetAutoscalerPolicyType = Counter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>list</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.ListPolicy">
-ListPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:CountsAndLists]
-List policy config params. Present only if FleetAutoscalerPolicyType = List.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>FleetAutoscalerPolicyType is the policy for autoscaling
-for a given Fleet</p>
-</p>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
-</p>
-<p>
-<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>fleetName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Autoscaling policy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sync</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
-FleetAutoscalerSync
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sync defines when FleetAutoscalers runs autoscaling</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
-</p>
-<p>
-<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currentReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>CurrentReplicas is the current number of gameserver replicas
-of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>desiredReplicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>DesiredReplicas is the desired number of gameserver replicas
-of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lastScaleTime</code></br>
-<em>
-<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ableToScale</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>AbleToScale indicates that we can access the target fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scalingLimited</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>ScalingLimited indicates that the calculated scale would be above or below the range
-defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
-</p>
-<p>
-<p>FleetAutoscalerSync describes when to sync a fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSyncType">
-FleetAutoscalerSyncType
-</a>
-</em>
-</td>
-<td>
-<p>Type of autoscaling sync.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>fixedInterval</code></br>
-<em>
-<a href="#autoscaling.agones.dev/v1.FixedIntervalSync">
-FixedIntervalSync
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FixedInterval config params. Present only if FleetAutoscalerSyncType = FixedInterval.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSyncType">FleetAutoscalerSyncType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
-</p>
-<p>
-<p>FleetAutoscalerSyncType is the sync strategy for a given Fleet</p>
-</p>
-<h3 id="autoscaling.agones.dev/v1.ListPolicy">ListPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>ListPolicy controls the desired behavior of the List autoscaler policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>key</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Key is the name of the List. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxCapacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MaxCapacity is the maximum aggregate List total capacity across the fleet.
-MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minCapacity</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MinCapacity is the minimum aggregate List total capacity across the fleet.
-If zero, it is ignored.
-If non zero, it must be smaller than MaxCapacity and bigger than BufferSize.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code></br>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize is the size of a buffer based on the List capacity that is available over the
-current aggregate List length in the Fleet (available capacity). It can be specified either
-as an absolute value (i.e. 5) or percentage format (i.e. 5%).
-Must be bigger than 0. Required field.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.WebhookPolicy">WebhookPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>WebhookPolicy controls the desired behavior of the webhook policy.
-It contains the description of the webhook autoscaler service
-used to form url which is accessible inside the cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>url</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>url</code> gives the location of the webhook, in standard URL form
-(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
-must be specified.</p>
-<p>The <code>host</code> should not refer to a service running in the cluster; use
-the <code>service</code> field instead. The host might be resolved via external
-DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
-in-cluster DNS as that would be a layering violation). <code>host</code> may
-also be an IP address.</p>
-<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
-risky unless you take great care to run this webhook on all hosts
-which run an apiserver which might need to make calls to this
-webhook. Such installs are likely to be non-portable, i.e., not easy
-to turn up in a new cluster.</p>
-<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
-<p>A path is optional, and if present may be any string permissible in
-a URL. You may use the path to pass an arbitrary string to the
-webhook, for example, a cluster identifier.</p>
-<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
-allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
-allowed, either.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>service</code></br>
-<em>
-<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#servicereference-v1-admissionregistration">
-Kubernetes admissionregistration/v1.ServiceReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>service</code> is a reference to the service for this webhook. Either
-<code>service</code> or <code>url</code> must be specified.</p>
-<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caBundle</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
-If unspecified, system trust roots on the apiserver are used.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
-</li></ul>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
-</h3>
-<p>
-<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-multicluster.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GameServerAllocationPolicy</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
-GameServerAllocationPolicySpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>priority</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
-</p>
-<p>
-<p>ClusterConnectionInfo defines the connection information for a cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>clusterName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Optional: the name of the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationEndpoints</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>The endpoints for the allocator service in the targeted cluster.
-If the AllocationEndpoints is not set, the allocation happens on local cluster.
-If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The cluster namespace from which to allocate gameservers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serverCa</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
-</h3>
-<p>
-<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currPriority</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-<p>currPriority Current priority index from the orderedPriorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>orderedPriorities</code></br>
-<em>
-[]int32
-</em>
-</td>
-<td>
-<p>orderedPriorities list of ordered priorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorityToCluster</code></br>
-<em>
-map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
-</em>
-</td>
-<td>
-<p>priorityToCluster Map of priority to cluster-policies map</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>clusterBlackList</code></br>
-<em>
-map[string]bool
-</em>
-</td>
-<td>
-<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
-</p>
-<p>
-<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>priority</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code></br>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code></br>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="agones.dev/v1">agones.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
@@ -7640,8 +6464,8 @@ This is useful for things like smoke testing of new game servers.</p>
 <em>(Optional)</em>
 <p>(Alpha, CountsAndLists feature flag) The first Priority on the array of Priorities is the most
 important for sorting. The allocator will use the first priority for sorting GameServers by
-available Capacity in the Selector set and acts as a tie-breaker after sorting the game servers
-by State and Strategy. Impacts which GameServer is checked first.</p>
+available Capacity in the Selector set. Acts as a tie-breaker after sorting the game servers
+by State and Strategy Packed. Impacts which GameServer is checked first.</p>
 </td>
 </tr>
 <tr>
@@ -7918,8 +6742,8 @@ This is useful for things like smoke testing of new game servers.</p>
 <em>(Optional)</em>
 <p>(Alpha, CountsAndLists feature flag) The first Priority on the array of Priorities is the most
 important for sorting. The allocator will use the first priority for sorting GameServers by
-available Capacity in the Selector set and acts as a tie-breaker after sorting the game servers
-by State and Strategy. Impacts which GameServer is checked first.</p>
+available Capacity in the Selector set. Acts as a tie-breaker after sorting the game servers
+by State and Strategy Packed. Impacts which GameServer is checked first.</p>
 </td>
 </tr>
 <tr>
@@ -8446,6 +7270,1182 @@ int64
 <code>maxAvailable</code></br>
 <em>
 int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
+</li></ul>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
+</h3>
+<p>
+<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+autoscaling.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>FleetAutoscaler</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
+FleetAutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sync</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
+FleetAutoscalerSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sync defines when FleetAutoscalers runs autoscaling</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
+FleetAutoscalerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
+It must be bigger than both MinReplicas and BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MinReplicas is the minimum amount of replicas that the fleet must have
+If zero, it is ignored.
+If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code></br>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
+Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
+Absolute number is calculated from percentage by rounding up.
+Example: when this is set to 20%, the autoscaler will make sure that 20%
+of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
+the autoscaler will make sure that there are 20 available game servers
+Must be bigger than 0
+Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
+and computation stability in different edge case (fleet just created, not enough
+capacity in the cluster etc)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.CounterPolicy">CounterPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>CounterPolicy controls the desired behavior of the Counter autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key is the name of the Counter. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCapacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MaxCapacity is the maximum aggregate Counter total capacity across the fleet.
+MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minCapacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MinCapacity is the minimum aggregate Counter total capacity across the fleet.
+If zero, MinCapacity is ignored.
+If non zero, MinCapacity must be smaller than MaxCapacity and bigger than BufferSize.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code></br>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize is the size of a buffer of counted items that are available in the Fleet (available
+capacity). Value can be an absolute number (ex: 5) or a percentage of desired gs instances
+(ex: 5%). An absolute number is calculated from percentage by rounding up.
+Must be bigger than 0. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FixedIntervalSync">FixedIntervalSync
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
+</p>
+<p>
+<p>FixedIntervalSync controls the desired behavior of the fixed interval based sync.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>seconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Seconds defines how often we run fleet autoscaling in seconds</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
+It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the Fleet being scaled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace associated with the request (if any).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+<p>The Fleet&rsquo;s status values</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response.
+This should be copied over from the corresponding FleetAutoscaleRequest.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scale</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Set to false if no scaling should occur to the Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>The targeted replica count</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
+</h3>
+<p>
+<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
+and then returned with a populated Response.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>request</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
+FleetAutoscaleRequest
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>response</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
+FleetAutoscaleResponse
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buffer</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.BufferPolicy">
+BufferPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhook</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.WebhookPolicy">
+WebhookPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counter</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.CounterPolicy">
+CounterPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:CountsAndLists]
+Counter policy config params. Present only if FleetAutoscalerPolicyType = Counter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>list</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.ListPolicy">
+ListPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:CountsAndLists]
+List policy config params. Present only if FleetAutoscalerPolicyType = List.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicyType is the policy for autoscaling
+for a given Fleet</p>
+</p>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sync</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
+FleetAutoscalerSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sync defines when FleetAutoscalers runs autoscaling</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>CurrentReplicas is the current number of gameserver replicas
+of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>desiredReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredReplicas is the desired number of gameserver replicas
+of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScaleTime</code></br>
+<em>
+<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ableToScale</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>AbleToScale indicates that we can access the target fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scalingLimited</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ScalingLimited indicates that the calculated scale would be above or below the range
+defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+</p>
+<p>
+<p>FleetAutoscalerSync describes when to sync a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSyncType">
+FleetAutoscalerSyncType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling sync.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>fixedInterval</code></br>
+<em>
+<a href="#autoscaling.agones.dev/v1.FixedIntervalSync">
+FixedIntervalSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FixedInterval config params. Present only if FleetAutoscalerSyncType = FixedInterval.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSyncType">FleetAutoscalerSyncType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
+</p>
+<p>
+<p>FleetAutoscalerSyncType is the sync strategy for a given Fleet</p>
+</p>
+<h3 id="autoscaling.agones.dev/v1.ListPolicy">ListPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>ListPolicy controls the desired behavior of the List autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key is the name of the List. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCapacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MaxCapacity is the maximum aggregate List total capacity across the fleet.
+MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minCapacity</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MinCapacity is the minimum aggregate List total capacity across the fleet.
+If zero, it is ignored.
+If non zero, it must be smaller than MaxCapacity and bigger than BufferSize.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code></br>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize is the size of a buffer based on the List capacity that is available over the
+current aggregate List length in the Fleet (available capacity). It can be specified either
+as an absolute value (i.e. 5) or percentage format (i.e. 5%).
+Must be bigger than 0. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.WebhookPolicy">WebhookPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>WebhookPolicy controls the desired behavior of the webhook policy.
+It contains the description of the webhook autoscaler service
+used to form url which is accessible inside the cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>url</code> gives the location of the webhook, in standard URL form
+(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
+must be specified.</p>
+<p>The <code>host</code> should not refer to a service running in the cluster; use
+the <code>service</code> field instead. The host might be resolved via external
+DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
+in-cluster DNS as that would be a layering violation). <code>host</code> may
+also be an IP address.</p>
+<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
+risky unless you take great care to run this webhook on all hosts
+which run an apiserver which might need to make calls to this
+webhook. Such installs are likely to be non-portable, i.e., not easy
+to turn up in a new cluster.</p>
+<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
+<p>A path is optional, and if present may be any string permissible in
+a URL. You may use the path to pass an arbitrary string to the
+webhook, for example, a cluster identifier.</p>
+<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
+allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
+allowed, either.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>service</code></br>
+<em>
+<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#servicereference-v1-admissionregistration">
+Kubernetes admissionregistration/v1.ServiceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>service</code> is a reference to the service for this webhook. Either
+<code>service</code> or <code>url</code> must be specified.</p>
+<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caBundle</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
+If unspecified, system trust roots on the apiserver are used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
+</li></ul>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
+</h3>
+<p>
+<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+multicluster.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerAllocationPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
+GameServerAllocationPolicySpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>priority</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
+</p>
+<p>
+<p>ClusterConnectionInfo defines the connection information for a cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clusterName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Optional: the name of the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationEndpoints</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The endpoints for the allocator service in the targeted cluster.
+If the AllocationEndpoints is not set, the allocation happens on local cluster.
+If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The cluster namespace from which to allocate gameservers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverCa</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
+</h3>
+<p>
+<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currPriority</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>currPriority Current priority index from the orderedPriorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>orderedPriorities</code></br>
+<em>
+[]int32
+</em>
+</td>
+<td>
+<p>orderedPriorities list of ordered priorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorityToCluster</code></br>
+<em>
+map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
+</em>
+</td>
+<td>
+<p>priorityToCluster Map of priority to cluster-policies map</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterBlackList</code></br>
+<em>
+map[string]bool
+</em>
+</td>
+<td>
+<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
+</p>
+<p>
+<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>priority</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code></br>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
 </em>
 </td>
 <td>

--- a/vendor/github.com/mitchellh/hashstructure/v2/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/v2/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/v2/README.md
@@ -1,0 +1,76 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally, specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+
+  * Optionally, hash the output of `.String()` on structs that implement fmt.Stringer,
+    allowing effective hashing of time.Time
+
+  * Optionally, override the hashing process by implementing `Hashable`.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure/v2
+```
+
+**Note on v2:** It is highly recommended you use the "v2" release since this
+fixes some significant hash collisions issues from v1. In practice, we used
+v1 for many years in real projects at HashiCorp and never had issues, but it
+is highly dependent on the shape of the data you're hashing and how you use
+those hashes.
+
+When using v2+, you can still generate weaker v1 hashes by using the
+`FormatV1` format when calling `Hash`.
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, hashstructure.FormatV2, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/v2/errors.go
+++ b/vendor/github.com/mitchellh/hashstructure/v2/errors.go
@@ -1,0 +1,22 @@
+package hashstructure
+
+import (
+	"fmt"
+)
+
+// ErrNotStringer is returned when there's an error with hash:"string"
+type ErrNotStringer struct {
+	Field string
+}
+
+// Error implements error for ErrNotStringer
+func (ens *ErrNotStringer) Error() string {
+	return fmt.Sprintf("hashstructure: %s has hash:\"string\" set, but does not implement fmt.Stringer", ens.Field)
+}
+
+// ErrFormat is returned when an invalid format is given to the Hash function.
+type ErrFormat struct{}
+
+func (*ErrFormat) Error() string {
+	return "format must be one of the defined Format values in the hashstructure library"
+}

--- a/vendor/github.com/mitchellh/hashstructure/v2/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/v2/hashstructure.go
@@ -1,0 +1,482 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+	"time"
+)
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+
+	// IgnoreZeroValue is determining if zero value fields should be
+	// ignored for hash calculation.
+	IgnoreZeroValue bool
+
+	// SlicesAsSets assumes that a `set` tag is always present for slices.
+	// Default is false (in which case the tag is used instead)
+	SlicesAsSets bool
+
+	// UseStringer will attempt to use fmt.Stringer always. If the struct
+	// doesn't implement fmt.Stringer, it'll fall back to trying usual tricks.
+	// If this is true, and the "string" tag is also set, the tag takes
+	// precedence (meaning that if the type doesn't implement fmt.Stringer, we
+	// panic)
+	UseStringer bool
+}
+
+// Format specifies the hashing process used. Different formats typically
+// generate different hashes for the same value and have different properties.
+type Format uint
+
+const (
+	// To disallow the zero value
+	formatInvalid Format = iota
+
+	// FormatV1 is the format used in v1.x of this library. This has the
+	// downsides noted in issue #18 but allows simultaneous v1/v2 usage.
+	FormatV1
+
+	// FormatV2 is the current recommended format and fixes the issues
+	// noted in FormatV1.
+	FormatV2
+
+	formatMax // so we can easily find the end
+)
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are
+// safe to read/write while hashing is being done.
+//
+// The "format" is required and must be one of the format values defined
+// by this library. You should probably just use "FormatV2". This allows
+// generated hashes uses alternate logic to maintain compatibility with
+// older versions.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+//   * "string" - The field will be hashed as a string, only works when the
+//                field implements fmt.Stringer
+//
+func Hash(v interface{}, format Format, opts *HashOptions) (uint64, error) {
+	// Validate our format
+	if format <= formatInvalid || format >= formatMax {
+		return 0, &ErrFormat{}
+	}
+
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		format:          format,
+		h:               opts.Hasher,
+		tag:             opts.TagName,
+		zeronil:         opts.ZeroNil,
+		ignorezerovalue: opts.IgnoreZeroValue,
+		sets:            opts.SlicesAsSets,
+		stringer:        opts.UseStringer,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	format          Format
+	h               hash.Hash64
+	tag             string
+	zeronil         bool
+	ignorezerovalue bool
+	sets            bool
+	stringer        bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+var timeType = reflect.TypeOf(time.Time{})
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch v.Type() {
+	case timeType:
+		w.h.Reset()
+		b, err := v.Interface().(time.Time).MarshalBinary()
+		if err != nil {
+			return 0, err
+		}
+
+		err = binary.Write(w.h, binary.LittleEndian, b)
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		if w.format != FormatV1 {
+			// Important: read the docs for hashFinishUnordered
+			h = hashFinishUnordered(w.h, h)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		parent := v.Interface()
+		var include Includable
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		if impl, ok := parent.(Hashable); ok {
+			return impl.Hash()
+		}
+
+		// If we can address this value, check if the pointer value
+		// implements our interfaces and use that if so.
+		if v.CanAddr() {
+			vptr := v.Addr()
+			parentptr := vptr.Interface()
+			if impl, ok := parentptr.(Includable); ok {
+				include = impl
+			}
+
+			if impl, ok := parentptr.(Hashable); ok {
+				return impl.Hash()
+			}
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if innerV := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				if w.ignorezerovalue {
+					if innerV.IsZero() {
+						continue
+					}
+				}
+
+				// if string is set, use the string value
+				if tag == "string" || w.stringer {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+					} else if tag == "string" {
+						// We only show this error if the tag explicitly
+						// requests a stringer.
+						return 0, &ErrNotStringer{
+							Field: v.Type().Field(i).Name,
+						}
+					}
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(innerV, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+
+			if w.format != FormatV1 {
+				// Important: read the docs for hashFinishUnordered
+				h = hashFinishUnordered(w.h, h)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set || w.sets {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		if set && w.format != FormatV1 {
+			// Important: read the docs for hashFinishUnordered
+			h = hashFinishUnordered(w.h, h)
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// After mixing a group of unique hashes with hashUpdateUnordered, it's always
+// necessary to call hashFinishUnordered. Why? Because hashUpdateUnordered
+// is a simple XOR, and calling hashUpdateUnordered on hashes produced by
+// hashUpdateUnordered can effectively cancel out a previous change to the hash
+// result if the same hash value appears later on. For example, consider:
+//
+//   hashUpdateUnordered(hashUpdateUnordered("A", "B"), hashUpdateUnordered("A", "C")) =
+//   H("A") ^ H("B")) ^ (H("A") ^ H("C")) =
+//   (H("A") ^ H("A")) ^ (H("B") ^ H(C)) =
+//   H(B) ^ H(C) =
+//   hashUpdateUnordered(hashUpdateUnordered("Z", "B"), hashUpdateUnordered("Z", "C"))
+//
+// hashFinishUnordered "hardens" the result, so that encountering partially
+// overlapping input data later on in a different context won't cancel out.
+func hashFinishUnordered(h hash.Hash64, a uint64) uint64 {
+	h.Reset()
+
+	// We just panic if the writes fail
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	if e1 != nil {
+		panic(e1)
+	}
+
+	return h.Sum64()
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/v2/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/v2/include.go
@@ -1,0 +1,22 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}
+
+// Hashable is an interface that can optionally be implemented by a struct
+// to override the hash value. This value will override the hash value for
+// the entire struct. Entries in the struct will not be hashed.
+type Hashable interface {
+	Hash() (uint64, error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,6 +243,9 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mennanov/fmutils v0.2.0
 ## explicit; go 1.15
 github.com/mennanov/fmutils
+# github.com/mitchellh/hashstructure/v2 v2.0.2
+## explicit; go 1.14
+github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/mapstructure v1.4.1
 ## explicit; go 1.14
 github.com/mitchellh/mapstructure


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / Why we need it**:

Updates GameServerAllocation to sort by Allocated Capacity when sorting by Priorities.

Adds in a SortKey for GameServerAllocation Priorities  to differentiate between requests with different priorities and / or scheduling during  ListenAndAllocate.

Removes a duplicate import of k8s.io/apimachinery/pkg/api/validation.


**Which issue(s) this PR fixes**:

Working on #2716

**Special notes for your reviewer**:


