### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |-
             const keywords = {
@@ -58,7 +58,7 @@ jobs:
               }
             }
             try {
-              github.issues.addLabels({
+              github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Track Obsolete Issues
     steps:
       - name: Track stale issues and check if obsolete
-        uses: actions/stale@v5
+        uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -29,7 +29,7 @@ jobs:
     name: stale issues
     steps:
       - name: Stale issues
-        uses: actions/stale@v5
+        uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30


### PR DESCRIPTION
**What this PR does / Why we need it**:

This PR bumps GitHub workflow actions to their latest versions. This avoids warning messages as seen [here](https://github.com/googleforgames/agones/actions/runs/6024545244).