### PR TITLE
docs: Erase the misleading section on High Availability Agones

### DIFF
--- a/site/content/en/docs/Advanced/high-availability-agones.md
+++ b/site/content/en/docs/Advanced/high-availability-agones.md
@@ -54,7 +54,3 @@ agones-ping-5b9647874-rksgg          1/1     Running   0          27h
 The number of replicas for `agones-extensions` can be set using helm variable [`agones.extensions.replicas`]({{< relref "/docs/Installation/Install Agones/helm.md#configuration" >}}), but the default is `2`. 
 
 We expect the aggregate memory consumption of the pods will be slightly higher than the previous singleton pod, but as the responsibilities are now split across the pods, the aggregate CPU consumption should also be similar.
-
-## Feature Design
-
-`SplitControllerAndExtensions` represents phase 1 of [HA Agones](https://github.com/googleforgames/agones/issues/2797). The remaining phases are not yet implemented.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

The document references the issue (https://github.com/googleforgames/agones/issues/2797) that already being closed.
This PR erase that section not to make user confused.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:


