### PR TITLE
Use Docker 24.0.6 for performanace test

### DIFF
--- a/ci/perf-test-cloudbuild.yaml
+++ b/ci/perf-test-cloudbuild.yaml
@@ -23,11 +23,11 @@ steps:
     args:
       - bash
       - -c
-      - "echo 'FROM gcr.io/cloud-builders/docker\nRUN apt-get install make\nENTRYPOINT\
+      - "echo 'FROM gcr.io/cloud-builders/docker:24.0.6\nRUN apt-get install make\nENTRYPOINT\
         \ [\"/usr/bin/make\"]' > Dockerfile.build"
     waitFor: ['-']
 
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/cloud-builders/docker:24.0.6
     id: build-make-docker
     args: [build, -f, Dockerfile.build, -t, make-docker, .]  # we need docker and make to run everything.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind featur

/kind hotfix

> /kind release

**What this PR does / Why we need it**:
After the Docker version used by Makefile upgraded to 24.0.6, performance tests Cloud Build started to fail `make push`. This PR updates the Docker used by performance tests Cloud Build to 24.0.6 to fix.
Test succeeded: https://pantheon.corp.google.com/cloud-build/builds;region=global/77d084eb-bc59-48fc-a45b-37b81f4f31fa?e=13803378&mods=logs_tg_prod&project=agones-images
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


