### PR TITLE
Downscale performance test cluster

### DIFF
--- a/build/terraform/performance/module.tf
+++ b/build/terraform/performance/module.tf
@@ -54,7 +54,7 @@ module "gke_standard_cluster" {
   overrideName = format("standard-performance-test-cluster-%s", replace(each.key, ".", "-"))
   releaseChannel = each.value[1]
   machineType = "e2-standard-4"
-  initialNodeCount = 310
+  initialNodeCount = 200
 }
 
 resource "google_compute_firewall" "udp" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

The test cluster was overloaded and we were running up against Quota issues in this region, so scaling down the performance cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

I watched the metrics for the performance test, and it doesn't seem to have an impact.

We could build out some usage dashboard to see if we need/want to decrease the cluster further, but that's a problem for another day.
