### PR TITLE
removes ltsc 2019

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -50,7 +50,7 @@ WINDOWS_DOCKER_PUSH_ARGS =
 # Versions of Windows Server to support, default is Windows Server 2019.
 # For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
 # GKE-Windows version map: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#version_mapping
-WINDOWS_VERSIONS = ltsc2019 ltsc2022
+WINDOWS_VERSIONS = ltsc2022
 
 # Specify stress test level 1..100
 # STRESS_TEST_LEVEL=n requires capacity between 50*n up to 100*n simple-game-server Game Servers.

--- a/build/README.md
+++ b/build/README.md
@@ -459,7 +459,7 @@ This option is enabled by default via implicit `make WITH_WINDOWS=1 build-images
 To disable, use `make WITH_WINDOWS=0 build-images`.
 
 ### WINDOWS_VERSIONS
-List of Windows Server versions to build for. Defaults to `ltsc2019` for Windows Server 2019.
+List of Windows Server versions to build for. Defaults to `ltsc2022` for Windows Server 2022.
 See https://hub.docker.com/_/microsoft-windows-servercore for all available Windows versions.
 
 ### WITH_ARM64
@@ -585,7 +585,7 @@ make test-e2e-integration ARGS='-run TestGameServerReserve'
 Run controller failure portion of the end-to-end tests.
 
 #### `make test-e2e-allocator-crash`
-Run allocator failure portion of the end-to-end test. 
+Run allocator failure portion of the end-to-end test.
 
 #### `make setup-prometheus`
 

--- a/cmd/sdk-server/Dockerfile.windows
+++ b/cmd/sdk-server/Dockerfile.windows
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG WINDOWS_VERSION=ltsc2019
+ARG WINDOWS_VERSION=ltsc2022
 FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 
 COPY ./bin/sdk-server.windows.amd64.exe /agones/sdk-server.exe

--- a/examples/simple-game-server/Dockerfile.windows
+++ b/examples/simple-game-server/Dockerfile.windows
@@ -18,7 +18,7 @@
 # for details.
 
 # Build Stage
-ARG WINDOWS_VERSION=ltsc2019
+ARG WINDOWS_VERSION=ltsc2022
 
 FROM --platform=linux/amd64 golang:1.21.6 as builder
 WORKDIR /go/src

--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -29,7 +29,7 @@ BUILDX_WINDOWS_BUILDER = windows-builder
 # Versions of Windows Server to support, default is Windows Server 2019.
 # For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
 # GKE-Windows version map: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#version_mapping
-WINDOWS_VERSIONS = ltsc2019 ltsc2022
+WINDOWS_VERSIONS = ltsc2022
 WINDOWS_DOCKER_PUSH_ARGS = # When pushing set to --push.
 # Build with Windows support
 WITH_WINDOWS ?= 1

--- a/examples/xonotic/Dockerfile.windows
+++ b/examples/xonotic/Dockerfile.windows
@@ -34,7 +34,7 @@
 # Use `--build-arg WINDOWS_VERSION=` to select the correct base image
 # See https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
 # for details.
-ARG WINDOWS_VERSION=ltsc2019
+ARG WINDOWS_VERSION=ltsc2022
 
 # Build Stage
 FROM --platform=linux/amd64 golang:1.21.6 as base

--- a/examples/xonotic/Makefile
+++ b/examples/xonotic/Makefile
@@ -26,7 +26,7 @@
 REPOSITORY ?=
 PROD_REPO ?= us-docker.pkg.dev/agones-images/examples
 
-WINDOWS_VERSIONS = ltsc2019 ltsc2022
+WINDOWS_VERSIONS = ltsc2022
 BUILDX_WINDOWS_BUILDER = windows-builder
 
 # Build with Windows support


### PR DESCRIPTION
**What type of PR is this?**

/kind hotfix

**What this PR does / Why we need it**:

To fix builds failing with:

```
ERROR: failed to solve: failed to compute cache key: mount callback failed on /tmp/containerd-mount2222915415: link /tmp/containerd-mount2222915415/Windows/INF/basicrender.inf /tmp/containerd-mount2222915415/Windows/System32/DriverStore/FileRepository/basicrender.inf_amd64_efdc64af60c69a6d/basicrender.inf: no such file or directory
```

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


