### PR TITLE
Adds Counter FleetAutoScaler e2e Test

### DIFF
--- a/examples/counterfleetautoscaler.yaml
+++ b/examples/counterfleetautoscaler.yaml
@@ -40,7 +40,8 @@ spec:
       # Required.
       bufferSize: 5
       # Minimum aggregate counter capacity that can be provided by this FleetAutoscaler.
-      # If minCapacity is not specified, the actual minimum capacity will be bufferSize.
+      # If minCapacity is not specified, the effective minimum capacity will be bufferSize.
+      # When bufferSize in percentage format is used, minCapacity should be set and more than 0.
       minCapacity: 10
       # Maximum aggregate counter capacity that can be provided by this FleetAutoscaler.
       # Required.

--- a/examples/listfleetautoscaler.yaml
+++ b/examples/listfleetautoscaler.yaml
@@ -41,7 +41,8 @@ spec:
       # Required.
       bufferSize: 5
       # Minimum aggregate list capacity that can be provided by this FleetAutoscaler.
-      # If minCapacity is not specified, the actual minimum capacity will be bufferSize.
+      # If minCapacity is not specified, the effective minimum capacity will be bufferSize.
+      # When bufferSize in percentage format is used, minCapacity should be set and more than 0.
       minCapacity: 10
       # Maximum aggregate list capacity that can be provided by this FleetAutoscaler.
       # Required.

--- a/pkg/apis/autoscaling/v1/fleetautoscaler.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler.go
@@ -377,6 +377,10 @@ func (c *CounterPolicy) ValidateCounterPolicy(fldPath *field.Path) field.ErrorLi
 		if err != nil || r < 1 || r > 99 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("bufferSize"), c.BufferSize.String(), "bufferSize should be between 1% and 99%"))
 		}
+		// When bufferSize in percentage format is used, minCapacity should be more than 0.
+		if c.MinCapacity < 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("minCapacity"), c.BufferSize.String(), " when bufferSize in percentage format is used, minCapacity should be more than 0"))
+		}
 	}
 
 	return allErrs
@@ -410,6 +414,10 @@ func (l *ListPolicy) ValidateListPolicy(fldPath *field.Path) field.ErrorList {
 		r, err := intstr.GetScaledValueFromIntOrPercent(&l.BufferSize, 100, true)
 		if err != nil || r < 1 || r > 99 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("bufferSize"), l.BufferSize.String(), "bufferSize should be between 1% and 99%"))
+		}
+		// When bufferSize in percentage format is used, minCapacity should be more than 0.
+		if l.MinCapacity < 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("minCapacity"), l.BufferSize.String(), " when bufferSize in percentage format is used, minCapacity should be more than 0"))
 		}
 	}
 	return allErrs

--- a/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
@@ -282,6 +282,7 @@ func TestFleetAutoscalerCounterValidateUpdate(t *testing.T) {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.Counter.BufferSize.Type = intstr.String
 				fap.Counter.BufferSize = intstr.FromString("99%")
+				fap.Counter.MinCapacity = 10
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
 			wantLength:   0,
@@ -290,24 +291,26 @@ func TestFleetAutoscalerCounterValidateUpdate(t *testing.T) {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.Counter.BufferSize.Type = intstr.String
 				fap.Counter.BufferSize = intstr.FromString("99.0%")
+				fap.Counter.MinCapacity = 1
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
 			wantLength:   1,
 			wantField:    "spec.policy.counter.bufferSize",
 		},
-		"bufferSize percentage too small": {
+		"bufferSize percentage and MinCapacity too small": {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.Counter.BufferSize.Type = intstr.String
 				fap.Counter.BufferSize = intstr.FromString("0%")
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
-			wantLength:   1,
+			wantLength:   2,
 			wantField:    "spec.policy.counter.bufferSize",
 		},
 		"bufferSize percentage too large": {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.Counter.BufferSize.Type = intstr.String
 				fap.Counter.BufferSize = intstr.FromString("100%")
+				fap.Counter.MinCapacity = 10
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
 			wantLength:   1,
@@ -399,6 +402,7 @@ func TestFleetAutoscalerListValidateUpdate(t *testing.T) {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.List.BufferSize.Type = intstr.String
 				fap.List.BufferSize = intstr.FromString("99%")
+				fap.List.MinCapacity = 1
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
 			wantLength:   0,
@@ -407,24 +411,26 @@ func TestFleetAutoscalerListValidateUpdate(t *testing.T) {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.List.BufferSize.Type = intstr.String
 				fap.List.BufferSize = intstr.FromString("99.0%")
+				fap.List.MinCapacity = 1
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
 			wantLength:   1,
 			wantField:    "spec.policy.list.bufferSize",
 		},
-		"bufferSize percentage too small": {
+		"bufferSize percentage and MinCapacity too small": {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.List.BufferSize.Type = intstr.String
 				fap.List.BufferSize = intstr.FromString("0%")
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
-			wantLength:   1,
+			wantLength:   2,
 			wantField:    "spec.policy.list.bufferSize",
 		},
 		"bufferSize percentage too large": {
 			fas: modifiedFAS(func(fap *FleetAutoscalerPolicy) {
 				fap.List.BufferSize.Type = intstr.String
 				fap.List.BufferSize = intstr.FromString("100%")
+				fap.List.MinCapacity = 1
 			}),
 			featureFlags: string(runtime.FeatureCountsAndLists) + "=true",
 			wantLength:   1,

--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -418,8 +418,9 @@ func scaleDownLimited(f *agonesv1.Fleet, gameServerLister listeragonesv1.GameSer
 		replicas--
 	}
 
-	if replicas < 0 { // This shouldn't ever happen, but putting it here just in case.
-		replicas = 0
+	// We are not currently able to scale down to zero replicas, so one replica is the minimum allowed
+	if replicas < 1 {
+		replicas = 1
 	}
 
 	return replicas, true, nil
@@ -520,8 +521,9 @@ func scaleDown(f *agonesv1.Fleet, gameServerLister listeragonesv1.GameServerList
 		}
 	}
 
-	if replicas < 0 { // This shouldn't ever happen, but putting it here just in case.
-		replicas = 0
+	// We are not currently able to scale down to zero replicas, so one replica is the minimum allowed.
+	if replicas < 1 {
+		replicas = 1
 	}
 
 	return replicas, false, nil

--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -502,6 +502,10 @@ func scaleDown(f *agonesv1.Fleet, gameServerLister listeragonesv1.GameServerList
 			}
 		}
 		availableCapacity = aggCapacity - aggCount
+		// Check if we've overshot our buffer
+		if availableCapacity < buffer {
+			return replicas + 1, false, nil
+		}
 		// Check if we're Limited (Below MinCapacity)
 		if aggCapacity < minCapacity {
 			return replicas + 1, true, nil
@@ -513,10 +517,6 @@ func scaleDown(f *agonesv1.Fleet, gameServerLister listeragonesv1.GameServerList
 		// Check if we're at Limited
 		if aggCapacity == minCapacity {
 			return replicas, true, nil
-		}
-		// Check if we've overshot our buffer
-		if availableCapacity < buffer {
-			return replicas + 1, false, nil
 		}
 	}
 

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -1189,7 +1189,6 @@ func TestApplyCounterPolicy(t *testing.T) {
 					Capacity: 7}
 			}),
 			featureFlags: string(utilruntime.FeatureCountsAndLists) + "=true",
-			// TODO: Is this what we want (replica = 0 if MaxCapcity < per Counter Capacity)? If buffer = 1 then must be at least replica = 1? Or Max Capacity takes precedence?
 			cp: &autoscalingv1.CounterPolicy{
 				Key:         "rooms",
 				MaxCapacity: 2,
@@ -1208,7 +1207,7 @@ func TestApplyCounterPolicy(t *testing.T) {
 								Capacity: 7,
 							}}}}},
 			want: expected{
-				replicas: 0,
+				replicas: 1,
 				limited:  true,
 				wantErr:  false,
 			},

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -10,12 +10,19 @@ Prerequisites:
 - (optional) set the `IMAGE_PULL_SECRET` env var to the secret name needed to pull the gameserver and/or Agones SDK images, if needed
 
 e2e tests are written as Go test. All go test techniques apply, e.g. picking
-what to run, timeout length. 
+what to run, timeout length.
 
 To run e2e tests on your kubectl configured cluster:
 
 ```
 make test-e2e
+```
+
+To run a single test on your kubectl configured cluster you can optionally include any flags listed
+in e2e test args in the agones/build/Makefile such as `FEATURE_GATES="CountsAndLists=true"`:
+
+```
+FEATURE_GATES="CountsAndLists=true" go test -race -run ^TestCounterAutoscaler$
 ```
 
 To run on minikube use the special target:

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -869,7 +869,7 @@ func TestCounterAutoscaler(t *testing.T) {
 			wantFasErr:   false,
 			wantReplicas: 9,
 		},
-		"Scale Down to MaxCapacity": { // TODO: Not working here (but works in pkg/fleetautoscalers/fleetautoscalers_test.go)
+		"Scale Down to MaxCapacity": {
 			fas: counterFas(func(fap *autoscalingv1.FleetAutoscalerPolicy) {
 				fap.Counter = &autoscalingv1.CounterPolicy{
 					Key:         "sessions",
@@ -915,6 +915,10 @@ func TestCounterAutoscaler(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
+			list, err := framework.ListGameServersFromFleet(flt)
+			for _, gs := range list {
+				log.WithField("Counter", gs.Status.Counters).Info("GAME SERVER COUNTERS")
+			}
 			defer fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 
 			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(testCase.wantReplicas))


### PR DESCRIPTION
**What type of PR is this?**

>/kind feature


**What this PR does / Why we need it**:

- Adds FleetAutoScaler e2e Test for Counter
- Updates fleetautoscalers applyCounterOrListPolicy to never return less than one desired replica when scaling down the fleet, as the fleet cannot scale back up from zero
- Adds validation that the autoscaler policy MinCapacity for both Counters and LIsts is greater than zero when buffer is a percentage

**Which issue(s) this PR fixes**:

Working on #2716 

**Special notes for your reviewer**:


