### PR TITLE
Remove `stale` and `obsolete` from PR's on update

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -43,3 +43,4 @@ jobs:
           close-issue-reason: not_planned
           stale-issue-label: wontfix
           enable-statistics: true
+          labels-to-remove-when-unstale: stale,obsolete

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -39,6 +39,7 @@ jobs:
             'awaiting-maintainer' label. Thank you for your contributions
           stale-issue-label: obsolete
           only-labels: stale
+          labels-to-remove-when-unstale: stale,obsolete
           exempt-issue-labels: awaiting-maintainer
           remove-stale-when-updated: true
           ascending: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -42,3 +42,4 @@ jobs:
           exempt-issue-labels: awaiting-maintainer, obsolete
           ascending: true
           enable-statistics: true
+          labels-to-remove-when-unstale: stale,obsolete


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Bug example: https://github.com/googleforgames/agones/issues/1782

Shouldn't have closed, but instead was. I assume because it was still labeled as "obsolete", and it had been 30 days - but only the stale label had been removed.

I added `labels-to-remove-when-unstale` to all the operations, since I'm not sure which operation does the work (and figured it couldn't hurt).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:


N/A