### PR TITLE
[Helm Chart] Only enable service monitor relabelings for prometheus scrape when prometheusServiceDiscovery is enabled

### DIFF
--- a/install/helm/agones/templates/service-monitor.yaml
+++ b/install/helm/agones/templates/service-monitor.yaml
@@ -35,20 +35,6 @@ spec:
       path: /metrics
       interval: {{ .Values.agones.metrics.serviceMonitor.interval }}
       relabelings:
-{{- if (.Values.agones.metrics.prometheusServiceDiscovery) }}
-        - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: "true"
-        - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          targetLabel: __metrics_path__
-          regex: (.+)
-        - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          targetLabel: __address__
-{{- end }}
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
         - sourceLabels: [__meta_kubernetes_namespace]

--- a/install/helm/agones/templates/service-monitor.yaml
+++ b/install/helm/agones/templates/service-monitor.yaml
@@ -35,6 +35,7 @@ spec:
       path: /metrics
       interval: {{ .Values.agones.metrics.serviceMonitor.interval }}
       relabelings:
+{{- if and (.Values.agones.metrics.prometheusServiceDiscovery) (.Values.agones.metrics.prometheusEnabled) }}
         - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
           regex: "true"
@@ -47,6 +48,7 @@ spec:
           regex: ([^:]+)(?::\d+)?;(\d+)
           replacement: $1:$2
           targetLabel: __address__
+{{- end }}
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
         - sourceLabels: [__meta_kubernetes_namespace]

--- a/install/helm/agones/templates/service-monitor.yaml
+++ b/install/helm/agones/templates/service-monitor.yaml
@@ -35,7 +35,7 @@ spec:
       path: /metrics
       interval: {{ .Values.agones.metrics.serviceMonitor.interval }}
       relabelings:
-{{- if and (.Values.agones.metrics.prometheusServiceDiscovery) (.Values.agones.metrics.prometheusEnabled) }}
+{{- if (.Values.agones.metrics.prometheusServiceDiscovery) }}
         - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
           regex: "true"


### PR DESCRIPTION
Only enable service monitor relabelings for prometheus scrape when prometheusServiceDiscovery is enabled

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
This is a fix for the helm chart install. When the service monitor is used and `prometheusServiceDiscovery` is set to `false` (it's `true` by default) there is no need for the prometheus scrape relabelings on the service monitor resource, this PR ensures that the prometheus scrape relabelings are only enabled when `prometheusServiceDiscovery` is `true`

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I also had an issue with `install/helm/agones/templates/extensions-deployment.yaml` requiring the `mountPath` to be changed, but that may have been a side effect of using an incompatible image while testing:
```
         volumeMounts:
         - name: certs
-          mountPath: /certs
+          mountPath: /home/agones/certs
           readOnly: true
```

