### PR TITLE
APIService: Updates to handlers for 1.27.x

### DIFF
--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -233,7 +233,6 @@ func TestControllerSyncGameServerWithDevIP(t *testing.T) {
 		gsFixture.ApplyDefaults()
 		gsFixture.Status.State = agonesv1.GameServerStateRequestReady
 
-
 		mocks.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			gameServers := &agonesv1.GameServerList{Items: []agonesv1.GameServer{*gsFixture}}
 			return true, gameServers, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

This includes a bug fix for the issue outlined in
https://github.com/kubernetes/kubernetes/issues/119662, specifically returning HTTP 406 for root /apis for all requests.

Also included an empty OpenAPI v3 discovery document to `/openapi/v3` to stop the regular requests from the K8s control plane, while also bringing the implementation for `/openapi/v2` to be consistent with the new one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #3172

**Special notes for your reviewer**:

Snuck in a linter fix as well.
