### PR TITLE
Reduce controller memory footprint considerably

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -336,21 +336,21 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 
 	// Run the Health Controller
 	go func() {
-		if err := c.healthController.Run(ctx); err != nil {
+		if err := c.healthController.Run(ctx, workers); err != nil {
 			c.baseLogger.WithError(err).Error("error running health controller")
 		}
 	}()
 
 	// Run the Migration Controller
 	go func() {
-		if err := c.migrationController.Run(ctx); err != nil {
+		if err := c.migrationController.Run(ctx, workers); err != nil {
 			c.baseLogger.WithError(err).Error("error running migration controller")
 		}
 	}()
 
 	// Run the Missing Pod Controller
 	go func() {
-		if err := c.missingPodController.Run(ctx); err != nil {
+		if err := c.missingPodController.Run(ctx, workers); err != nil {
 			c.baseLogger.WithError(err).Error("error running missing pod controller")
 		}
 	}()

--- a/pkg/gameservers/health_test.go
+++ b/pkg/gameservers/health_test.go
@@ -412,7 +412,7 @@ func TestHealthControllerRun(t *testing.T) {
 	gsWatch.Add(gs.DeepCopy())
 	podWatch.Add(pod.DeepCopy())
 
-	go hc.Run(stop) // nolint: errcheck
+	go hc.Run(stop, 1) // nolint: errcheck
 	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
 		return hc.workerqueue.RunCount() == 1, nil
 	})

--- a/pkg/gameservers/migration.go
+++ b/pkg/gameservers/migration.go
@@ -110,13 +110,13 @@ func NewMigrationController(health healthcheck.Handler,
 
 // Run processes the rate limited queue.
 // Will block until stop is closed
-func (mc *MigrationController) Run(ctx context.Context) error {
+func (mc *MigrationController) Run(ctx context.Context, workers int) error {
 	mc.baseLogger.Debug("Wait for cache sync")
 	if !cache.WaitForCacheSync(ctx.Done(), mc.nodeSynced, mc.gameServerSynced, mc.podSynced) {
 		return errors.New("failed to wait for caches to sync")
 	}
 
-	mc.workerqueue.Run(ctx, 1)
+	mc.workerqueue.Run(ctx, workers)
 	return nil
 }
 

--- a/pkg/gameservers/migration_test.go
+++ b/pkg/gameservers/migration_test.go
@@ -267,7 +267,7 @@ func TestMigrationControllerRun(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		err := c.Run(ctx)
+		err := c.Run(ctx, 1)
 		assert.Nil(t, err, "Run should not error")
 	}()
 

--- a/pkg/gameservers/missing_test.go
+++ b/pkg/gameservers/missing_test.go
@@ -184,7 +184,7 @@ func TestMissingPodControllerRun(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		err := c.Run(ctx)
+		err := c.Run(ctx, 1)
 		assert.Nil(t, err, "Run should not error")
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

In the past it wasn't deemed necessary to give the sub-controllers of the GameServer controller (Health, Missing and Migration) more than 1 worker for their queues, as speed of processing wasn't hugely important for their particular workloads.

An unfortunate consequence of that is that their queues can back up quite significantly, since they can't process events very fast at all. causing big jumps in memory usage.

This change brings those controllers in line with all the others, such that they have the same number of workers as every other controller - and now we have a much more stable memory footprint for the controller since they can process their incoming events in a timely manner.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #3380

**Special notes for your reviewer**:

Added a couple of extra checks to queuing as well.