### PR TITLE
Add handling for StatusAddresses in GameServerStatus for the Unity SDK

### DIFF
--- a/sdks/unity/model/GameServerStatus.cs
+++ b/sdks/unity/model/GameServerStatus.cs
@@ -35,9 +35,17 @@ namespace Agones.Model
             this.State = (string) data["state"];
             this.Address = (string) data["address"];
 
+            this.Addresses = new List<StatusAddresses>();
+            var addressItems = (IReadOnlyList<object>) data["addresses"];
+            foreach (var i in addressItems)
+            {
+                var address = new StatusAddresses((Dictionary<string, object>) i);
+                this.Addresses.Add(address);
+            }
+
             this.Ports = new List<StatusPort>();
-            var items = (IReadOnlyList<object>) data["ports"];
-            foreach (var i in items)
+            var portItems = (IReadOnlyList<object>) data["ports"];
+            foreach (var i in portItems)
             {
                 var port = new StatusPort((Dictionary<string, object>) i);
                 this.Ports.Add(port);
@@ -46,6 +54,7 @@ namespace Agones.Model
 
         public string State { get; }
         public string Address { get; }
+        public List<StatusAddresses> Addresses { get; }
         public List<StatusPort> Ports { get; }
 
         /// <summary>
@@ -58,6 +67,7 @@ namespace Agones.Model
             sb.Append("class GameServerStatus {\n");
             sb.Append("  State: ").Append(State).Append("\n");
             sb.Append("  Address: ").Append(Address).Append("\n");
+            sb.Append("  Addresses: ").Append(string.Join(";", Addresses)).Append("\n");
             sb.Append("  Ports: ").Append(string.Join(";", Ports)).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -95,6 +105,11 @@ namespace Agones.Model
                      this.Address.Equals(input.Address))
                 ) &&
                 (
+                    this.Addresses == input.Addresses ||
+                    this.Addresses != null &&
+                    this.Addresses.SequenceEqual(input.Addresses)
+                ) &&
+                (
                     this.Ports == input.Ports ||
                     this.Ports != null &&
                     this.Ports.SequenceEqual(input.Ports)
@@ -114,6 +129,8 @@ namespace Agones.Model
                     hashCode = hashCode * 59 + this.State.GetHashCode();
                 if (this.Address != null)
                     hashCode = hashCode * 59 + this.Address.GetHashCode();
+                if (this.Addresses != null)
+                    hashCode = hashCode * 59 + this.Addresses.GetHashCode();
                 if (this.Ports != null)
                     hashCode = hashCode * 59 + this.Ports.GetHashCode();
                 return hashCode;

--- a/sdks/unity/model/StatusAddresses.cs
+++ b/sdks/unity/model/StatusAddresses.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Agones.Model
+{
+  /// <summary>
+  /// StatusAddresses represents an address with a specific type.
+  /// </summary>
+  public class StatusAddresses : IEquatable<StatusAddresses>
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StatusAddresses" /> class.
+    /// </summary>
+    /// <param name="data">The data dictionary containing the address and type.</param>
+    public StatusAddresses(IReadOnlyDictionary<string, object> data)
+    {
+      this.Address = (string)data["address"];
+      this.Type = (string)data["type"];
+    }
+
+    public string Address { get; }
+    public string Type { get; }
+
+    /// <summary>
+    /// Returns the string presentation of the object
+    /// </summary>
+    /// <returns>String presentation of the object</returns>
+    public override string ToString()
+    {
+      var sb = new StringBuilder();
+      sb.Append("class StatusAddresses {\n");
+      sb.Append("  Address: ").Append(Address).Append("\n");
+      sb.Append("  Type: ").Append(Type).Append("\n");
+      sb.Append("}\n");
+      return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns true if objects are equal
+    /// </summary>
+    /// <param name="input">Object to be compared</param>
+    /// <returns>Boolean</returns>
+    public override bool Equals(object input)
+    {
+      return this.Equals(input as StatusAddresses);
+    }
+
+    /// <summary>
+    /// Returns true if StatusAddresses instances are equal
+    /// </summary>
+    /// <param name="input">Instance of StatusAddresses to be compared</param>
+    /// <returns>Boolean</returns>
+    public bool Equals(StatusAddresses input)
+    {
+      if (input == null)
+        return false;
+
+      return
+          (
+              this.Address == input.Address ||
+              (this.Address != null &&
+               this.Address.Equals(input.Address))
+          ) &&
+          (
+              this.Type == input.Type ||
+              (this.Type != null &&
+               this.Type.Equals(input.Type))
+          );
+    }
+
+    /// <summary>
+    /// Gets the hash code
+    /// </summary>
+    /// <returns>Hash code</returns>
+    public override int GetHashCode()
+    {
+      unchecked // Overflow is fine, just wrap
+      {
+        int hashCode = 41;
+        if (this.Address != null)
+          hashCode = hashCode * 59 + this.Address.GetHashCode();
+        if (this.Type != null)
+          hashCode = hashCode * 59 + this.Type.GetHashCode();
+        return hashCode;
+      }
+    }
+  }
+}

--- a/sdks/unity/model/StatusAddresses.cs.meta
+++ b/sdks/unity/model/StatusAddresses.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3afc63918d1d4b0e98644a2cb0cd0f4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
/kind feature

**What this PR does / Why we need it**:
This PR introduces the functionality to fetch the list of addresses associated with a game server object. This is crucial for developers who require access to both IP addresses and DNS names for their game servers. Given the current structure, where the "address" field primarily accommodates ExternalDNS, there's a notable absence of a straightforward method to obtain the ExternalIP.

**Special notes for your reviewer**:
I have conducted thorough testing of this feature within our Agones Kubernetes cluster, and it has performed as expected, effectively addressing the current limitation.
<img width="1270" alt="Screenshot 2024-03-27 at 6 32 47 PM" src="https://github.com/googleforgames/agones/assets/5378415/04d011c7-6b92-4d37-9ea2-a10a8058c33b">
