### PR TITLE
ci/cache project root cloudbuild.yaml fix

### DIFF
--- a/build/build-image/cache/cloudbuild.yaml
+++ b/build/build-image/cache/cloudbuild.yaml
@@ -15,6 +15,18 @@
 
 steps:
 
+    #
+    # Move everything to the /workspace as this is what the canonical
+    # build script uses, and we want to be as close to that as possible.
+    #
+  - name: bash
+    id: setup-cache-files
+    script: |
+      mkdir /tmp/workspace && \
+      mv /workspace/* /tmp/workspace && \
+      mv /tmp/workspace/build/build-image/cache/* . && \
+      ls -l
+
   - name: 'gcr.io/cloud-builders/docker'
     id: build_base_image
     args:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

When setting up a trigger for this cloudbuild.yaml file, it can only run from the repository root - which then means this script fails as files aren't where they are expected.

This fix retains the original structure of the cloudbuild.yaml and shifts the original source files into where the rest of the script expects it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

N/A
