### PR TITLE
Verify gen-all-sdk-grpc has run

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -216,3 +216,19 @@ sdk-shell-csharp:
 sdk-publish-csharp: RELEASE_VERSION ?= $(base_version)
 sdk-publish-csharp:
 	$(MAKE) run-sdk-command-csharp COMMAND=publish VERSION=$(RELEASE_VERSION) DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS) -it"
+
+# difference in sdks before and after gen-all-sdk-grpc target
+test-gen-all-sdk-grpc:
+	make gen-all-sdk-grpc
+	@echo; \
+	echo "=== Diffing workspace after 'make gen-all-sdk-grpc'"; \
+	diff_output=$$(git diff --name-status HEAD -- ../sdks); \
+	diff_output_test_sdk=$$(git diff --name-status HEAD -- ../test/sdk); \
+	if [ -z "$$diff_output" ] && [ -z "$$diff_output_test_sdk" ]; then \
+		echo "+++ Success: No differences found."; \
+	else \
+		echo "*** Failure: Differences found:"; \
+		echo "$$diff_output"; \
+		echo "$$diff_output_test_sdk"; \
+		exit 1; \
+	fi

--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -181,10 +181,11 @@ run-sdk-conformance-test-rust:
 	DOCKER_RUN_ARGS="$(DOCKER_RUN_ARGS) -e RUN_ASYNC=true" $(MAKE) run-sdk-conformance-test SDK_FOLDER=rust GRPC_PORT=9004 HTTP_PORT=9104 FEATURE_GATES=PlayerTracking=true TESTS=$(DEFAULT_CONFORMANCE_TESTS),$(ALPHA_CONFORMANCE_TESTS)
 
 run-sdk-conformance-test-rest:
+	# (note: the restapi folder doesn't use GRPC_PORT but run-sdk-conformance-no-build defaults it, so we supply a unique value here)
 	# run without feature flags
-	$(MAKE) run-sdk-conformance-test SDK_FOLDER=restapi HTTP_PORT=9050
+	$(MAKE) run-sdk-conformance-test SDK_FOLDER=restapi GRPC_PORT=9050 HTTP_PORT=9150
 	# run with feature flags enabled
-	$(MAKE) run-sdk-conformance-test SDK_FOLDER=restapi GRPC_PORT=9001 HTTP_PORT=9101 FEATURE_GATES=PlayerTracking=true TESTS=$(DEFAULT_CONFORMANCE_TESTS),$(ALPHA_CONFORMANCE_TESTS)
+	$(MAKE) run-sdk-conformance-test SDK_FOLDER=restapi GRPC_PORT=9050 HTTP_PORT=9150 FEATURE_GATES=PlayerTracking=true TESTS=$(DEFAULT_CONFORMANCE_TESTS),$(ALPHA_CONFORMANCE_TESTS)
 
 	$(MAKE) run-sdk-command COMMAND=clean SDK_FOLDER=restapi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -116,6 +116,16 @@ steps:
   args: ["ensure-build-sdk-image-base"]
 
 #
+# Preventing SDKs failure in CI
+#
+- name: "make-docker"
+  id: test-gen-all-sdk-grpc
+  waitFor:
+    - ensure-build-sdk-image-base
+  dir: "build"
+  args: ["test-gen-all-sdk-grpc"]
+
+#
 # Preventing Broken PR Merges in CI
 #
 - name: "make-docker"
@@ -134,6 +144,7 @@ steps:
   waitFor:
     - pull-build-image
     - test-gen-crd-client
+    - test-gen-all-sdk-grpc
   dir: "build"
   args: ["lint"] # pull the build image if it exists
 


### PR DESCRIPTION
Adds a build step to verify that `make gen-all-sdk-grpc` has run.

Credit to @Kalaiselvi84 for original #3310

Sample output:
```
=== Diffing workspace after 'make gen-all-sdk-grpc'
*** Failure: Differences found:
D    sdks/rust/proto/allocation/allocation.proto
D    sdks/rust/proto/googleapis/google/api/annotations.proto
D    sdks/rust/proto/googleapis/google/api/client.proto
D    sdks/rust/proto/googleapis/google/api/field_behavior.proto
D    sdks/rust/proto/googleapis/google/api/http.proto
D    sdks/rust/proto/googleapis/google/api/launch_stage.proto
D    sdks/rust/proto/googleapis/google/api/resource.proto
D    sdks/rust/proto/grpc-gateway/LICENSE.txt
D    sdks/rust/proto/grpc-gateway/protoc-gen-openapiv2/options/annotations.proto
D    sdks/rust/proto/grpc-gateway/protoc-gen-openapiv2/options/openapiv2.proto
D    sdks/rust/proto/sdk/alpha/alpha.proto
D    sdks/rust/proto/sdk/beta/beta.proto
D    sdks/rust/proto/sdk/sdk.proto
```

(Note this sample output was also what happens when I just run this
check on my desktop because the `rust` generation spews files as root.)

Along the way: Subsume #3348: Move the restapi folder GRPC_PORT off of the same port as the go folder tests. (In case it's not clear on review, the problem is the second invocation where we set GRPC_PORT to 9001, which is the same as the go folder.)

