### PR TITLE
Skip /tmp/ on yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -46,4 +46,5 @@ ignore:
   - /site/node_modules/
   - /site/themes/docsy/
   - /site/vendor/
+  - /tmp/
   - /vendor/


### PR DESCRIPTION
I use `tmp` for random config - ignore it in `make lint`.

