### PR TITLE
Docs: Make hitting <enter> on connection explicit

### DIFF
--- a/site/content/en/docs/Getting Started/create-gameserver.md
+++ b/site/content/en/docs/Getting Started/create-gameserver.md
@@ -153,38 +153,33 @@ to the `GameServer`, please check the
 
 ### 3. Connect to the GameServer
 
-{{< alert title="Note" color="info">}}
-If you have Agones installed on Google Kubernetes Engine, and are using
-  Cloud Shell for your terminal, UDP is blocked. For this step, we recommend
-  SSH'ing into a running VM in your project, such as a Kubernetes node.
-  You can click the 'SSH' button on the [Google Compute Engine Instances](https://console.cloud.google.com/compute/instances)
-  page to do this.
-  Run `toolbox` on GKE Node to run docker container with tools and then `nc` command would be available.
-{{< /alert >}}
+You can now communicate with the Game Server, by running:
+```shell
+nc -u {IP} {PORT}
+```
 
-You can now communicate with the Game Server :
+Now write any text you would like, and hit `<Enter>`. You should see your text echoed back, like so: 
+
+```shell
+nc -u 35.233.183.43 7190
+Hello World !
+ACK: Hello World !
+```
+
+You can finally type `EXIT` and hit `<Enter>`, which tells the SDK to run the 
+[Shutdown command]({{< ref "/docs/Guides/Client SDKs/_index.md#shutdown" >}}), and therefore shuts down the `GameServer`.
+
+If you run `kubectl describe gameserver` again - either the GameServer will be gone completely, or it will be in `Shutdown` state, on the way to being deleted.
 
 {{< alert title="Note" color="info">}}
 If you do not have netcat installed
-  (i.e. you get a response of `nc: command not found`),
-  you can install netcat by running `sudo apt install netcat`.
+(i.e. you get a response of `nc: command not found`),
+you can install netcat by running `sudo apt install netcat`.
 
 If you are on Windows, you can alternatively install netcat on
 [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10),
 or download a version of netcat for Windows from [nmap.org](https://nmap.org/ncat/).
 {{< /alert >}}
-
-```
-nc -u {IP} {PORT}
-Hello World !
-ACK: Hello World !
-EXIT
-```
-
-You can finally type `EXIT` which tells the SDK to run the [Shutdown command]({{< ref "/docs/Guides/Client SDKs/_index.md#shutdown" >}}), and therefore shuts down the `GameServer`.
-
-If you run `kubectl describe gameserver` again - either the GameServer will be gone completely, or it will be in `Shutdown` state, on the way to being deleted.
-
 
 ## Next Step
 

--- a/site/content/en/docs/Getting Started/create-gameserver.md
+++ b/site/content/en/docs/Getting Started/create-gameserver.md
@@ -169,6 +169,8 @@ ACK: Hello World !
 You can finally type `EXIT` and hit `<Enter>`, which tells the SDK to run the 
 [Shutdown command]({{< ref "/docs/Guides/Client SDKs/_index.md#shutdown" >}}), and therefore shuts down the `GameServer`.
 
+To exit `nc` you can press `<ctrl>+c`.
+
 If you run `kubectl describe gameserver` again - either the GameServer will be gone completely, or it will be in `Shutdown` state, on the way to being deleted.
 
 {{< alert title="Note" color="info">}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Making the `nc` command in the quickstart explicit in "enter text" and then "hit enter", because a few people have got confused by that.

Also, UDP works in Cloud Shell, so dropping the warning!

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A
