### PR TITLE
Bumps simple-game-server version to 0.22

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -61,7 +61,7 @@ KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
-GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
 
 # Enable all alpha feature gates. Keep in sync with `false` (alpha) entries in pkg/util/runtime/features.go:featureDefaults
 ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&PlayerTracking=true&CountsAndLists=true&FleetAllocationOverflow=true&Example=true"

--- a/examples/crd-client/create-gs.yaml
+++ b/examples/crd-client/create-gs.yaml
@@ -38,5 +38,5 @@ spec:
           imagePullPolicy: Always
           env:
             - name: GAMESERVER_IMAGE
-              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
       restartPolicy: Never

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -117,4 +117,4 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -116,7 +116,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
           imagePullPolicy: Always
           # nodeSelector is a label that can be used to tell Kubernetes which host
           # OS to use. For Windows game servers uncomment the nodeSelector

--- a/install/helm/agones/templates/tests/test-runner.yaml
+++ b/install/helm/agones/templates/tests/test-runner.yaml
@@ -29,7 +29,7 @@ spec:
     imagePullPolicy: Always
     env:
     - name: GAMESERVER_IMAGE
-      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21"
+      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22"
     - name: IS_HELM_TEST
       value: "true"
     - name: GAMESERVERS_NAMESPACE

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -163,7 +163,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 							"template": {
 								"spec": {
 									"containers": [{
-										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21",
+										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22",
 										"name": false
 									}]
 								}

--- a/site/config.toml
+++ b/site/config.toml
@@ -100,7 +100,7 @@ dev_eks_example_cluster_version = "1.28"
 dev_minikube_example_cluster_version = "1.27.6"
 
 # example tag
-example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21"
+example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22"
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = true

--- a/site/content/en/docs/Guides/fleet-updates.md
+++ b/site/content/en/docs/Guides/fleet-updates.md
@@ -174,7 +174,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
 ```
 
 See the [Fleet reference]({{% relref "../Reference/fleet.md" %}}) for more details.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -149,7 +149,7 @@ func NewFromFlags() (*Framework, error) {
 	}
 
 	viper.SetDefault(kubeconfigFlag, filepath.Join(usr.HomeDir, ".kube", "config"))
-	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21")
+	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22")
 	viper.SetDefault(pullSecretFlag, "")
 	viper.SetDefault(stressTestLevelFlag, 0)
 	viper.SetDefault(perfOutputDirFlag, "")

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -1000,7 +1000,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution: ERROR
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
 `
 	err := os.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0o644)
 	require.NoError(t, err)

--- a/test/load/allocation/fleet.yaml
+++ b/test/load/allocation/fleet.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - args: [-automaticShutdownDelaySec=600]
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
               name: simple-game-server
               resources:
                 limits:

--- a/test/load/allocation/performance-test-fleet-template.yaml
+++ b/test/load/allocation/performance-test-fleet-template.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - args: [-automaticShutdownDelaySec=AUTOMATIC_SHUTDOWN_DELAY_SEC_REPLACEMENT]
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.18
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
               name: simple-game-server
               resources:
                 limits:

--- a/test/load/allocation/scenario-fleet.yaml
+++ b/test/load/allocation/scenario-fleet.yaml
@@ -38,7 +38,7 @@ spec:
               value: 'true'
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.21
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.22
               args: [-automaticShutdownDelaySec=60, -readyIterations=10]
               resources:
                 limits:


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / Why we need it:

Updates the simple-game-server tag references to the newest version 0.22 updated in https://github.com/googleforgames/agones/pull/3500.

Which issue(s) this PR fixes:

Working on https://github.com/googleforgames/agones/issues/2716

Special notes for your reviewer: