### PR TITLE
feat: discard disconnected game server streams

### DIFF
--- a/pkg/sdkserver/helper_test.go
+++ b/pkg/sdkserver/helper_test.go
@@ -98,12 +98,14 @@ func (m *emptyMockStream) RecvMsg(msg interface{}) error {
 }
 
 type gameServerMockStream struct {
+	ctx  context.Context
 	msgs chan *sdk.GameServer
 }
 
 // newGameServerMockStream implements SDK_WatchGameServerServer for testing
 func newGameServerMockStream() *gameServerMockStream {
 	return &gameServerMockStream{
+		ctx:  context.Background(),
 		msgs: make(chan *sdk.GameServer, 10),
 	}
 }
@@ -125,8 +127,8 @@ func (*gameServerMockStream) SetTrailer(metadata.MD) {
 	panic("implement me")
 }
 
-func (*gameServerMockStream) Context() netcontext.Context {
-	panic("implement me")
+func (m *gameServerMockStream) Context() netcontext.Context {
+	return m.ctx
 }
 
 func (*gameServerMockStream) SendMsg(m interface{}) error {

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -795,6 +795,65 @@ func TestSDKServerSendGameServerUpdate(t *testing.T) {
 	assert.Equal(t, fixture.ObjectMeta.Name, sdkGS.ObjectMeta.Name)
 }
 
+func TestSDKServer_SendGameServerUpdateRemovesDisconnectedStream(t *testing.T) {
+	t.Parallel()
+
+	fixture := &agonesv1.GameServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Status: agonesv1.GameServerStatus{
+			State: agonesv1.GameServerStateReady,
+		},
+	}
+
+	m := agtesting.NewMocks()
+	fakeWatch := watch.NewFake()
+	m.AgonesClient.AddWatchReactor("gameservers", k8stesting.DefaultWatchReactor(fakeWatch, nil))
+	sc, err := defaultSidecar(m)
+	require.NoError(t, err)
+	assert.Empty(t, sc.connectedStreams)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sc.ctx = ctx
+	sc.informerFactory.Start(ctx.Done())
+
+	fakeWatch.Add(fixture.DeepCopy())
+	assert.True(t, cache.WaitForCacheSync(ctx.Done(), sc.gameServerSynced))
+	sc.gsWaitForSync.Done()
+
+	// Wait for the GameServer to be populated, as we can't rely on WaitForCacheSync.
+	require.Eventually(t, func() bool {
+		_, err := sc.gameServer()
+		return err == nil
+	}, time.Minute, time.Second, "Could not find the GameServer")
+
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	t.Cleanup(streamCancel)
+
+	// Trigger stream removal by sending an update on a cancelled stream.
+
+	stream := newGameServerMockStream()
+	stream.ctx = streamCtx
+
+	asyncWatchGameServer(t, sc, stream)
+	assert.Nil(t, waitConnectedStreamCount(sc, 1))
+
+	<-stream.msgs // Initial msg when WatchGameServer() is called.
+
+	streamCancel()
+
+	sc.sendGameServerUpdate(fixture)
+
+	select {
+	case <-stream.msgs:
+		assert.Fail(t, "Event stream should have been removed.")
+	case <-time.After(1 * time.Second):
+	}
+}
+
 func TestSDKServerUpdateEventHandler(t *testing.T) {
 	t.Parallel()
 	fixture := &agonesv1.GameServer{

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -1604,7 +1604,7 @@ func waitForMessage(sc *SDKServer) error {
 	})
 }
 
-func waitConnectedStreamCount(sc *SDKServer, count int) error {
+func waitConnectedStreamCount(sc *SDKServer, count int) error { //nolint:unparam // Keep flexibility.
 	return wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
 		sc.streamMutex.RLock()
 		defer sc.streamMutex.RUnlock()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

This PR adds the ability for the SDK server to remove closed streams and only log once when a closed stream is found.
GRPC streams take a context, which is forwarded by the SDK, and when that context is cancelled, currently the SDK server starts logging repeatedly about the connection being closed.
With the changes from this pull request, what happens instead is that when a closed stream is found, an error is logged and it is then removed from the `connectedStreams` slice.
In order to know whether the stream is closed, we check the status of the `stream.Context()`.

Unit tests are updated to cover all relevant cases due to the changes in this PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Fixes #3327 

**Special notes for your reviewer**:

The unit test is a copy&paste from the above test, just with an adjustment to test the removal of the stream.

This MR was also tested with a new build image for the sidecar, applied via agones-controller in Kubernetes.
The game server called the sidecar's WatchGameServer, and later cancelled the connection.

The fix reported the context cancellation once and removed the stream from the connected streams.

No more error reports.
