### PR TITLE
Fixes occasional data race flake with TestSDKServerAddListValue

### DIFF
--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -1175,9 +1175,10 @@ func (s *SDKServer) updateList(ctx context.Context) error {
 	}
 	gsCopy := gs.DeepCopy()
 
-	s.logger.WithField("batchListUpdates", s.gsListUpdates).Debug("Batch updating List(s)")
 	s.gsUpdateMutex.Lock()
 	defer s.gsUpdateMutex.Unlock()
+
+	s.logger.WithField("batchListUpdates", s.gsListUpdates).Debug("Batch updating List(s)")
 
 	names := []string{}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

Fixes occasional data race flake with TestSDKServerAddListValue by putting the s.gsListUpdates call in the logger after the mutex lock.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


