### PR TITLE
Optimise GameServer Sub-Controller Queues

### DIFF
--- a/pkg/gameservers/gameservers.go
+++ b/pkg/gameservers/gameservers.go
@@ -26,6 +26,11 @@ import (
 
 // isGameServerPod returns if this Pod is a Pod that comes from a GameServer
 func isGameServerPod(pod *corev1.Pod) bool {
+	// add some defense in case this happens
+	if pod == nil {
+		return false
+	}
+
 	if agonesv1.GameServerRolePodSelector.Matches(labels.Set(pod.ObjectMeta.Labels)) {
 		owner := metav1.GetControllerOf(pod)
 		return owner != nil && owner.Kind == "GameServer"

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -89,7 +89,7 @@ func NewHealthController(
 	_, _ = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			pod := newObj.(*corev1.Pod)
-			if isGameServerPod(pod) && hc.isUnhealthy(pod) {
+			if pod.ObjectMeta.DeletionTimestamp.IsZero() && isGameServerPod(pod) && hc.isUnhealthy(pod) {
 				hc.workerqueue.Enqueue(pod)
 			}
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Looking at pprof profiles of the Agones Controller, we see a lot memory in the Migration controller and the Missing Controller queues.

This implements improved checking at the event layer, before placing items in the workerqueue, which drops the memory footprint, and also allows for faster processing of the edge cases that Missing and Migration Controllers implement.

Also did a review of the Health Controller and made a small improvement there as well.

Looking at the memory pprof profile and load tests, we see a decrease in memory usage, and also less of a slow "step up" of memory over time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Closes #3748

**Special notes for your reviewer**:

Here's some pretty pictures!

Here's the two tests run side by side - I only did 30m, but you can see a drop in memory, and less of a "step up" in memory usage you slowly see the beginnings of with the original code
![two-tests](https://github.com/googleforgames/agones/assets/298370/0fd36bde-6ae8-4d29-b38a-bba3298e55fd)

Also updated pprof, it's all basically JSON de/serialisation, which is pretty much what we would want to see.

![pprof-flame-fixed](https://github.com/googleforgames/agones/assets/298370/2bdc1dde-1474-4c2e-b724-0d8870b58842)
