### PR TITLE
Add security context to Agones containers

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -103,6 +103,10 @@ spec:
       - name: agones-controller
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ default .Values.agones.image.tag .Values.agones.image.controller.tag }}"
         imagePullPolicy: {{ .Values.agones.image.controller.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
         env:
         # minimum port that can be exposed to GameServer traffic
         - name: MIN_PORT

--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         imagePullPolicy: {{ .Values.agones.image.extensions.pullPolicy }}
         securityContext:
           runAsNonRoot: true
-          runAsUser: 1001
+          runAsUser: 1000
           allowPrivilegeEscalation: false
         env:
         - name: PROMETHEUS_EXPORTER

--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -97,6 +97,10 @@ spec:
       - name: agones-extensions
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.extensions.name}}:{{ default .Values.agones.image.tag .Values.agones.image.extensions.tag }}"
         imagePullPolicy: {{ .Values.agones.image.extensions.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
         env:
         - name: PROMETHEUS_EXPORTER
           value: {{ .Values.agones.metrics.prometheusEnabled | quote }}

--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -90,6 +90,10 @@ spec:
         - name: agones-ping
           image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.ping.name}}:{{ default .Values.agones.image.tag .Values.agones.image.ping.tag }}"
           imagePullPolicy: {{ .Values.agones.image.ping.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1002
+            allowPrivilegeEscalation: false
 {{- if .Values.agones.ping.resources }}
           resources:
 {{ toYaml .Values.agones.ping.resources | indent 12 }}

--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -92,7 +92,7 @@ spec:
           imagePullPolicy: {{ .Values.agones.image.ping.pullPolicy }}
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1002
+            runAsUser: 1000
             allowPrivilegeEscalation: false
 {{- if .Values.agones.ping.resources }}
           resources:

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -231,7 +231,7 @@ spec:
         imagePullPolicy: {{ .Values.agones.image.allocator.pullPolicy }}
         securityContext:
           runAsNonRoot: true
-          runAsUser: 1003
+          runAsUser: 1000
           allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -229,6 +229,10 @@ spec:
       - name: agones-allocator
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.allocator.name}}:{{ default .Values.agones.image.tag .Values.agones.image.allocator.tag }}"
         imagePullPolicy: {{ .Values.agones.image.allocator.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1003
+          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /live

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -17227,7 +17227,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: true
-          runAsUser: 1001
+          runAsUser: 1000
           allowPrivilegeEscalation: false
         env:
         - name: PROMETHEUS_EXPORTER
@@ -17368,7 +17368,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1002
+            runAsUser: 1000
             allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
@@ -17446,7 +17446,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: true
-          runAsUser: 1003
+          runAsUser: 1000
           allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -17061,6 +17061,10 @@ spec:
       - name: agones-controller
         image: "us-docker.pkg.dev/agones-images/release/agones-controller:1.41.0"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
         env:
         # minimum port that can be exposed to GameServer traffic
         - name: MIN_PORT
@@ -17221,6 +17225,10 @@ spec:
       - name: agones-extensions
         image: "us-docker.pkg.dev/agones-images/release/agones-extensions:1.41.0"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
         env:
         - name: PROMETHEUS_EXPORTER
           value: "true"
@@ -17358,6 +17366,10 @@ spec:
         - name: agones-ping
           image: "us-docker.pkg.dev/agones-images/release/agones-ping:1.41.0"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1002
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               port: 8080
@@ -17432,6 +17444,10 @@ spec:
       - name: agones-allocator
         image: "us-docker.pkg.dev/agones-images/release/agones-allocator:1.41.0"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1003
+          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /live


### PR DESCRIPTION
Added runAsNonRoot(true) and allowPrivilegeEscalation(false) into the containers field of controller, extensions, ping, and allocator.

Left out sidecar because it is generated by the controller and require another set of changes.

Towards #3848 