### PR TITLE
Adds Chat Message History and Connects to the NPC Chat API

### DIFF
--- a/examples/simple-genai-server/README.md
+++ b/examples/simple-genai-server/README.md
@@ -85,6 +85,21 @@ each request as part of the GenAIRequest structure. The default values for `GenA
 to start the chat. The default values for the prompt is an empty string. `NumChats` is the number of
 requests made to the `SimEndpoint` and `GenAiEndpoint`. The default value for is `NumChats` is `1`.
 
+If you want to set up the chat with the npc-chat-api from the [Google for Games GenAI](https://github.com/googleforgames/GenAI-quickstart/genai/api/npc_chat_api)
+you will need the Game Servers on the same cluster as the GenAI Inference Server. Set either the
+`GenAiEndpoint` or `SimEndpoint` to the NPC service `"http://npc-chat-api.genai.svc.cluster.local:80"`.
+Set whichever endpoint the pointing to the NPC service to be, either the `GenAiNpc` or `SimNpc`,
+to be `"true"`. The `GenAIRequest` to the NPC endpoint only sends the message (prompt), so any
+additional context outside of the prompt is ignored. `FromID` is the entity sending messages to NPC,
+and `ToID` is the entity receiving the message (the NPC ID).
+```
+type NPCRequest struct {
+	Msg    string `json:"message,omitempty"`
+	FromId int `json:"from_id,omitempty"`
+	ToId   int `json:"to_id,omitempty"`
+}
+```
+
 ## Running the Game Server
 
 Once you have modified the `gameserver_autochat.yaml` or `gameserver_manualchat.yaml` to use your

--- a/examples/simple-genai-server/gameserver_autochat.yaml
+++ b/examples/simple-genai-server/gameserver_autochat.yaml
@@ -29,20 +29,20 @@ spec:
           image: us-docker.pkg.dev/agones-images/examples/simple-genai-game-server:0.1
           # imagePullPolicy: Always  # add for development
           env:
-            - name: GenAiEndpoint
+            - name: GEN_AI_ENDPOINT
               # Replace with your GenAI and Sim inference servers' endpoint addresses. If the game
               # server is in the same cluster as your inference server you can also use the k8s
               # service discovery such as value: "http://vertex-chat-api.genai.svc.cluster.local:80"
               value: "http://192.1.1.2/genai/chat"
-            - name: SimEndpoint
+            - name: SIM_ENDPOINT
               value: "http://192.1.1.2/genai/chat"
-            - name: SimContext
+            - name: SIM_CONTEXT
               value: "You are buying a car"
-            - name: GenAiContext
+            - name: GEN_AI_CONTEXT
               value: "You are a car salesperson"
-            - name: Prompt
+            - name: PROMPT
               value: "I would like to buy a car"
-            - name: NumChats
+            - name: NUM_CHATS
               value: "50"
           resources:
             requests:

--- a/examples/simple-genai-server/gameserver_manualchat.yaml
+++ b/examples/simple-genai-server/gameserver_manualchat.yaml
@@ -29,12 +29,12 @@ spec:
           image: us-docker.pkg.dev/agones-images/examples/simple-genai-game-server:0.1
           # imagePullPolicy: Always  # add for development
           env:
-            - name: GenAiEndpoint
+            - name: GEN_AI_ENDPOINT
               # Replace with your GenAI server's endpoint address. If the game server is in the
               # same cluster as your inference server you can also use the k8s service discovery
               # such as value: "http://vertex-chat-api.genai.svc.cluster.local:80"
               value: "http://192.1.1.2/genai/chat"
-            - name: GenAiContext
+            - name: GEN_AI_CONTEXT
               # Context is optional, and will be sent along with each post request
               value: "You are a car salesperson"
           resources:

--- a/examples/simple-genai-server/gameserver_npcchat.yaml
+++ b/examples/simple-genai-server/gameserver_npcchat.yaml
@@ -29,26 +29,26 @@ spec:
           image: us-docker.pkg.dev/agones-images/examples/simple-genai-game-server:0.1
           # imagePullPolicy: Always  # add for development
           env:
-            - name: GenAiEndpoint
+            - name: GEN_AI_ENDPOINT
             # Use the service endpoint address when running in the same cluster as the inference server.
               # TODO (igooch): Change this to the `/genai/npc-chat` endpoint when it's properly plumbed in the inference server
               value: "http://npc-chat-api.genai.svc.cluster.local:80"
             # GenAiContext is not passed to the npc-chat-api endpoint.
-            - name: GenAiNpc # False by default. Use GenAiNpc "true" when using the npc-chat-api as the GenAiEndpoint.
+            - name: GEN_AI_NPC # False by default. Use GEN_AI_NPC "true" when using the npc-chat-api as the GEN_AI_ENDPOINT.
               value: "true"
-            - name: FromID # Default is "2".
+            - name: FROM_ID # Default is "2".
               value: "2"
-            - name: ToID # Default is "1".
+            - name: TO_ID # Default is "1".
               value: "1"
-            - name: SimEndpoint
+            - name: SIM_ENDPOINT
               value: "http://192.1.1.2/genai/chat"
-            - name: SimContext
+            - name: SIM_CONTEXT
               value: "Ask questions about one of the following: What happened here? Where were you during the earthquake? Do you have supplies?"
-            - name: SimNpc
-              value: "false" # False by default. Use SimNpc "true" when using the npc-chat-api as the SimEndpoint.
-            - name: Prompt
+            - name: SIM_NPC
+              value: "false" # False by default. Use SIM_NPC "true" when using the npc-chat-api as the SIM_ENDPOINT.
+            - name: PROMPT
               value: "Hello"
-            - name: NumChats
+            - name: NUM_CHATS
               value: "50"
           resources:
             requests:

--- a/examples/simple-genai-server/gameserver_npcchat.yaml
+++ b/examples/simple-genai-server/gameserver_npcchat.yaml
@@ -35,6 +35,10 @@ spec:
             # GenAiContext is not passed to the npc-chat-api endpoint.
             - name: GenAiNpc # False by default. Use GenAiNpc "true" when using the npc-chat-api as the GenAiEndpoint.
               value: "true"
+            - name: FromID # Default is "2".
+              value: "2"
+            - name: ToID # Default is "1".
+              value: "1"
             - name: SimEndpoint
               value: "http://vertex-chat-api.genai.svc.cluster.local:80"
             - name: SimContext

--- a/examples/simple-genai-server/gameserver_npcchat.yaml
+++ b/examples/simple-genai-server/gameserver_npcchat.yaml
@@ -1,0 +1,61 @@
+---
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: agones.dev/v1
+kind: GameServer
+metadata:
+  name: gen-ai-server-npc
+spec:
+  ports:
+    - name: default
+      portPolicy: Dynamic
+      containerPort: 7654
+      protocol: TCP
+  template:
+    spec:
+      containers:
+        - name: simple-genai-game-server
+          image: us-docker.pkg.dev/agones-images/examples/simple-genai-game-server:0.1
+          # imagePullPolicy: Always  # add for development
+          env:
+            - name: GenAiEndpoint
+            # Use the service endpoint address when running in the same cluster as the inference server.
+              value: "http://npc-chat-api.genai.svc.cluster.local:80"
+            # GenAiContext is not passed to the npc-chat-api endpoint.
+            - name: GenAiNpc # False by default. Use GenAiNpc "true" when using the npc-chat-api as the GenAiEndpoint.
+              value: "true"
+            - name: SimEndpoint
+              value: "http://vertex-chat-api.genai.svc.cluster.local:80"
+            - name: SimContext
+              value: "Ask questions about one of the following: What happened here? Where were you during the earthquake? Do you have supplies?"
+            - name: SimNpc
+              value: "false" # False by default. Use SimNpc "true" when using the npc-chat-api as the SimEndpoint.
+            - name: Prompt
+              value: "Hello"
+            - name: NumChats
+              value: "50"
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 20m
+            limits:
+              memory: 64Mi
+              cpu: 20m
+      # Schedule onto the game server node pool when running in the same cluster as the inference server.
+      tolerations:
+        - key: "agones.dev/role"
+          value: "gameserver"
+          effect: "NoExecute"
+      nodeSelector:
+        agones.dev/role: gameserver

--- a/examples/simple-genai-server/gameserver_npcchat.yaml
+++ b/examples/simple-genai-server/gameserver_npcchat.yaml
@@ -31,6 +31,7 @@ spec:
           env:
             - name: GenAiEndpoint
             # Use the service endpoint address when running in the same cluster as the inference server.
+              # TODO (igooch): Change this to the `/genai/npc-chat` endpoint when it's properly plumbed in the inference server
               value: "http://npc-chat-api.genai.svc.cluster.local:80"
             # GenAiContext is not passed to the npc-chat-api endpoint.
             - name: GenAiNpc # False by default. Use GenAiNpc "true" when using the npc-chat-api as the GenAiEndpoint.
@@ -40,7 +41,7 @@ spec:
             - name: ToID # Default is "1".
               value: "1"
             - name: SimEndpoint
-              value: "http://vertex-chat-api.genai.svc.cluster.local:80"
+              value: "http://192.1.1.2/genai/chat"
             - name: SimContext
               value: "Ask questions about one of the following: What happened here? Where were you during the earthquake? Do you have supplies?"
             - name: SimNpc
@@ -57,9 +58,9 @@ spec:
               memory: 64Mi
               cpu: 20m
       # Schedule onto the game server node pool when running in the same cluster as the inference server.
-      tolerations:
-        - key: "agones.dev/role"
-          value: "gameserver"
-          effect: "NoExecute"
-      nodeSelector:
-        agones.dev/role: gameserver
+      # tolerations:
+      #   - key: "agones.dev/role"
+      #     value: "gameserver"
+      #     effect: "NoExecute"
+      # nodeSelector:
+      #   agones.dev/role: gameserver

--- a/examples/simple-genai-server/main.go
+++ b/examples/simple-genai-server/main.go
@@ -47,62 +47,62 @@ func main() {
 	numChats := flag.Int("NumChats", 1, "Number of back and forth chats between the sim and genAI")
 	genAiNpc := flag.Bool("GenAiNpc", false, "Set to true if the GenAIEndpoint is the npc-chat-api endpoint")
 	simNpc := flag.Bool("SimNpc", false, "Set to true if the SimEndpoint is the npc-chat-api endpoint")
-	fromID := flag.Int("FromID", 2, "Entity sending messages to the npc-chat-api")
-	toID := flag.Int("ToID", 1, "Entity receiving messages on the npc-chat-api (the NPC's ID)")
+	fromId := flag.Int("FromID", 2, "Entity sending messages to the npc-chat-api")
+	toId := flag.Int("ToID", 1, "Entity receiving messages on the npc-chat-api (the NPC's ID)")
 
 	flag.Parse()
 	if ep := os.Getenv("PORT"); ep != "" {
 		port = &ep
 	}
-	if sc := os.Getenv("SimContext"); sc != "" {
+	if sc := os.Getenv("SIM_CONTEXT"); sc != "" {
 		simContext = &sc
 	}
-	if gac := os.Getenv("GenAiContext"); gac != "" {
+	if gac := os.Getenv("GEN_AI_CONTEXT"); gac != "" {
 		genAiContext = &gac
 	}
-	if p := os.Getenv("Prompt"); p != "" {
+	if p := os.Getenv("PROMPT"); p != "" {
 		prompt = &p
 	}
-	if se := os.Getenv("SimEndpoint"); se != "" {
+	if se := os.Getenv("SIM_ENDPOINT"); se != "" {
 		simEndpoint = &se
 	}
-	if gae := os.Getenv("GenAiEndpoint"); gae != "" {
+	if gae := os.Getenv("GEN_AI_ENDPOINT"); gae != "" {
 		genAiEndpoint = &gae
 	}
-	if nc := os.Getenv("NumChats"); nc != "" {
+	if nc := os.Getenv("NUM_CHATS"); nc != "" {
 		num, err := strconv.Atoi(nc)
 		if err != nil {
 			log.Fatalf("Could not parse NumChats: %v", err)
 		}
 		numChats = &num
 	}
-	if gan := os.Getenv("GenAiNpc"); gan != "" {
+	if gan := os.Getenv("GEN_AI_NPC"); gan != "" {
 		gnpc, err := strconv.ParseBool(gan)
 		if err != nil {
 			log.Fatalf("Could parse GenAiNpc: %v", err)
 		}
 		genAiNpc = &gnpc
 	}
-	if sn := os.Getenv("SimNpc"); sn != "" {
+	if sn := os.Getenv("SIM_NPC"); sn != "" {
 		snpc, err := strconv.ParseBool(sn)
 		if err != nil {
 			log.Fatalf("Could parse GenAiNpc: %v", err)
 		}
 		simNpc = &snpc
 	}
-	if fid := os.Getenv("FromID"); fid != "" {
+	if fid := os.Getenv("FROM_ID"); fid != "" {
 		num, err := strconv.Atoi(fid)
 		if err != nil {
-			log.Fatalf("Could not parse FromID: %v", err)
+			log.Fatalf("Could not parse FromId: %v", err)
 		}
-		fromID = &num
+		fromId = &num
 	}
-	if tid := os.Getenv("ToID"); tid != "" {
+	if tid := os.Getenv("TO_ID"); tid != "" {
 		num, err := strconv.Atoi(tid)
 		if err != nil {
-			log.Fatalf("Could not parse ToID: %v", err)
+			log.Fatalf("Could not parse ToId: %v", err)
 		}
-		toID = &num
+		toId = &num
 	}
 
 	log.Print("Creating SDK instance")
@@ -117,14 +117,14 @@ func main() {
 	var simConn *connection
 	if *simEndpoint != "" {
 		log.Printf("Creating Sim Client at endpoint %s", *simEndpoint)
-		simConn = initClient(*simEndpoint, *simContext, "Sim", *simNpc, *fromID, *toID)
+		simConn = initClient(*simEndpoint, *simContext, "Sim", *simNpc, *fromId, *toId)
 	}
 
 	if *genAiEndpoint == "" {
 		log.Fatalf("GenAiEndpoint must be specified")
 	}
 	log.Printf("Creating GenAI Client at endpoint %s", *genAiEndpoint)
-	genAiConn := initClient(*genAiEndpoint, *genAiContext, "GenAI", *genAiNpc, *fromID, *toID)
+	genAiConn := initClient(*genAiEndpoint, *genAiContext, "GenAI", *genAiNpc, *fromId, *toId)
 
 	log.Print("Marking this server as ready")
 	if err := s.Ready(); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:
Adds chat message history to the GenAI Request. This will make for better responses from VertexAI.

Adds the request type NPC which allows for making requests to the [Google for Games GenAI NPC API](https://github.com/googleforgames/GenAI-quickstart/genai/api/npc_chat_api).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This works with Vertex, so in https://github.com/googleforgames/GenAI-quickstart/blob/205ba78aa65782f00a8654e31c88efdc4fdaded6/genai/api/npc_chat_api/config/config.toml#L20-L21 comment out "GKEGenAI", and uncomment "VertexAI".

You will need to first start up and run the GenAI Quickstart cluster, then start and run the NPC chat server.

