### PR TITLE
correct path of gameserver for windows node

### DIFF
--- a/examples/simple-game-server/Dockerfile.windows
+++ b/examples/simple-game-server/Dockerfile.windows
@@ -33,7 +33,7 @@ FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 
 WORKDIR /
 
-COPY --from=builder /go/src/agones.dev/agones/examples/simple-game-server/simple-game-server.exe /server
+COPY --from=builder /go/src/agones.dev/agones/examples/simple-game-server/simple-game-server.exe /server/
 
 EXPOSE 7654
 USER ContainerUser


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**: A user([100156994](https://github.com/100156994)) has raised an issue and after correcting the path he was able to ran the game server in the local windows container.
Created this PR so that we can have it in the upcoming release.

**Which issue(s) this PR fixes**: https://github.com/googleforgames/agones/issues/3675
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #3675 

**Special notes for your reviewer**:


