### PR TITLE
restapi generation: clean before generation so we don't leak files

### DIFF
--- a/build/boilerplate.go.txt
+++ b/build/boilerplate.go.txt
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/boilerplate.yaml.txt
+++ b/build/boilerplate.yaml.txt
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC All Rights Reserved.
+# Copyright 2023 Google LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-sdk-images/restapi/gen.sh
+++ b/build/build-sdk-images/restapi/gen.sh
@@ -19,6 +19,8 @@ header() {
 }
 
 wget -q https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.35/swagger-codegen-cli-3.0.35.jar -O /tmp/swagger-codegen-cli.jar
+
+rm -rf /go/src/agones.dev/agones/test/sdk/restapi/swagger /go/src/agones.dev/agones/test/sdk/restapi/alpha/swagger
 java -jar /tmp/swagger-codegen-cli.jar generate -i /go/src/agones.dev/agones/sdks/swagger/sdk.swagger.json  -l go -o /go/src/agones.dev/agones/test/sdk/restapi/swagger
 java -jar /tmp/swagger-codegen-cli.jar generate -i /go/src/agones.dev/agones/sdks/swagger/alpha.swagger.json  -l go -o /go/src/agones.dev/agones/test/sdk/restapi/alpha/swagger
 

--- a/pkg/sdk/alpha/alpha.pb.go
+++ b/pkg/sdk/alpha/alpha.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/alpha/alpha.pb.gw.go
+++ b/pkg/sdk/alpha/alpha.pb.gw.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/alpha/alpha_grpc.pb.go
+++ b/pkg/sdk/alpha/alpha_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/beta/beta.pb.go
+++ b/pkg/sdk/beta/beta.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/beta/beta_grpc.pb.go
+++ b/pkg/sdk/beta/beta_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/sdk.pb.go
+++ b/pkg/sdk/sdk.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/sdk.pb.gw.go
+++ b/pkg/sdk/sdk.pb.gw.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sdk/sdk_grpc.pb.go
+++ b/pkg/sdk/sdk_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/agones/sdk.grpc.pb.h
+++ b/sdks/cpp/include/agones/sdk.grpc.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/agones/sdk.pb.h
+++ b/sdks/cpp/include/agones/sdk.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/google/api/annotations.pb.h
+++ b/sdks/cpp/include/google/api/annotations.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/google/api/http.pb.h
+++ b/sdks/cpp/include/google/api/http.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/protoc-gen-openapiv2/options/annotations.pb.h
+++ b/sdks/cpp/include/protoc-gen-openapiv2/options/annotations.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/protoc-gen-openapiv2/options/openapiv2.pb.h
+++ b/sdks/cpp/include/protoc-gen-openapiv2/options/openapiv2.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/agones/sdk.grpc.pb.cc
+++ b/sdks/cpp/src/agones/sdk.grpc.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/agones/sdk.pb.cc
+++ b/sdks/cpp/src/agones/sdk.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/google/annotations.pb.cc
+++ b/sdks/cpp/src/google/annotations.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/google/http.pb.cc
+++ b/sdks/cpp/src/google/http.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/protoc-gen-openapiv2/annotations.pb.cc
+++ b/sdks/cpp/src/protoc-gen-openapiv2/annotations.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/protoc-gen-openapiv2/openapiv2.pb.cc
+++ b/sdks/cpp/src/protoc-gen-openapiv2/openapiv2.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/csharp/sdk/generated/Alpha.cs
+++ b/sdks/csharp/sdk/generated/Alpha.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/csharp/sdk/generated/AlphaGrpc.cs
+++ b/sdks/csharp/sdk/generated/AlphaGrpc.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/csharp/sdk/generated/Sdk.cs
+++ b/sdks/csharp/sdk/generated/Sdk.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/csharp/sdk/generated/SdkGrpc.cs
+++ b/sdks/csharp/sdk/generated/SdkGrpc.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/alpha/alpha_grpc_pb.js
+++ b/sdks/nodejs/lib/alpha/alpha_grpc_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/alpha/alpha_pb.js
+++ b/sdks/nodejs/lib/alpha/alpha_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/alpha/google/api/annotations_pb.js
+++ b/sdks/nodejs/lib/alpha/google/api/annotations_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/alpha/google/api/http_pb.js
+++ b/sdks/nodejs/lib/alpha/google/api/http_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/alpha/protoc-gen-openapiv2/options/annotations_pb.js
+++ b/sdks/nodejs/lib/alpha/protoc-gen-openapiv2/options/annotations_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/alpha/protoc-gen-openapiv2/options/openapiv2_pb.js
+++ b/sdks/nodejs/lib/alpha/protoc-gen-openapiv2/options/openapiv2_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/google/api/annotations_pb.js
+++ b/sdks/nodejs/lib/google/api/annotations_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/google/api/http_pb.js
+++ b/sdks/nodejs/lib/google/api/http_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/protoc-gen-openapiv2/options/annotations_pb.js
+++ b/sdks/nodejs/lib/protoc-gen-openapiv2/options/annotations_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/protoc-gen-openapiv2/options/openapiv2_pb.js
+++ b/sdks/nodejs/lib/protoc-gen-openapiv2/options/openapiv2_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/sdk_grpc_pb.js
+++ b/sdks/nodejs/lib/sdk_grpc_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/nodejs/lib/sdk_pb.js
+++ b/sdks/nodejs/lib/sdk_pb.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/api_sdk.go
+++ b/test/sdk/restapi/alpha/swagger/api_sdk.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/client.go
+++ b/test/sdk/restapi/alpha/swagger/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/configuration.go
+++ b/test/sdk/restapi/alpha/swagger/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_alpha_bool.go
+++ b/test/sdk/restapi/alpha/swagger/model_alpha_bool.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_alpha_count.go
+++ b/test/sdk/restapi/alpha/swagger/model_alpha_count.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_alpha_counter.go
+++ b/test/sdk/restapi/alpha/swagger/model_alpha_counter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_alpha_list.go
+++ b/test/sdk/restapi/alpha/swagger/model_alpha_list.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_alpha_player_id.go
+++ b/test/sdk/restapi/alpha/swagger/model_alpha_player_id.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_alpha_player_id_list.go
+++ b/test/sdk/restapi/alpha/swagger/model_alpha_player_id_list.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_sdkalpha_empty.go
+++ b/test/sdk/restapi/alpha/swagger/model_sdkalpha_empty.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_the_counter_to_update.go
+++ b/test/sdk/restapi/alpha/swagger/model_the_counter_to_update.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_the_list_to_update.go
+++ b/test/sdk/restapi/alpha/swagger/model_the_list_to_update.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_v1alpha1_nameadd_value_body.go
+++ b/test/sdk/restapi/alpha/swagger/model_v1alpha1_nameadd_value_body.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/model_v1alpha1_nameremove_value_body.go
+++ b/test/sdk/restapi/alpha/swagger/model_v1alpha1_nameremove_value_body.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/alpha/swagger/response.go
+++ b/test/sdk/restapi/alpha/swagger/response.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/api_sdk.go
+++ b/test/sdk/restapi/swagger/api_sdk.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/client.go
+++ b/test/sdk/restapi/swagger/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/configuration.go
+++ b/test/sdk/restapi/swagger/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_game_server_object_meta.go
+++ b/test/sdk/restapi/swagger/model_game_server_object_meta.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_game_server_spec.go
+++ b/test/sdk/restapi/swagger/model_game_server_spec.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_googlerpc_status.go
+++ b/test/sdk/restapi/swagger/model_googlerpc_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_sdk_duration.go
+++ b/test/sdk/restapi/swagger/model_sdk_duration.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_sdk_empty.go
+++ b/test/sdk/restapi/swagger/model_sdk_empty.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_sdk_game_server.go
+++ b/test/sdk/restapi/swagger/model_sdk_game_server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_sdk_game_server_status.go
+++ b/test/sdk/restapi/swagger/model_sdk_game_server_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_sdk_key_value.go
+++ b/test/sdk/restapi/swagger/model_sdk_key_value.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_spec_health.go
+++ b/test/sdk/restapi/swagger/model_spec_health.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_status_address.go
+++ b/test/sdk/restapi/swagger/model_status_address.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_status_counter_status.go
+++ b/test/sdk/restapi/swagger/model_status_counter_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_status_list_status.go
+++ b/test/sdk/restapi/swagger/model_status_list_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_status_player_status.go
+++ b/test/sdk/restapi/swagger/model_status_player_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_status_port.go
+++ b/test/sdk/restapi/swagger/model_status_port.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/model_stream_result_of_sdk_game_server.go
+++ b/test/sdk/restapi/swagger/model_stream_result_of_sdk_game_server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/sdk/restapi/swagger/response.go
+++ b/test/sdk/restapi/swagger/response.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC All Rights Reserved.
+// Copyright 2023 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Without this change, if `restapi` generates a file previously and then you run generation again and the file is _not_ generated, the old file will still be there. This then results in the `header` script adding the boilerplate a second time, resulting a diff every time.

Along the way: the boilerplate is still 2022

Note to reviewer: the second commit is the re-generation with new boilerplate.