### PR TITLE
CI: Fix 404 on CI link testing

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -128,17 +128,17 @@ no = 'Sorry to hear that. Please <a href="https://github.com/googleforgames/agon
 	name = "Slack"
 	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U"
 	icon = "fab fa-slack"
-        desc = "Chat with other project users in #users"
+desc = "Chat with other project users in #users"
 [[params.links.user]]
 	name = "User mailing list"
 	url = "https://groups.google.com/forum/#!forum/agones-discuss"
 	icon = "fa fa-envelope"
-        desc = "Discussion and help from your fellow users"
+	desc = "Discussion and help from your fellow users"
 [[params.links.user]]
 	name ="Twitter"
 	url = "https://twitter.com/agonesdev"
 	icon = "fab fa-twitter"
-        desc = "Follow us on Twitter to get the latest news!"
+	desc = "Follow us on Twitter to get the latest news!"
 [[params.links.user]]
 	name ="Community Meetings"
 	url = "https://www.youtube.com/playlist?list=PLhkWKwFGACw2dFpdmwxOyUCzlGP2-n7uF"
@@ -149,12 +149,12 @@ no = 'Sorry to hear that. Please <a href="https://github.com/googleforgames/agon
 	name = "GitHub"
 	url = "https://github.com/googleforgames/agones"
 	icon = "fab fa-github"
-        desc = "Development takes place here!"
+	desc = "Development takes place here!"
 [[params.links.developer]]
 	name = "Slack"
 	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U"
 	icon = "fab fa-slack"
-        desc = "Chat with other project developers in #developers"
+	desc = "Chat with other project developers in #developers"
 [[params.links.developer]]
 	name ="Community Meetings"
 	url = "https://www.youtube.com/playlist?list=PLhkWKwFGACw2dFpdmwxOyUCzlGP2-n7uF"

--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -21,6 +21,6 @@ ExternalTimeout: 60
 IgnoreURLs:
   - http://localhost
   - https://twitter.com/agonesdev
+  - https://www.youtube.com/playlist
 HTTPHeaders:
-  User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
-    Chrome/100.0.4896.127 Safari/537.36
+  User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Not sure why, but youtube playlist links are 404ing.

I couldn't specify data-proofer-ignore since it's part of the Docsy layout, so I ignored it at the htmltest layer.

Did some minor cleanup while I was in there as well - updating some yaml formatting and updating the User-Agent as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Unblocks CI

**Special notes for your reviewer**:

N/A