### PR TITLE
Docs: Link to SDK Service Account

### DIFF
--- a/site/content/en/docs/Advanced/service-accounts.md
+++ b/site/content/en/docs/Advanced/service-accounts.md
@@ -23,6 +23,14 @@ of the Kubernetes API.
 
 If needed, you can provide your own service account on the `Pod` specification in the `GameServer` configuration.
 
+{{< alert title="Warning" color="warning" >}}
+If you bring your own Service Account, it's your responsibility to ensure it matches all the RBAC permissions
+the `GameServer` `Pod` usually acquires from Agones by default, otherwise `GameServers` can fail.
+
+The default RBAC permissions for can be found in the {{< ghlink href="install/helm/agones/templates/serviceaccounts/sdk.yaml" >}}installation
+YAML on GitHub{{< /ghlink >}} and can be used for a reference.
+{{</ alert >}}
+
 For example:
 
 ```yaml


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

"GameServer Pod Service Accounts" didn't provide a reference to what the SDK service account permissions should be - so this updates the docs to the point to the relevant Helm yaml file that is the reference for this, with an accompanying warning on what getting your RBAC permissions wrong can do.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #3564

**Special notes for your reviewer**:


