### PR TITLE
Adds GameServerAllocation e2e tests for Counters

### DIFF
--- a/examples/gameserverallocation.yaml
+++ b/examples/gameserverallocation.yaml
@@ -57,6 +57,14 @@ spec:
       players:
         minAvailable: 0
         maxAvailable: 99
+      # [Stage:Alpha]
+      # [FeatureFlag:CountsAndLists]
+      # Counts and Lists provides the configuration for generic (player, room, session, etc.) tracking features.
+      # Commented out since Alpha, and disabled by default
+      # counters:
+      #   players:
+      #     minAvailable: 1
+      #     maxAvailable: 10
   # defines how GameServers are organised across the cluster.
   # Options include:
   # "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack

--- a/examples/gameserverallocation.yaml
+++ b/examples/gameserverallocation.yaml
@@ -51,13 +51,6 @@ spec:
       # label/annotation/player selectors to retrieve an already Allocated GameServer.
       gameServerState: Ready
       # [Stage:Alpha]
-      # [FeatureFlag:PlayerAllocationFilter]
-      # Provides a filter on minimum and maximum values for player capacity when retrieving a GameServer
-      # through Allocation. Defaults to no limits.
-      players:
-        minAvailable: 0
-        maxAvailable: 99
-      # [Stage:Alpha]
       # [FeatureFlag:CountsAndLists]
       # Counts and Lists provides the configuration for generic (player, room, session, etc.) tracking features.
       # Commented out since Alpha, and disabled by default
@@ -65,6 +58,13 @@ spec:
       #   players:
       #     minAvailable: 1
       #     maxAvailable: 10
+      # [Stage:Alpha]
+      # [FeatureFlag:PlayerAllocationFilter]
+      # Provides a filter on minimum and maximum values for player capacity when retrieving a GameServer
+      # through Allocation. Defaults to no limits.
+      players:
+        minAvailable: 0
+        maxAvailable: 99
   # defines how GameServers are organised across the cluster.
   # Options include:
   # "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -904,7 +904,10 @@ func (gs *GameServer) UpdateCounterCapacity(name string, capacity int64) error {
 	}
 	if counter, ok := gs.Status.Counters[name]; ok {
 		counter.Capacity = capacity
-		// TODO: If Capacity is now less than Count, do we want to reset Count here to equal Capacity?
+		// If Capacity is now less than Count, reset Count here to equal Capacity
+		if counter.Count > counter.Capacity {
+			counter.Count = counter.Capacity
+		}
 		gs.Status.Counters[name] = counter
 		return nil
 	}

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -1631,7 +1631,7 @@ func TestGameServerUpdateCount(t *testing.T) {
 			amount:  1,
 			wantErr: true,
 		},
-		"amount less than zero no-op and error": {
+		"negative amount no-op and error": {
 			gs: GameServer{Status: GameServerStatus{
 				Counters: map[string]CounterStatus{
 					"foos": {
@@ -1695,7 +1695,7 @@ func TestGameServerUpdateCount(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		"decrement beyond count no-op and error": {
+		"decrement beyond zero truncated": {
 			gs: GameServer{Status: GameServerStatus{
 				Counters: map[string]CounterStatus{
 					"baz": {
@@ -1706,12 +1706,12 @@ func TestGameServerUpdateCount(t *testing.T) {
 			action: "Decrement",
 			amount: 100,
 			want: CounterStatus{
-				Count:    99,
+				Count:    0,
 				Capacity: 100,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
-		"increment beyond capacity no-op and error": {
+		"increment beyond capacity truncated": {
 			gs: GameServer{Status: GameServerStatus{
 				Counters: map[string]CounterStatus{
 					"splayers": {
@@ -1722,10 +1722,10 @@ func TestGameServerUpdateCount(t *testing.T) {
 			action: "Increment",
 			amount: 2,
 			want: CounterStatus{
-				Count:    99,
+				Count:    100,
 				Capacity: 100,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 

--- a/pkg/apis/allocation/v1/gameserverallocation_test.go
+++ b/pkg/apis/allocation/v1/gameserverallocation_test.go
@@ -836,7 +836,7 @@ func TestGameServerCounterActions(t *testing.T) {
 		want    *agonesv1.GameServer
 		wantErr bool
 	}{
-		"update counter capacity": {
+		"update counter capacity and count is set to capacity": {
 			ca: CounterAction{
 				Capacity: int64Pointer(0),
 			},
@@ -850,7 +850,7 @@ func TestGameServerCounterActions(t *testing.T) {
 			want: &agonesv1.GameServer{Status: agonesv1.GameServerStatus{
 				Counters: map[string]agonesv1.CounterStatus{
 					"mages": {
-						Count:    1,
+						Count:    0,
 						Capacity: 0,
 					}}}},
 			wantErr: false,
@@ -912,7 +912,9 @@ func TestGameServerCounterActions(t *testing.T) {
 			want: &agonesv1.GameServer{Status: agonesv1.GameServerStatus{
 				Counters: map[string]agonesv1.CounterStatus{
 					"heroes": {
-						Count:    1,
+						// Note: The Capacity is set first, and Count updated to not be greater than Capacity.
+						// Then the Count is decremented. See: gameserver.go/UpdateCounterCapacity
+						Count:    0,
 						Capacity: 10,
 					}}}},
 			wantErr: false,

--- a/pkg/apis/allocation/v1/gameserverallocation_test.go
+++ b/pkg/apis/allocation/v1/gameserverallocation_test.go
@@ -855,7 +855,7 @@ func TestGameServerCounterActions(t *testing.T) {
 					}}}},
 			wantErr: false,
 		},
-		"fail update counter capacity and count": {
+		"fail update counter capacity and truncate update count": {
 			ca: CounterAction{
 				Action:   &INCREMENT,
 				Amount:   int64Pointer(10),
@@ -871,7 +871,7 @@ func TestGameServerCounterActions(t *testing.T) {
 			want: &agonesv1.GameServer{Status: agonesv1.GameServerStatus{
 				Counters: map[string]agonesv1.CounterStatus{
 					"sages": {
-						Count:    99,
+						Count:    100,
 						Capacity: 100,
 					}}}},
 			wantErr: true,

--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -370,7 +370,7 @@ func TestAllocatorApplyAllocationToGameServerCountsListsActions(t *testing.T) {
 					Capacity: 40,
 				}},
 		},
-		"CounterActions and ListActions only update list capacity": {
+		"CounterActions and ListActions truncate counter Count and update list capacity": {
 			features: fmt.Sprintf("%s=true", runtime.FeatureCountsAndLists),
 			gs:       &gs2,
 			gsa: &allocationv1.GameServerAllocation{
@@ -392,7 +392,7 @@ func TestAllocatorApplyAllocationToGameServerCountsListsActions(t *testing.T) {
 						}}}},
 			wantCounters: map[string]agonesv1.CounterStatus{
 				"rooms": {
-					Count:    101,
+					Count:    1000,
 					Capacity: 1000,
 				}},
 			wantLists: map[string]agonesv1.ListStatus{

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -1622,6 +1622,7 @@ func TestFleetAggregatedCounterStatus(t *testing.T) {
 
 	flt, err := client.Fleets(framework.Namespace).Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
 	assert.NoError(t, err)
+	defer client.Fleets(framework.Namespace).Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
 
 	// allocate two of them.

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -1621,7 +1621,7 @@ func TestFleetAggregatedCounterStatus(t *testing.T) {
 	}
 
 	flt, err := client.Fleets(framework.Namespace).Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer client.Fleets(framework.Namespace).Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
 

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -1651,21 +1651,19 @@ func TestFleetAggregatedCounterStatus(t *testing.T) {
 	allocatedCapacity := 0
 	allocatedCount := 0
 	// set random counts and capacities for each gameserver
-	for i := range list {
-		// Do this, otherwise scopelint complains about "using a reference for the variable on range scope"
-		gs := &list[i]
+	for _, gs := range list {
 		count := rand.IntnRange(2, 9)
 		capacity := rand.IntnRange(count, 100)
 
 		totalCapacity += capacity
 		msg := fmt.Sprintf("SET_COUNTER_CAPACITY games %d", capacity)
-		reply, err := framework.SendGameServerUDP(t, gs, msg)
+		reply, err := framework.SendGameServerUDP(t, &gs, msg)
 		require.NoError(t, err)
 		assert.Equal(t, "true", reply)
 
 		totalCount += count
 		msg = fmt.Sprintf("SET_COUNTER_COUNT games %d", count)
-		reply, err = framework.SendGameServerUDP(t, gs, msg)
+		reply, err = framework.SendGameServerUDP(t, &gs, msg)
 		require.NoError(t, err)
 		assert.Equal(t, "true", reply)
 

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -1226,7 +1226,7 @@ func TestCountsAndLists(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-
+	ctx := context.Background()
 	gs := framework.DefaultGameServer(framework.Namespace)
 
 	gs.Spec.Counters = make(map[string]agonesv1.CounterStatus)
@@ -1253,7 +1253,7 @@ func TestCountsAndLists(t *testing.T) {
 
 	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
-
+	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, gs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 	assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
 
 	testCases := map[string]struct {

--- a/test/e2e/gameserverallocation_test.go
+++ b/test/e2e/gameserverallocation_test.go
@@ -648,7 +648,7 @@ func TestCounterGameServerAllocationActions(t *testing.T) {
 	one := int64(1)
 	five := int64(5)
 	six := int64(6)
-	// negativeOne := int64(-1)
+	negativeOne := int64(-1)
 
 	testCases := map[string]struct {
 		gsa          allocationv1.GameServerAllocation
@@ -692,65 +692,65 @@ func TestCounterGameServerAllocationActions(t *testing.T) {
 		},
 		// TODO: These allocated a gameserver (although the Counter action is not performed) Is this what we want?
 		// Do we want to validate negative CounterActions in the GSA?
-		// "decrement past zero": {
-		// 	gsa: allocationv1.GameServerAllocation{
-		// 		Spec: allocationv1.GameServerAllocationSpec{
-		// 			Counters: map[string]allocationv1.CounterAction{
-		// 				"games": {
-		// 					Action: &decrement,
-		// 					Amount: &six,
-		// 				}}}},
-		// },
-		// "decrement negative": {
-		// 	gsa: allocationv1.GameServerAllocation{
-		// 		Spec: allocationv1.GameServerAllocationSpec{
-		// 			Counters: map[string]allocationv1.CounterAction{
-		// 				"games": {
-		// 					Action: &decrement,
-		// 					Amount: &negativeOne,
-		// 				}}}},
-		// 	wantGsaErr: true,
-		// },
-		// "increment past capacity": {
-		// 	gsa: allocationv1.GameServerAllocation{
-		// 		Spec: allocationv1.GameServerAllocationSpec{
-		// 			Counters: map[string]allocationv1.CounterAction{
-		// 				"games": {
-		// 					Action: &increment,
-		// 					Amount: &six,
-		// 				}}}},
-		// },
-		// "increment negative": {
-		// 	gsa: allocationv1.GameServerAllocation{
-		// 		Spec: allocationv1.GameServerAllocationSpec{
-		// 			Counters: map[string]allocationv1.CounterAction{
-		// 				"games": {
-		// 					Action: &increment,
-		// 					Amount: &negativeOne,
-		// 				}}}},
-		// 	wantGsaErr: true,
-		// },
-		// "change capacity negative": {
-		// 	gsa: allocationv1.GameServerAllocation{
-		// 		Spec: allocationv1.GameServerAllocationSpec{
-		// 			Counters: map[string]allocationv1.CounterAction{
-		// 				"games": {
-		// 					Capacity: &negativeOne,
-		// 				}}}},
-		// 	wantGsaErr: true,
-		// },
+		"decrement past zero": {
+			gsa: allocationv1.GameServerAllocation{
+				Spec: allocationv1.GameServerAllocationSpec{
+					Counters: map[string]allocationv1.CounterAction{
+						"games": {
+							Action: &decrement,
+							Amount: &six,
+						}}}},
+		},
+		"decrement negative": {
+			gsa: allocationv1.GameServerAllocation{
+				Spec: allocationv1.GameServerAllocationSpec{
+					Counters: map[string]allocationv1.CounterAction{
+						"games": {
+							Action: &decrement,
+							Amount: &negativeOne,
+						}}}},
+			// wantGsaErr: true,
+		},
+		"increment past capacity": {
+			gsa: allocationv1.GameServerAllocation{
+				Spec: allocationv1.GameServerAllocationSpec{
+					Counters: map[string]allocationv1.CounterAction{
+						"games": {
+							Action: &increment,
+							Amount: &six,
+						}}}},
+		},
+		"increment negative": {
+			gsa: allocationv1.GameServerAllocation{
+				Spec: allocationv1.GameServerAllocationSpec{
+					Counters: map[string]allocationv1.CounterAction{
+						"games": {
+							Action: &increment,
+							Amount: &negativeOne,
+						}}}},
+			// wantGsaErr: true,
+		},
+		"change capacity negative": {
+			gsa: allocationv1.GameServerAllocation{
+				Spec: allocationv1.GameServerAllocationSpec{
+					Counters: map[string]allocationv1.CounterAction{
+						"games": {
+							Capacity: &negativeOne,
+						}}}},
+			// wantGsaErr: true,
+		},
 		// Same issue with this test as above with increment/decrement/capacity, the GS is still allocated.
 		// (If we want different behavior will need to change test to not check for "games" and to
 		// instead check for counter action Counter name.)
-		// "Counter does not exist": {
-		// 	gsa: allocationv1.GameServerAllocation{
-		// 		Spec: allocationv1.GameServerAllocationSpec{
-		// 			Counters: map[string]allocationv1.CounterAction{
-		// 				"lames": {
-		// 					Action: &increment,
-		// 					Amount: &one,
-		// 				}}}},
-		// },
+		"Counter does not exist": {
+			gsa: allocationv1.GameServerAllocation{
+				Spec: allocationv1.GameServerAllocationSpec{
+					Counters: map[string]allocationv1.CounterAction{
+						"lames": {
+							Action: &increment,
+							Amount: &one,
+						}}}},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/test/e2e/gameserverallocation_test.go
+++ b/test/e2e/gameserverallocation_test.go
@@ -692,7 +692,7 @@ func TestCounterGameServerAllocationActions(t *testing.T) {
 			wantCount:    &zero,
 			wantCapacity: &ten,
 		},
-		"change capacity": {
+		"change capacity to less than count also updates count": {
 			gsa: allocationv1.GameServerAllocation{
 				Spec: allocationv1.GameServerAllocationSpec{
 					Selectors: []allocationv1.GameServerSelector{
@@ -703,7 +703,7 @@ func TestCounterGameServerAllocationActions(t *testing.T) {
 							Capacity: &zero,
 						}}}},
 			wantGsaErr:   false,
-			wantCount:    &five,
+			wantCount:    &zero,
 			wantCapacity: &zero,
 		},
 		"decrement past zero truncated": {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / Why we need it**:

* Adds GameServerAllocation filtering e2e test for Counters
* Adds GameServerAllocation sorting e2e test for Counters
* Adds GameServerAllocation CounterActions e2e test for Counters
* Updates Fleet and GameServer e2e tests to delete the fleet after test run
* Adds Counters to GameServerAllocation example
* Changes GameServer UpdateCount logic to truncate requests rather than a no-op for increment or decrement requests that go above capacity or below zero
* Changes UpdateCounterCapacity in gameserver.go to update Count to equal Capacity when Capacity is set to a value less than Count

**Which issue(s) this PR fixes**:

Working on #2716

**Special notes for your reviewer**:


