### PR TITLE
Bumps simple-game-server version to 0.18

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -61,7 +61,7 @@ KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
-GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
 
 # Enable all alpha feature gates. Keep in sync with `false` (alpha) entries in pkg/util/runtime/features.go:featureDefaults
 ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&PlayerTracking=true&CountsAndLists=true&FleetAllocationOverflow=true&Example=true"

--- a/examples/crd-client/create-gs.yaml
+++ b/examples/crd-client/create-gs.yaml
@@ -38,5 +38,5 @@ spec:
           imagePullPolicy: Always
           env:
             - name: GAMESERVER_IMAGE
-              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
       restartPolicy: Never

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -117,4 +117,4 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -116,7 +116,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
           imagePullPolicy: Always
           # nodeSelector is a label that can be used to tell Kubernetes which host
           # OS to use. For Windows game servers uncomment the nodeSelector

--- a/examples/simple-game-server/dev-gameserver.yaml
+++ b/examples/simple-game-server/dev-gameserver.yaml
@@ -31,4 +31,4 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18

--- a/examples/simple-game-server/fleet-distributed.yaml
+++ b/examples/simple-game-server/fleet-distributed.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
               resources:
                 requests:
                   memory: 64Mi

--- a/examples/simple-game-server/fleet-tcp.yaml
+++ b/examples/simple-game-server/fleet-tcp.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
               env:
                 # Disables the UDP listener (Enabled by default)
                 - name: UDP

--- a/examples/simple-game-server/fleet.yaml
+++ b/examples/simple-game-server/fleet.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
               resources:
                 requests:
                   memory: 64Mi

--- a/examples/simple-game-server/gameserver-passthrough.yaml
+++ b/examples/simple-game-server/gameserver-passthrough.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
           env:
             - name: PASSTHROUGH
               value: 'TRUE'

--- a/examples/simple-game-server/gameserver-windows.yaml
+++ b/examples/simple-game-server/gameserver-windows.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
           resources:
             requests:
               memory: 64Mi

--- a/examples/simple-game-server/gameserver.yaml
+++ b/examples/simple-game-server/gameserver.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
           resources:
             requests:
               memory: 64Mi

--- a/install/helm/agones/templates/tests/test-runner.yaml
+++ b/install/helm/agones/templates/tests/test-runner.yaml
@@ -29,7 +29,7 @@ spec:
     imagePullPolicy: Always
     env:
     - name: GAMESERVER_IMAGE
-      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17"
+      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18"
     - name: IS_HELM_TEST
       value: "true"
     - name: GAMESERVERS_NAMESPACE

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -163,7 +163,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 							"template": {
 								"spec": {
 									"containers": [{
-										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17",
+										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18",
 										"name": false
 									}]
 								}

--- a/site/config.toml
+++ b/site/config.toml
@@ -102,7 +102,7 @@ dev_eks_example_cluster_version = "1.27"
 dev_minikube_example_cluster_version = "1.26.6"
 
 # example tag
-example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17"
+example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18"
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = true

--- a/site/content/en/docs/Guides/fleet-updates.md
+++ b/site/content/en/docs/Guides/fleet-updates.md
@@ -129,25 +129,25 @@ the rate that you deem fit for your specific rollout.
 
 {{< alpha title="Allocated GameSever Overflow Notification" gate="FleetAllocationOverflow" >}}
 
-When `Allocated` `GameServers` are utilised for a long time, such as a Lobby `GameServer`, 
-or a `GameServer` that is being reused multiple times in a row, it can be useful 
-to notify an `Allocated` `GameServer` process when its backing Fleet has been updated. 
-When an update occurs, the `Allocated` `GameServer`, may want to actively perform a graceful shutdown and release its 
+When `Allocated` `GameServers` are utilised for a long time, such as a Lobby `GameServer`,
+or a `GameServer` that is being reused multiple times in a row, it can be useful
+to notify an `Allocated` `GameServer` process when its backing Fleet has been updated.
+When an update occurs, the `Allocated` `GameServer`, may want to actively perform a graceful shutdown and release its
 resources such that it can be replaced by a new version, or similar actions.
 
-To do this, we provide the ability to apply a user-provided set of labels and/or annotations to the `Allocated` 
+To do this, we provide the ability to apply a user-provided set of labels and/or annotations to the `Allocated`
 `GameServers` when a `Fleet` update occurs that updates its `GameServer` template, or generally
-causes the `Fleet` replica count to drop below the number of currently `Allocated` `GameServers`. 
+causes the `Fleet` replica count to drop below the number of currently `Allocated` `GameServers`.
 
 This provides two useful capabilities:
 
 1. The `GameServer` [`SDK.WatchGameServer()`]({{% relref "./Client SDKs/_index.md#watchgameserverfunctiongameserver" %}})
-   command can be utilised to react to this annotation and/or label change to 
+   command can be utilised to react to this annotation and/or label change to
    indicate the Fleet system change, and the game server binary could execute code accordingly.
-2. This can also be used to proactively update `GameServer` labels, to effect change in allocation strategy - such as 
-   preferring the newer `GameServers` when allocating, but falling back to the older version if there aren't enough 
+2. This can also be used to proactively update `GameServer` labels, to effect change in allocation strategy - such as
+   preferring the newer `GameServers` when allocating, but falling back to the older version if there aren't enough
    of the new ones yet spun up.
-   
+
 The labels and/or annotations are applied to `GameServers` in a `Fleet` in the order designated by their configured [Fleet scheduling]({{< ref "/docs/Advanced/scheduling-and-autoscaling#fleet-scheduling">}}).
 
 Example yaml configuration:
@@ -174,7 +174,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: gcr.io/agones-images/simple-game-server:0.13
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
 ```
 
 See the [Fleet reference]({{% relref "../Reference/fleet.md" %}}) for more details.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -149,7 +149,7 @@ func NewFromFlags() (*Framework, error) {
 	}
 
 	viper.SetDefault(kubeconfigFlag, filepath.Join(usr.HomeDir, ".kube", "config"))
-	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17")
+	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18")
 	viper.SetDefault(pullSecretFlag, "")
 	viper.SetDefault(stressTestLevelFlag, 0)
 	viper.SetDefault(perfOutputDirFlag, "")

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -1000,7 +1000,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution: ERROR
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
 `
 	err := os.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0o644)
 	require.NoError(t, err)

--- a/test/load/allocation/fleet.yaml
+++ b/test/load/allocation/fleet.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - args: [-automaticShutdownDelaySec=600]
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
               name: simple-game-server
               resources:
                 limits:

--- a/test/load/allocation/scenario-fleet.yaml
+++ b/test/load/allocation/scenario-fleet.yaml
@@ -38,7 +38,7 @@ spec:
               value: 'true'
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.17
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
               args: [-automaticShutdownDelaySec=60, -readyIterations=10]
               resources:
                 limits:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Updates the simple-game-server tag references to the newest version 0.18 updated in #3378.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


