### PR TITLE
Adds gameserverallocation e2e tests for Lists

### DIFF
--- a/pkg/apis/allocation/v1/gameserverallocation_test.go
+++ b/pkg/apis/allocation/v1/gameserverallocation_test.go
@@ -948,7 +948,7 @@ func TestGameServerListActions(t *testing.T) {
 		want    *agonesv1.GameServer
 		wantErr bool
 	}{
-		"update list capacity": {
+		"update list capacity truncates list": {
 			la: ListAction{
 				Capacity: int64Pointer(0),
 			},
@@ -962,7 +962,7 @@ func TestGameServerListActions(t *testing.T) {
 			want: &agonesv1.GameServer{Status: agonesv1.GameServerStatus{
 				Lists: map[string]agonesv1.ListStatus{
 					"pages": {
-						Values:   []string{"page1", "page2"},
+						Values:   []string{},
 						Capacity: 0,
 					}}}},
 			wantErr: false,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

Adds GameServerAllocation e2e tests for Lists.

Changes GameServerAllocation action to truncate the List to Capacity if only the capacity is changed, to be consistent with the behavior with Counters.

**Which issue(s) this PR fixes**:

Working on #2716 

**Special notes for your reviewer**:


