### PR TITLE
Changes `sdk-server` to Patch instead of Update

### DIFF
--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -45,7 +45,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: ["agones.dev"]
   resources: ["gameservers"]
-  verbs: ["list", "update", "watch"]
+  verbs: ["list", "patch", "watch"]
 ---
   {{- range .Values.gameservers.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -16691,7 +16691,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: ["agones.dev"]
   resources: ["gameservers"]
-  verbs: ["list", "update", "watch"]
+  verbs: ["list", "patch", "watch"]
 ---
 # Source: agones/templates/service/allocation.yaml
 # Bind the agones-allocator ServiceAccount to the agones-allocator ClusterRole

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -1451,7 +1451,7 @@ func TestGameServerCountPortsForRange(t *testing.T) {
 }
 
 func TestGameServerPatch(t *testing.T) {
-	fixture := &GameServer{ObjectMeta: metav1.ObjectMeta{Name: "lucy"},
+	fixture := &GameServer{ObjectMeta: metav1.ObjectMeta{Name: "lucy", ResourceVersion: "1234"},
 		Spec: GameServerSpec{Container: "goat"}}
 
 	delta := fixture.DeepCopy()
@@ -1461,6 +1461,7 @@ func TestGameServerPatch(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Contains(t, string(patch), `{"op":"replace","path":"/spec/container","value":"bear"}`)
+	assert.Contains(t, string(patch), `{"op":"test","path":"/metadata/resourceVersion","value":"1234"}`)
 }
 
 func TestGameServerGetDevAddress(t *testing.T) {

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -456,7 +456,7 @@ func (s *SDKServer) patchGameServer(ctx context.Context, gs, gsCopy *agonesv1.Ga
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("PATCH", string(patch))
+
 	return s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
 }
 

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -979,7 +979,12 @@ func (s *SDKServer) updateCounter(ctx context.Context) error {
 		names = append(names, name)
 	}
 
-	gs, err = s.gameServerGetter.GameServers(s.namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
+	patch, err := gs.Patch(gsCopy)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -826,7 +826,7 @@ func (s *SDKServer) GetCounter(ctx context.Context, in *beta.GetCounterRequest) 
 		return nil, errors.Errorf("counter not found: %s", in.Name)
 	}
 	s.logger.WithField("Get Counter", counter).Debugf("Got Counter %s", in.Name)
-	protoCounter := beta.Counter{Name: in.Name, Count: counter.Count, Capacity: counter.Capacity}
+	protoCounter := &beta.Counter{Name: in.Name, Count: counter.Count, Capacity: counter.Capacity}
 	// If there are batched changes that have not yet been applied, apply them to the Counter.
 	// This does NOT validate batched the changes.
 	if counterUpdate, ok := s.gsCounterUpdates[in.Name]; ok {
@@ -848,7 +848,7 @@ func (s *SDKServer) GetCounter(ctx context.Context, in *beta.GetCounterRequest) 
 		s.logger.WithField("Get Counter", counter).Debugf("Applied Batched Counter Updates %v", counterUpdate)
 	}
 
-	return &protoCounter, nil
+	return protoCounter, nil
 }
 
 // UpdateCounter collapses all UpdateCounterRequests for a given Counter into a single request.
@@ -984,7 +984,7 @@ func (s *SDKServer) updateCounter(ctx context.Context) error {
 		names = append(names, name)
 	}
 
-	_, err = s.patchGameServer(ctx, gs, gsCopy)
+	gs, err = s.patchGameServer(ctx, gs, gsCopy)
 	if err != nil {
 		return err
 	}
@@ -1215,7 +1215,7 @@ func (s *SDKServer) updateList(ctx context.Context) error {
 		names = append(names, name)
 	}
 
-	_, err = s.patchGameServer(ctx, gs, gsCopy)
+	gs, err = s.patchGameServer(ctx, gs, gsCopy)
 	if err != nil {
 		return err
 	}

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -1215,7 +1215,12 @@ func (s *SDKServer) updateList(ctx context.Context) error {
 		names = append(names, name)
 	}
 
-	gs, err = s.gameServerGetter.GameServers(s.namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
+	patch, err := gs.Patch(gsCopy)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -1383,12 +1383,17 @@ func (s *SDKServer) updatePlayerCapacity(ctx context.Context) error {
 	gsCopy.Status.Players.Capacity = s.gsPlayerCapacity
 	s.gsUpdateMutex.RUnlock()
 
-	gs, err = s.gameServerGetter.GameServers(s.namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
+	patch, err := gs.Patch(gsCopy)
 	if err != nil {
 		return err
 	}
-	s.recorder.Event(gs, corev1.EventTypeNormal, "PlayerCapacity", fmt.Sprintf("Set to %d", gs.Status.Players.Capacity))
-	return nil
+
+	gs, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	if err == nil {
+		s.recorder.Event(gs, corev1.EventTypeNormal, "PlayerCapacity", fmt.Sprintf("Set to %d", gs.Status.Players.Capacity))
+	}
+
+	return err
 }
 
 // updateConnectedPlayers updates the Player IDs and Count fields in the GameServer's Status.
@@ -1416,12 +1421,17 @@ func (s *SDKServer) updateConnectedPlayers(ctx context.Context) error {
 		return nil
 	}
 
-	gs, err = s.gameServerGetter.GameServers(s.namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
+	patch, err := gs.Patch(gsCopy)
 	if err != nil {
 		return err
 	}
-	s.recorder.Event(gs, corev1.EventTypeNormal, "PlayerCount", fmt.Sprintf("Set to %d", gs.Status.Players.Count))
-	return nil
+
+	gs, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	if err == nil {
+		s.recorder.Event(gs, corev1.EventTypeNormal, "PlayerCount", fmt.Sprintf("Set to %d", gs.Status.Players.Count))
+	}
+
+	return err
 }
 
 // NewSDKServerContext returns a Context that cancels when SIGTERM or os.Interrupt

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -504,12 +504,7 @@ func (s *SDKServer) updateAnnotations(ctx context.Context) error {
 	}
 	s.gsUpdateMutex.RUnlock()
 
-	patch, err := gs.Patch(gsCopy)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	_, err = s.patchGameServer(ctx, gs, gsCopy)
 	return err
 }
 
@@ -989,12 +984,7 @@ func (s *SDKServer) updateCounter(ctx context.Context) error {
 		names = append(names, name)
 	}
 
-	patch, err := gs.Patch(gsCopy)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	_, err = s.patchGameServer(ctx, gs, gsCopy)
 	if err != nil {
 		return err
 	}
@@ -1225,12 +1215,7 @@ func (s *SDKServer) updateList(ctx context.Context) error {
 		names = append(names, name)
 	}
 
-	patch, err := gs.Patch(gsCopy)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	_, err = s.patchGameServer(ctx, gs, gsCopy)
 	if err != nil {
 		return err
 	}
@@ -1383,12 +1368,7 @@ func (s *SDKServer) updatePlayerCapacity(ctx context.Context) error {
 	gsCopy.Status.Players.Capacity = s.gsPlayerCapacity
 	s.gsUpdateMutex.RUnlock()
 
-	patch, err := gs.Patch(gsCopy)
-	if err != nil {
-		return err
-	}
-
-	gs, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	gs, err = s.patchGameServer(ctx, gs, gsCopy)
 	if err == nil {
 		s.recorder.Event(gs, corev1.EventTypeNormal, "PlayerCapacity", fmt.Sprintf("Set to %d", gs.Status.Players.Capacity))
 	}
@@ -1421,12 +1401,7 @@ func (s *SDKServer) updateConnectedPlayers(ctx context.Context) error {
 		return nil
 	}
 
-	patch, err := gs.Patch(gsCopy)
-	if err != nil {
-		return err
-	}
-
-	gs, err = s.gameServerGetter.GameServers(s.namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
+	gs, err = s.patchGameServer(ctx, gs, gsCopy)
 	if err == nil {
 		s.recorder.Event(gs, corev1.EventTypeNormal, "PlayerCount", fmt.Sprintf("Set to %d", gs.Status.Players.Count))
 	}

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -1046,7 +1046,7 @@ func TestSDKServerReserveTimeout(t *testing.T) {
 	}
 	assertReservedUntilDuration := func(d time.Duration) func(status agonesv1.GameServerStatus) {
 		return func(status agonesv1.GameServerStatus) {
-			assert.WithinDuration(t, time.Now().Add(d), status.ReservedUntil.Time, 1*time.Second)
+			assert.WithinDuration(t, time.Now().Add(d), status.ReservedUntil.Time, 1500*time.Millisecond)
 		}
 	}
 	assertReservedUntilNil := func(status agonesv1.GameServerStatus) {

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -173,7 +173,7 @@ func TestSidecarRun(t *testing.T) {
 
 			gs := agonesv1.GameServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test", Namespace: "default",
+					Name: "test", Namespace: "default", ResourceVersion: "0",
 				},
 				Spec: agonesv1.GameServerSpec{
 					Health: agonesv1.Health{Disabled: false, FailureThreshold: 1, PeriodSeconds: 1, InitialDelaySeconds: 0},
@@ -310,7 +310,7 @@ func TestSDKServerSyncGameServer(t *testing.T) {
 			updated := false
 			gs := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{
 				UID:  "1234",
-				Name: sc.gameServerName, Namespace: sc.namespace,
+				Name: sc.gameServerName, Namespace: sc.namespace, ResourceVersion: "0",
 				Labels: map[string]string{}, Annotations: map[string]string{}},
 			}
 
@@ -382,7 +382,7 @@ func TestSidecarUpdateState(t *testing.T) {
 
 			m.AgonesClient.AddReactor("list", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 				gs := agonesv1.GameServer{
-					ObjectMeta: metav1.ObjectMeta{Name: sc.gameServerName, Namespace: sc.namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: sc.gameServerName, Namespace: sc.namespace, ResourceVersion: "0"},
 					Status:     agonesv1.GameServerStatus{},
 				}
 
@@ -467,7 +467,7 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 
 	gs := agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test", Namespace: "default",
+			Name: "test", Namespace: "default", ResourceVersion: "0",
 		},
 		Spec: agonesv1.GameServerSpec{},
 		Status: agonesv1.GameServerStatus{
@@ -939,7 +939,7 @@ func TestSDKServerReserveTimeoutOnRun(t *testing.T) {
 
 	gs := agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test", Namespace: "default",
+			Name: "test", Namespace: "default", ResourceVersion: "0",
 		},
 		Status: agonesv1.GameServerStatus{
 			State: agonesv1.GameServerStateReserved,
@@ -1001,7 +1001,7 @@ func TestSDKServerReserveTimeout(t *testing.T) {
 
 	gs := agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test", Namespace: "default",
+			Name: "test", Namespace: "default", ResourceVersion: "0",
 		},
 		Spec: agonesv1.GameServerSpec{Health: agonesv1.Health{Disabled: true}},
 	}
@@ -1278,7 +1278,7 @@ func TestSDKServerUpdateCounter(t *testing.T) {
 
 			gs := agonesv1.GameServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test", Namespace: "default", Generation: 1,
+					Name: "test", Namespace: "default", ResourceVersion: "0", Generation: 1,
 				},
 				Spec: agonesv1.GameServerSpec{
 					SdkServer: agonesv1.SdkServer{
@@ -1431,7 +1431,7 @@ func TestSDKServerAddListValue(t *testing.T) {
 
 			gs := agonesv1.GameServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test", Namespace: "default", Generation: 1,
+					Name: "test", Namespace: "default", ResourceVersion: "0", Generation: 1,
 				},
 				Spec: agonesv1.GameServerSpec{
 					SdkServer: agonesv1.SdkServer{
@@ -1580,7 +1580,7 @@ func TestSDKServerRemoveListValue(t *testing.T) {
 
 			gs := agonesv1.GameServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test", Namespace: "default", Generation: 1,
+					Name: "test", Namespace: "default", ResourceVersion: "0", Generation: 1,
 				},
 				Spec: agonesv1.GameServerSpec{
 					SdkServer: agonesv1.SdkServer{
@@ -1738,7 +1738,7 @@ func TestSDKServerUpdateList(t *testing.T) {
 
 			gs := agonesv1.GameServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test", Namespace: "default", Generation: 1,
+					Name: "test", Namespace: "default", ResourceVersion: "0", Generation: 1,
 				},
 				Spec: agonesv1.GameServerSpec{
 					SdkServer: agonesv1.SdkServer{
@@ -1866,7 +1866,7 @@ func TestSDKServerPlayerCapacity(t *testing.T) {
 
 	gs := agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test", Namespace: "default",
+			Name: "test", Namespace: "default", ResourceVersion: "0",
 		},
 		Spec: agonesv1.GameServerSpec{
 			SdkServer: agonesv1.SdkServer{
@@ -2019,7 +2019,7 @@ func TestSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 	capacity := int64(3)
 	gs := agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test", Namespace: "default",
+			Name: "test", Namespace: "default", ResourceVersion: "0",
 		},
 		Spec: agonesv1.GameServerSpec{
 			SdkServer: agonesv1.SdkServer{

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -47,9 +47,9 @@ import (
 	testclocks "k8s.io/utils/clock/testing"
 )
 
-// PatchGameServer is a helper function for the AddReactor "patch" that creates and applies a patch
+// patchGameServer is a helper function for the AddReactor "patch" that creates and applies a patch
 // to a gameserver. Returns a patched copy and does not modify the original game server.
-func PatchGameServer(t *testing.T, action k8stesting.Action, gs *agonesv1.GameServer) *agonesv1.GameServer {
+func patchGameServer(t *testing.T, action k8stesting.Action, gs *agonesv1.GameServer) *agonesv1.GameServer {
 	pa := action.(k8stesting.PatchAction)
 	patchJSON := pa.GetPatch()
 	patch, err := jsonpatch.DecodePatch(patchJSON)
@@ -191,7 +191,7 @@ func TestSidecarRun(t *testing.T) {
 			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 				defer close(done)
 
-				gsCopy := PatchGameServer(t, action, &gs)
+				gsCopy := patchGameServer(t, action, &gs)
 
 				if v.expected.state != "" {
 					assert.Equal(t, v.expected.state, gsCopy.Status.State)
@@ -319,7 +319,7 @@ func TestSDKServerSyncGameServer(t *testing.T) {
 			})
 
 			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-				gsCopy := PatchGameServer(t, action, &gs)
+				gsCopy := patchGameServer(t, action, &gs)
 
 				if v.expected.state != "" {
 					assert.Equal(t, v.expected.state, gsCopy.Status.State)
@@ -481,7 +481,7 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 	})
 
 	m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		gsCopy := PatchGameServer(t, action, &gs)
+		gsCopy := patchGameServer(t, action, &gs)
 
 		return true, gsCopy, nil
 	})
@@ -956,7 +956,7 @@ func TestSDKServerReserveTimeoutOnRun(t *testing.T) {
 	})
 
 	m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		gsCopy := PatchGameServer(t, action, &gs)
+		gsCopy := patchGameServer(t, action, &gs)
 
 		updated <- gsCopy.Status
 
@@ -1012,7 +1012,7 @@ func TestSDKServerReserveTimeout(t *testing.T) {
 	})
 
 	m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		gsCopy := PatchGameServer(t, action, &gs)
+		gsCopy := patchGameServer(t, action, &gs)
 
 		state <- gsCopy.Status
 		return true, gsCopy, nil
@@ -1298,7 +1298,7 @@ func TestSDKServerUpdateCounter(t *testing.T) {
 			updated := make(chan map[string]agonesv1.CounterStatus, 10)
 
 			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-				gsCopy := PatchGameServer(t, action, &gs)
+				gsCopy := patchGameServer(t, action, &gs)
 
 				updated <- gsCopy.Status.Counters
 				return true, gsCopy, nil
@@ -1451,7 +1451,7 @@ func TestSDKServerAddListValue(t *testing.T) {
 			updated := make(chan map[string]agonesv1.ListStatus, 10)
 
 			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-				gsCopy := PatchGameServer(t, action, &gs)
+				gsCopy := patchGameServer(t, action, &gs)
 
 				updated <- gsCopy.Status.Lists
 				return true, gsCopy, nil
@@ -1600,7 +1600,7 @@ func TestSDKServerRemoveListValue(t *testing.T) {
 			updated := make(chan map[string]agonesv1.ListStatus, 10)
 
 			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-				gsCopy := PatchGameServer(t, action, &gs)
+				gsCopy := patchGameServer(t, action, &gs)
 
 				updated <- gsCopy.Status.Lists
 				return true, gsCopy, nil
@@ -1758,7 +1758,7 @@ func TestSDKServerUpdateList(t *testing.T) {
 			updated := make(chan map[string]agonesv1.ListStatus, 10)
 
 			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-				gsCopy := PatchGameServer(t, action, &gs)
+				gsCopy := patchGameServer(t, action, &gs)
 
 				updated <- gsCopy.Status.Lists
 				return true, gsCopy, nil
@@ -1886,7 +1886,7 @@ func TestSDKServerPlayerCapacity(t *testing.T) {
 	updated := make(chan int64, 10)
 	m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 
-		gsCopy := PatchGameServer(t, action, &gs)
+		gsCopy := patchGameServer(t, action, &gs)
 
 		updated <- gsCopy.Status.Players.Capacity
 		return true, gsCopy, nil
@@ -2039,7 +2039,7 @@ func TestSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 
 	updated := make(chan *agonesv1.PlayerStatus, 10)
 	m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		gsCopy := PatchGameServer(t, action, &gs)
+		gsCopy := patchGameServer(t, action, &gs)
 		updated <- gsCopy.Status.Players
 		return true, gsCopy, nil
 	})

--- a/sdks/go/beta.go
+++ b/sdks/go/beta.go
@@ -39,8 +39,8 @@ func newBeta(conn *grpc.ClientConn) *Beta {
 
 // GetCounterCount returns the Count for a Counter, given the Counter's key (name).
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) GetCounterCount(key string) (int64, error) {
-	counter, err := a.client.GetCounter(context.Background(), &beta.GetCounterRequest{Name: key})
+func (b *Beta) GetCounterCount(key string) (int64, error) {
+	counter, err := b.client.GetCounter(context.Background(), &beta.GetCounterRequest{Name: key})
 	if err != nil {
 		return -1, errors.Wrapf(err, "could not get Counter %s count", key)
 	}
@@ -56,11 +56,11 @@ func (a *Beta) GetCounterCount(key string) (int64, error) {
 // Note: A potential race condition here is that if count values are set from both the SDK and
 // through the K8s API (Allocation or otherwise), since the SDK append operation back to the CRD
 // value is batched asynchronous any value incremented past the capacity will be silently truncated.
-func (a *Beta) IncrementCounter(key string, amount int64) error {
+func (b *Beta) IncrementCounter(key string, amount int64) error {
 	if amount < 0 {
 		return errors.Errorf("amount must be a positive int64, found %d", amount)
 	}
-	_, err := a.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
+	_, err := b.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
 		CounterUpdateRequest: &beta.CounterUpdateRequest{
 			Name:      key,
 			CountDiff: amount,
@@ -74,11 +74,11 @@ func (a *Beta) IncrementCounter(key string, amount int64) error {
 // DecrementCounter decreases the current count by the given nonnegative integer amount.
 // The Counter Will not go below 0. Will execute the decrement operation against the current CRD value.
 // Will error if the count is at 0 (to the latest knowledge of the SDK), and no decrement will occur.
-func (a *Beta) DecrementCounter(key string, amount int64) error {
+func (b *Beta) DecrementCounter(key string, amount int64) error {
 	if amount < 0 {
 		return errors.Errorf("amount must be a positive int64, found %d", amount)
 	}
-	_, err := a.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
+	_, err := b.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
 		CounterUpdateRequest: &beta.CounterUpdateRequest{
 			Name:      key,
 			CountDiff: amount * -1,
@@ -91,8 +91,8 @@ func (a *Beta) DecrementCounter(key string, amount int64) error {
 
 // SetCounterCount sets a count to the given value. Use with care, as this will overwrite any previous
 // invocations’ value. Cannot be greater than Capacity.
-func (a *Beta) SetCounterCount(key string, amount int64) error {
-	_, err := a.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
+func (b *Beta) SetCounterCount(key string, amount int64) error {
+	_, err := b.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
 		CounterUpdateRequest: &beta.CounterUpdateRequest{
 			Name:  key,
 			Count: wrapperspb.Int64(amount),
@@ -105,8 +105,8 @@ func (a *Beta) SetCounterCount(key string, amount int64) error {
 
 // GetCounterCapacity returns the Capacity for a Counter, given the Counter's key (name).
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) GetCounterCapacity(key string) (int64, error) {
-	counter, err := a.client.GetCounter(context.Background(), &beta.GetCounterRequest{Name: key})
+func (b *Beta) GetCounterCapacity(key string) (int64, error) {
+	counter, err := b.client.GetCounter(context.Background(), &beta.GetCounterRequest{Name: key})
 	if err != nil {
 		return -1, errors.Wrapf(err, "could not get Counter %s capacity", key)
 	}
@@ -114,8 +114,8 @@ func (a *Beta) GetCounterCapacity(key string) (int64, error) {
 }
 
 // SetCounterCapacity sets the capacity for the given Counter. A capacity of 0 is no capacity.
-func (a *Beta) SetCounterCapacity(key string, amount int64) error {
-	_, err := a.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
+func (b *Beta) SetCounterCapacity(key string, amount int64) error {
+	_, err := b.client.UpdateCounter(context.Background(), &beta.UpdateCounterRequest{
 		CounterUpdateRequest: &beta.CounterUpdateRequest{
 			Name:     key,
 			Capacity: wrapperspb.Int64(amount),
@@ -128,8 +128,8 @@ func (a *Beta) SetCounterCapacity(key string, amount int64) error {
 
 // GetListCapacity returns the Capacity for a List, given the List's key (name).
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) GetListCapacity(key string) (int64, error) {
-	list, err := a.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
+func (b *Beta) GetListCapacity(key string) (int64, error) {
+	list, err := b.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
 	if err != nil {
 		return -1, errors.Wrapf(err, "could not get List %s", key)
 	}
@@ -138,8 +138,8 @@ func (a *Beta) GetListCapacity(key string) (int64, error) {
 
 // SetListCapacity sets the capacity for a given list. Capacity must be between 0 and 1000.
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) SetListCapacity(key string, amount int64) error {
-	_, err := a.client.UpdateList(context.Background(), &beta.UpdateListRequest{
+func (b *Beta) SetListCapacity(key string, amount int64) error {
+	_, err := b.client.UpdateList(context.Background(), &beta.UpdateListRequest{
 		List: &beta.List{
 			Name:     key,
 			Capacity: amount,
@@ -155,8 +155,8 @@ func (a *Beta) SetListCapacity(key string, amount int64) error {
 // ListContains returns if a string exists in a List's values list, given the List's key (name)
 // and the string value. Search is case-sensitive.
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) ListContains(key, value string) (bool, error) {
-	list, err := a.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
+func (b *Beta) ListContains(key, value string) (bool, error) {
+	list, err := b.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
 	if err != nil {
 		return false, errors.Wrapf(err, "could not get List %s", key)
 	}
@@ -170,8 +170,8 @@ func (a *Beta) ListContains(key, value string) (bool, error) {
 
 // GetListLength returns the length of the Values list for a List, given the List's key (name).
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) GetListLength(key string) (int, error) {
-	list, err := a.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
+func (b *Beta) GetListLength(key string) (int, error) {
+	list, err := b.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
 	if err != nil {
 		return -1, errors.Wrapf(err, "could not get List %s", key)
 	}
@@ -180,8 +180,8 @@ func (a *Beta) GetListLength(key string) (int, error) {
 
 // GetListValues returns the Values for a List, given the List's key (name).
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) GetListValues(key string) ([]string, error) {
-	list, err := a.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
+func (b *Beta) GetListValues(key string) ([]string, error) {
+	list, err := b.client.GetList(context.Background(), &beta.GetListRequest{Name: key})
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get List %s", key)
 	}
@@ -191,8 +191,8 @@ func (a *Beta) GetListValues(key string) ([]string, error) {
 // AppendListValue appends a string to a List's values list, given the List's key (name)
 // and the string value. Will error if the string already exists in the list.
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) AppendListValue(key, value string) error {
-	_, err := a.client.AddListValue(context.Background(), &beta.AddListValueRequest{Name: key, Value: value})
+func (b *Beta) AppendListValue(key, value string) error {
+	_, err := b.client.AddListValue(context.Background(), &beta.AddListValueRequest{Name: key, Value: value})
 	if err != nil {
 		return errors.Wrapf(err, "could not get List %s", key)
 	}
@@ -202,8 +202,8 @@ func (a *Beta) AppendListValue(key, value string) error {
 // DeleteListValue removes a string from a List's values list, given the List's key (name)
 // and the string value. Will error if the string does not exist in the list.
 // Will error if the key was not predefined in the GameServer resource on creation.
-func (a *Beta) DeleteListValue(key, value string) error {
-	_, err := a.client.RemoveListValue(context.Background(), &beta.RemoveListValueRequest{Name: key, Value: value})
+func (b *Beta) DeleteListValue(key, value string) error {
+	_, err := b.client.RemoveListValue(context.Background(), &beta.RemoveListValueRequest{Name: key, Value: value})
 	if err != nil {
 		return errors.Wrapf(err, "could not get List %s", key)
 	}

--- a/sdks/go/beta_test.go
+++ b/sdks/go/beta_test.go
@@ -62,104 +62,104 @@ func TestBetaGetAndUpdateCounter(t *testing.T) {
 		Capacity: 500,
 	}
 
-	a := Beta{
+	b := Beta{
 		client: mock,
 	}
 
 	t.Parallel()
 
 	t.Run("Set Counter and Set Capacity", func(t *testing.T) {
-		count, err := a.GetCounterCount("sessions")
+		count, err := b.GetCounterCount("sessions")
 		assert.NoError(t, err)
 		assert.Equal(t, sessions.Count, count)
 
-		capacity, err := a.GetCounterCapacity("sessions")
+		capacity, err := b.GetCounterCapacity("sessions")
 		assert.NoError(t, err)
 		assert.Equal(t, sessions.Capacity, capacity)
 
 		wantCapacity := int64(25)
-		err = a.SetCounterCapacity("sessions", wantCapacity)
+		err = b.SetCounterCapacity("sessions", wantCapacity)
 		assert.NoError(t, err)
 
-		capacity, err = a.GetCounterCapacity("sessions")
+		capacity, err = b.GetCounterCapacity("sessions")
 		assert.NoError(t, err)
 		assert.Equal(t, wantCapacity, capacity)
 
 		wantCount := int64(10)
-		err = a.SetCounterCount("sessions", wantCount)
+		err = b.SetCounterCount("sessions", wantCount)
 		assert.NoError(t, err)
 
-		count, err = a.GetCounterCount("sessions")
+		count, err = b.GetCounterCount("sessions")
 		assert.NoError(t, err)
 		assert.Equal(t, wantCount, count)
 	})
 
 	t.Run("Get and Set Non-Defined Counter", func(t *testing.T) {
-		_, err := a.GetCounterCount("secessions")
+		_, err := b.GetCounterCount("secessions")
 		assert.Error(t, err)
 
-		_, err = a.GetCounterCapacity("secessions")
+		_, err = b.GetCounterCapacity("secessions")
 		assert.Error(t, err)
 
-		err = a.SetCounterCapacity("secessions", int64(100))
+		err = b.SetCounterCapacity("secessions", int64(100))
 		assert.Error(t, err)
 
-		err = a.SetCounterCount("secessions", int64(0))
+		err = b.SetCounterCount("secessions", int64(0))
 		assert.Error(t, err)
 	})
 
 	// nolint:dupl // testing DecrementCounter and IncrementCounter are not duplicates.
 	t.Run("Decrement Counter Fails then Success", func(t *testing.T) {
-		count, err := a.GetCounterCount("games")
+		count, err := b.GetCounterCount("games")
 		assert.NoError(t, err)
 		assert.Equal(t, games.Count, count)
 
-		err = a.DecrementCounter("games", 21)
+		err = b.DecrementCounter("games", 21)
 		assert.Error(t, err)
 
-		count, err = a.GetCounterCount("games")
+		count, err = b.GetCounterCount("games")
 		assert.NoError(t, err)
 		assert.Equal(t, games.Count, count)
 
-		err = a.DecrementCounter("games", -12)
+		err = b.DecrementCounter("games", -12)
 		assert.Error(t, err)
 
-		count, err = a.GetCounterCount("games")
+		count, err = b.GetCounterCount("games")
 		assert.NoError(t, err)
 		assert.Equal(t, games.Count, count)
 
-		err = a.DecrementCounter("games", 12)
+		err = b.DecrementCounter("games", 12)
 		assert.NoError(t, err)
 
-		count, err = a.GetCounterCount("games")
+		count, err = b.GetCounterCount("games")
 		assert.NoError(t, err)
 		assert.Equal(t, int64(0), count)
 	})
 
 	// nolint:dupl // testing DecrementCounter and IncrementCounter are not duplicates.
 	t.Run("Increment Counter Fails then Success", func(t *testing.T) {
-		count, err := a.GetCounterCount("gamers")
+		count, err := b.GetCounterCount("gamers")
 		assert.NoError(t, err)
 		assert.Equal(t, gamers.Count, count)
 
-		err = a.IncrementCounter("gamers", 250)
+		err = b.IncrementCounter("gamers", 250)
 		assert.Error(t, err)
 
-		count, err = a.GetCounterCount("gamers")
+		count, err = b.GetCounterCount("gamers")
 		assert.NoError(t, err)
 		assert.Equal(t, gamers.Count, count)
 
-		err = a.IncrementCounter("gamers", -237)
+		err = b.IncrementCounter("gamers", -237)
 		assert.Error(t, err)
 
-		count, err = a.GetCounterCount("gamers")
+		count, err = b.GetCounterCount("gamers")
 		assert.NoError(t, err)
 		assert.Equal(t, gamers.Count, count)
 
-		err = a.IncrementCounter("gamers", 237)
+		err = b.IncrementCounter("gamers", 237)
 		assert.NoError(t, err)
 
-		count, err = a.GetCounterCount("gamers")
+		count, err = b.GetCounterCount("gamers")
 		assert.NoError(t, err)
 		assert.Equal(t, int64(500), count)
 	})
@@ -203,74 +203,74 @@ func TestBetaGetAndUpdateList(t *testing.T) {
 		Capacity: 5,
 	}
 
-	a := Beta{
+	b := Beta{
 		client: mock,
 	}
 
 	t.Parallel()
 
 	t.Run("Get and Set List Capacity", func(t *testing.T) {
-		capacity, err := a.GetListCapacity("foo")
+		capacity, err := b.GetListCapacity("foo")
 		assert.NoError(t, err)
 		assert.Equal(t, foo.Capacity, capacity)
 
 		wantCapacity := int64(5)
-		err = a.SetListCapacity("foo", wantCapacity)
+		err = b.SetListCapacity("foo", wantCapacity)
 		assert.NoError(t, err)
 
-		capacity, err = a.GetListCapacity("foo")
+		capacity, err = b.GetListCapacity("foo")
 		assert.NoError(t, err)
 		assert.Equal(t, wantCapacity, capacity)
 	})
 
 	t.Run("Get List Length, Get List Values, ListContains, and Append List Value", func(t *testing.T) {
-		length, err := a.GetListLength("bar")
+		length, err := b.GetListLength("bar")
 		assert.NoError(t, err)
 		assert.Equal(t, len(bar.Values), length)
 
-		values, err := a.GetListValues("bar")
+		values, err := b.GetListValues("bar")
 		assert.NoError(t, err)
 		assert.Equal(t, bar.Values, values)
 
-		err = a.AppendListValue("bar", "ghi")
+		err = b.AppendListValue("bar", "ghi")
 		assert.NoError(t, err)
 
-		length, err = a.GetListLength("bar")
+		length, err = b.GetListLength("bar")
 		assert.NoError(t, err)
 		assert.Equal(t, len(bar.Values)+1, length)
 
 		wantValues := []string{"abc", "def", "ghi"}
-		values, err = a.GetListValues("bar")
+		values, err = b.GetListValues("bar")
 		assert.NoError(t, err)
 		assert.Equal(t, wantValues, values)
 
-		contains, err := a.ListContains("bar", "ghi")
+		contains, err := b.ListContains("bar", "ghi")
 		assert.NoError(t, err)
 		assert.True(t, contains)
 	})
 
 	t.Run("Get List Length, Get List Values, ListContains, and Delete List Value", func(t *testing.T) {
-		length, err := a.GetListLength("baz")
+		length, err := b.GetListLength("baz")
 		assert.NoError(t, err)
 		assert.Equal(t, len(baz.Values), length)
 
-		values, err := a.GetListValues("baz")
+		values, err := b.GetListValues("baz")
 		assert.NoError(t, err)
 		assert.Equal(t, baz.Values, values)
 
-		err = a.DeleteListValue("baz", "456")
+		err = b.DeleteListValue("baz", "456")
 		assert.NoError(t, err)
 
-		length, err = a.GetListLength("baz")
+		length, err = b.GetListLength("baz")
 		assert.NoError(t, err)
 		assert.Equal(t, len(baz.Values)-1, length)
 
 		wantValues := []string{"123", "789"}
-		values, err = a.GetListValues("baz")
+		values, err = b.GetListValues("baz")
 		assert.NoError(t, err)
 		assert.Equal(t, wantValues, values)
 
-		contains, err := a.ListContains("baz", "456")
+		contains, err := b.ListContains("baz", "456")
 		assert.NoError(t, err)
 		assert.False(t, contains)
 	})
@@ -282,15 +282,15 @@ type betaMock struct {
 	lists    map[string]*beta.List
 }
 
-func (a *betaMock) GetCounter(ctx context.Context, in *beta.GetCounterRequest, opts ...grpc.CallOption) (*beta.Counter, error) {
-	if counter, ok := a.counters[in.Name]; ok {
+func (b *betaMock) GetCounter(ctx context.Context, in *beta.GetCounterRequest, opts ...grpc.CallOption) (*beta.Counter, error) {
+	if counter, ok := b.counters[in.Name]; ok {
 		return counter, nil
 	}
 	return nil, errors.Errorf("counter not found: %s", in.Name)
 }
 
-func (a *betaMock) UpdateCounter(ctx context.Context, in *beta.UpdateCounterRequest, opts ...grpc.CallOption) (*beta.Counter, error) {
-	counter, err := a.GetCounter(ctx, &beta.GetCounterRequest{Name: in.CounterUpdateRequest.Name})
+func (b *betaMock) UpdateCounter(ctx context.Context, in *beta.UpdateCounterRequest, opts ...grpc.CallOption) (*beta.Counter, error) {
+	counter, err := b.GetCounter(ctx, &beta.GetCounterRequest{Name: in.CounterUpdateRequest.Name})
 	if err != nil {
 		return nil, err
 	}
@@ -319,17 +319,17 @@ func (a *betaMock) UpdateCounter(ctx context.Context, in *beta.UpdateCounterRequ
 			in.CounterUpdateRequest)
 	}
 
-	a.counters[in.CounterUpdateRequest.Name] = counter
-	return a.counters[in.CounterUpdateRequest.Name], nil
+	b.counters[in.CounterUpdateRequest.Name] = counter
+	return b.counters[in.CounterUpdateRequest.Name], nil
 }
 
 // GetList returns the list of betaMock. Note: unlike the SDK Server, this does not return
 // a list with any pending batched changes applied.
-func (a *betaMock) GetList(ctx context.Context, in *beta.GetListRequest, opts ...grpc.CallOption) (*beta.List, error) {
+func (b *betaMock) GetList(ctx context.Context, in *beta.GetListRequest, opts ...grpc.CallOption) (*beta.List, error) {
 	if in == nil {
 		return nil, errors.Errorf("GetListRequest cannot be nil")
 	}
-	if list, ok := a.lists[in.Name]; ok {
+	if list, ok := b.lists[in.Name]; ok {
 		return list, nil
 	}
 	return nil, errors.Errorf("list not found: %s", in.Name)
@@ -337,11 +337,11 @@ func (a *betaMock) GetList(ctx context.Context, in *beta.GetListRequest, opts ..
 
 // Note: unlike the SDK Server, UpdateList does not batch changes and instead updates the list
 // directly.
-func (a *betaMock) UpdateList(ctx context.Context, in *beta.UpdateListRequest, opts ...grpc.CallOption) (*beta.List, error) {
+func (b *betaMock) UpdateList(ctx context.Context, in *beta.UpdateListRequest, opts ...grpc.CallOption) (*beta.List, error) {
 	if in == nil {
 		return nil, errors.Errorf("UpdateListRequest cannot be nil")
 	}
-	list, ok := a.lists[in.List.Name]
+	list, ok := b.lists[in.List.Name]
 	if !ok {
 		return nil, errors.Errorf("list not found: %s", in.List.Name)
 	}
@@ -352,17 +352,17 @@ func (a *betaMock) UpdateList(ctx context.Context, in *beta.UpdateListRequest, o
 	if len(list.Values) > int(list.Capacity) {
 		list.Values = append([]string{}, list.Values[:list.Capacity]...)
 	}
-	a.lists[in.List.Name] = list
+	b.lists[in.List.Name] = list
 	return &beta.List{}, nil
 }
 
 // Note: unlike the SDK Server, AddListValue does not batch changes and instead updates the list
 // directly.
-func (a *betaMock) AddListValue(ctx context.Context, in *beta.AddListValueRequest, opts ...grpc.CallOption) (*beta.List, error) {
+func (b *betaMock) AddListValue(ctx context.Context, in *beta.AddListValueRequest, opts ...grpc.CallOption) (*beta.List, error) {
 	if in == nil {
 		return nil, errors.Errorf("AddListValueRequest cannot be nil")
 	}
-	list, ok := a.lists[in.Name]
+	list, ok := b.lists[in.Name]
 	if !ok {
 		return nil, errors.Errorf("list not found: %s", in.Name)
 	}
@@ -375,17 +375,17 @@ func (a *betaMock) AddListValue(ctx context.Context, in *beta.AddListValueReques
 		}
 	}
 	list.Values = append(list.Values, in.Value)
-	a.lists[in.Name] = list
+	b.lists[in.Name] = list
 	return &beta.List{}, nil
 }
 
 // Note: unlike the SDK Server, RemoveListValue does not batch changes and instead updates the list
 // directly.
-func (a *betaMock) RemoveListValue(ctx context.Context, in *beta.RemoveListValueRequest, opts ...grpc.CallOption) (*beta.List, error) {
+func (b *betaMock) RemoveListValue(ctx context.Context, in *beta.RemoveListValueRequest, opts ...grpc.CallOption) (*beta.List, error) {
 	if in == nil {
 		return nil, errors.Errorf("RemoveListValueRequest cannot be nil")
 	}
-	list, ok := a.lists[in.Name]
+	list, ok := b.lists[in.Name]
 	if !ok {
 		return nil, errors.Errorf("list not found: %s", in.Name)
 	}
@@ -394,7 +394,7 @@ func (a *betaMock) RemoveListValue(ctx context.Context, in *beta.RemoveListValue
 			continue
 		}
 		list.Values = append(list.Values[:i], list.Values[i+1:]...)
-		a.lists[in.Name] = list
+		b.lists[in.Name] = list
 		return &beta.List{}, nil
 	}
 	return nil, errors.Errorf("not found. Value: %s not found in List: %s", in.Value, in.Name)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

See #3767#update-vs-patch

**Which issue(s) this PR fixes**:

Completes part II of #3767

**Special notes for your reviewer**:

I did not change PlayerTracking as the feature will be deprecated.
