### PR TITLE
Delete the performance test fleet and fleetautoscaler after each test

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -437,6 +437,7 @@ install: $(ensure-build-image) install-custom-pull-secret
 		--set agones.featureGates=$(FEATURE_GATES) \
 		--set agones.allocator.service.loadBalancerIP=$(EXTERNAL_IP) \
 		--set agones.metrics.serviceMonitor.enabled=$(SERVICE_MONITOR) \
+		--set agones.requireDedicatedNodes=true \
 		$(HELM_ARGS) \
 		agones $(mount_path)/install/helm/agones/
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -437,7 +437,6 @@ install: $(ensure-build-image) install-custom-pull-secret
 		--set agones.featureGates=$(FEATURE_GATES) \
 		--set agones.allocator.service.loadBalancerIP=$(EXTERNAL_IP) \
 		--set agones.metrics.serviceMonitor.enabled=$(SERVICE_MONITOR) \
-		--set agones.requireDedicatedNodes=true \
 		$(HELM_ARGS) \
 		agones $(mount_path)/install/helm/agones/
 

--- a/build/performance-test.sh
+++ b/build/performance-test.sh
@@ -70,6 +70,9 @@ cat performance-test-variable.txt
 
 printf "\nStart testing."
 ./runScenario.sh performance-test-variable.txt
+
+kubectl delete -f performance-test-fleet.yaml
+kubectl delete -f performance-test-autoscaler.yaml
 printf "\nFinish testing."
 
 rm performance-test-fleet.yaml performance-test-autoscaler.yaml performance-test-variable.txt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking


/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
After the performance test finishes, for some reason some gameserver could be stuck in Allocated state which makes the next execution of the test will timeout because the number of Ready gameserver can not reach expected state. In the PR, we clean up the fleet and fleetautoscaler after each test finish so the next one can start with a clean state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


