### PR TITLE
Bump simple-game-server references to 0.19

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -61,7 +61,7 @@ KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
-GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
 
 # Enable all alpha feature gates. Keep in sync with `false` (alpha) entries in pkg/util/runtime/features.go:featureDefaults
 ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&PlayerTracking=true&CountsAndLists=true&FleetAllocationOverflow=true&Example=true"

--- a/examples/crd-client/create-gs.yaml
+++ b/examples/crd-client/create-gs.yaml
@@ -38,5 +38,5 @@ spec:
           imagePullPolicy: Always
           env:
             - name: GAMESERVER_IMAGE
-              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
       restartPolicy: Never

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -117,4 +117,4 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -116,7 +116,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
           imagePullPolicy: Always
           # nodeSelector is a label that can be used to tell Kubernetes which host
           # OS to use. For Windows game servers uncomment the nodeSelector

--- a/examples/simple-game-server/dev-gameserver.yaml
+++ b/examples/simple-game-server/dev-gameserver.yaml
@@ -31,4 +31,4 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19

--- a/examples/simple-game-server/fleet-distributed.yaml
+++ b/examples/simple-game-server/fleet-distributed.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
               resources:
                 requests:
                   memory: 64Mi

--- a/examples/simple-game-server/fleet-tcp.yaml
+++ b/examples/simple-game-server/fleet-tcp.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
               env:
                 # Disables the UDP listener (Enabled by default)
                 - name: UDP

--- a/examples/simple-game-server/fleet.yaml
+++ b/examples/simple-game-server/fleet.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
               resources:
                 requests:
                   memory: 64Mi

--- a/examples/simple-game-server/gameserver-passthrough.yaml
+++ b/examples/simple-game-server/gameserver-passthrough.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
           env:
             - name: PASSTHROUGH
               value: 'TRUE'

--- a/examples/simple-game-server/gameserver-windows.yaml
+++ b/examples/simple-game-server/gameserver-windows.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
           resources:
             requests:
               memory: 64Mi

--- a/examples/simple-game-server/gameserver.yaml
+++ b/examples/simple-game-server/gameserver.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
           resources:
             requests:
               memory: 64Mi

--- a/install/helm/agones/templates/tests/test-runner.yaml
+++ b/install/helm/agones/templates/tests/test-runner.yaml
@@ -29,7 +29,7 @@ spec:
     imagePullPolicy: Always
     env:
     - name: GAMESERVER_IMAGE
-      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18"
+      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19"
     - name: IS_HELM_TEST
       value: "true"
     - name: GAMESERVERS_NAMESPACE

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -163,7 +163,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 							"template": {
 								"spec": {
 									"containers": [{
-										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18",
+										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19",
 										"name": false
 									}]
 								}

--- a/site/config.toml
+++ b/site/config.toml
@@ -100,7 +100,7 @@ dev_eks_example_cluster_version = "1.27"
 dev_minikube_example_cluster_version = "1.26.6"
 
 # example tag
-example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18"
+example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19"
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = true

--- a/site/content/en/blog/releases/1.35.0.md
+++ b/site/content/en/blog/releases/1.35.0.md
@@ -44,7 +44,7 @@ Images available with this release:
 - [us-docker.pkg.dev/agones-images/examples/crd-client:0.10](https://us-docker.pkg.dev/agones-images/examples/crd-client:0.10)
 - [us-docker.pkg.dev/agones-images/examples/nodejs-simple-server:0.8](https://us-docker.pkg.dev/agones-images/examples/nodejs-simple-server:0.8)
 - [us-docker.pkg.dev/agones-images/examples/rust-simple-server:0.12](https://us-docker.pkg.dev/agones-images/examples/rust-simple-server:0.12)
-- [us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18](https://us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18)
+- [us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19](https://us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19)
 - [us-docker.pkg.dev/agones-images/examples/supertuxkart-example:0.8](https://us-docker.pkg.dev/agones-images/examples/supertuxkart-example:0.8)
 - [us-docker.pkg.dev/agones-images/examples/unity-simple-server:0.3](https://us-docker.pkg.dev/agones-images/examples/unity-simple-server:0.3)
 - [us-docker.pkg.dev/agones-images/examples/xonotic-example:1.2](https://us-docker.pkg.dev/agones-images/examples/xonotic-example:1.2)

--- a/site/content/en/docs/Guides/fleet-updates.md
+++ b/site/content/en/docs/Guides/fleet-updates.md
@@ -174,7 +174,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
 ```
 
 See the [Fleet reference]({{% relref "../Reference/fleet.md" %}}) for more details.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -149,7 +149,7 @@ func NewFromFlags() (*Framework, error) {
 	}
 
 	viper.SetDefault(kubeconfigFlag, filepath.Join(usr.HomeDir, ".kube", "config"))
-	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18")
+	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19")
 	viper.SetDefault(pullSecretFlag, "")
 	viper.SetDefault(stressTestLevelFlag, 0)
 	viper.SetDefault(perfOutputDirFlag, "")

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -1000,7 +1000,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution: ERROR
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
 `
 	err := os.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0o644)
 	require.NoError(t, err)

--- a/test/load/allocation/fleet.yaml
+++ b/test/load/allocation/fleet.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - args: [-automaticShutdownDelaySec=600]
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
               name: simple-game-server
               resources:
                 limits:

--- a/test/load/allocation/scenario-fleet.yaml
+++ b/test/load/allocation/scenario-fleet.yaml
@@ -38,7 +38,7 @@ spec:
               value: 'true'
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.19
               args: [-automaticShutdownDelaySec=60, -readyIterations=10]
               resources:
                 limits:


### PR DESCRIPTION
I pushed `simple-game-server:0.19` after #3436 was merged, update all references to verify it still works with everything.

Note to reviewers: This was simply:
```
for f in $(grep -lR simple-game-server:0.18); do
  sed -i "s/simple-game-server:0.18/simple-game-server:0.19/g" $f
done
```

I double checked this with `grep -R simple-game-server | grep 0.18` after, which showed only the changelog.