### PR TITLE
Xonotic: gLibc incompatibility

### DIFF
--- a/examples/xonotic/Dockerfile
+++ b/examples/xonotic/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -o xonotic.zip https://dl.xonotic.org/xonotic-0.8.6.zip && \
     unzip -qq xonotic.zip && rm xonotic.zip
 
 # final image
-FROM debian:bullseye
+FROM debian:bookworm
 
 WORKDIR /home/xonotic
 

--- a/examples/xonotic/Makefile
+++ b/examples/xonotic/Makefile
@@ -38,15 +38,14 @@ WINDOWS_DOCKER_PUSH_ARGS = --push
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
 ifeq ($(REPOSITORY),)
-	server_tag := xonotic-example:1.4
+	server_tag := xonotic-example:1.5
 else
-	server_tag := $(REPOSITORY)/xonotic-example:1.4
+	server_tag := $(REPOSITORY)/xonotic-example:1.5
 endif
 
 server_tag_linux_amd64 = $(server_tag)-linux-amd64
 push_server_manifest = $(server_tag_linux_amd64)
 root_path := $(realpath $(project_path)/../..)
-
 
 ifeq ($(WITH_WINDOWS), 1)
 push_server_manifest += $(foreach windows_version, $(WINDOWS_VERSIONS), $(server_tag)-windows_amd64-$(windows_version))

--- a/examples/xonotic/fleet.yaml
+++ b/examples/xonotic/fleet.yaml
@@ -35,4 +35,4 @@ spec:
         spec:
           containers:
             - name: xonotic
-              image: us-docker.pkg.dev/agones-images/examples/xonotic-example:1.4
+              image: us-docker.pkg.dev/agones-images/examples/xonotic-example:1.5

--- a/examples/xonotic/gameserver.yaml
+++ b/examples/xonotic/gameserver.yaml
@@ -24,5 +24,5 @@ spec:
     spec:
       containers:
         - name: xonotic
-          image: us-docker.pkg.dev/agones-images/examples/xonotic-example:1.4
+          image: us-docker.pkg.dev/agones-images/examples/xonotic-example:1.5
           # imagePullPolicy: Always  # add for development


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Xonotic image was previously broken with the following error:

```
❯ kubectl logs xonotic-ggbpd-g22ww --container xonotic
/home/xonotic/wrapper: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/xonotic/wrapper)
/home/xonotic/wrapper: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/xonotic/wrapper)
```

Looks like it needed a newer version of debian to run inline with the updated golang update.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Should let #3494 pass once the new image is pushed to prod

**Special notes for your reviewer**:


Glad we're building the e2e tests now!