### PR TITLE
docs: clarify virtualization setup for Windows versions

### DIFF
--- a/site/content/en/docs/Installation/Creating Cluster/minikube.md
+++ b/site/content/en/docs/Installation/Creating Cluster/minikube.md
@@ -52,10 +52,11 @@ via Agones exposed ports.
 * Docker (default)
 * Hyperkit
 
-**Windows (amd64)**
-* hyper-v (might need
-  <a href="https://blog.thepolyglotprogrammer.com/setting-up-kubernetes-on-wsl-to-work-with-minikube-on-windows-10-90dac3c72fa1">this blog post</a>
-  and/or [this comment](https://github.com/microsoft/WSL/issues/4288#issuecomment-652259640) for WSL support)
+**Windows (amd64 - Windows 10 Enterprise or Pro)**
+* Hyper-V: You might need to refer to [this blog post](https://blog.thepolyglotprogrammer.com/setting-up-kubernetes-on-wsl-to-work-with-minikube-on-windows-10-90dac3c72fa1) and/or [this comment](https://github.com/microsoft/WSL/issues/4288#issuecomment-652259640) for WSL support.
+
+**Windows (amd64 - Windows 10 Home)**
+* VirtualBox: You might need [this command](https://github.com/kubernetes/minikube/issues/3900) to disable hardware virtualization checks before starting the VM.
 
 _If you have successfully tested with other platforms and drivers, please click "edit this page" in the top right hand
 side and submit a pull request to let us know._


### PR DESCRIPTION
- Separate Hyper-V setup for Windows 10 Enterprise/Pro
- Add VirtualBox instructions for Windows 10 Home

**What type of PR is this?**
/kind documentation

**What this PR does / Why we need it**:
Clarifies virtualization setup for Windows versions, specifying Hyper-V for Enterprise/Pro and VirtualBox for Home, with relevant support links. 

**Special notes for your reviewer**:
The VirtualBox driver has been successfully tested with the latest version of the simple-game-server: https://raw.githubusercontent.com/googleforgames/agones/release-1.40.0/examples/simple-game-server/gameserver.yaml

