### PR TITLE
Moved Passthrough feature description to the correct section in Feature Stages

### DIFF
--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -28,6 +28,7 @@ The current set of `alpha` and `beta` feature gates:
 |-----------------------------------------------------------------------------------------------------------------------------|------------------------------------|----------|---------|--------|
 | [CountsAndLists](https://github.com/googleforgames/agones/issues/2716)                                                      | `CountsAndLists`                   | Enabled  | `Beta` | 1.41.0 |
 | [DisableResyncOnSDKServer](https://github.com/googleforgames/agones/issues/3377)                                            | `DisableResyncOnSDKServer`         | Enabled  | `Beta`  | 1.40.0 |
+| [Support Passthrough on GKE Autopilot](https://github.com/googleforgames/agones/issues/3721)                                | `AutopilotPassthroughPort`         | Disabled | `Alpha` | 1.41.0 |
 | [Support for Extended Duration Pods on GKE Autopilot (*1.28+ only*)](https://github.com/googleforgames/agones/issues/3386)  | `GKEAutopilotExtendedDurationPods` | Disabled | `Alpha` | 1.37.0 |
 | [GameServer player capacity filtering on GameServerAllocations](https://github.com/googleforgames/agones/issues/1239)       | `PlayerAllocationFilter`           | Disabled | `Alpha` | 1.14.0 |
 | [Player Tracking]({{< ref "/docs/Guides/player-tracking.md" >}})                                                            | `PlayerTracking`                   | Disabled | `Alpha` | 1.6.0  |


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
/kind hotfix
> /kind release

**What this PR does / Why we need it**:
 Doc change for Passthrough feature in the Feature Stages was in the wrong place

**Which issue(s) this PR fixes**:
Related to #3721 

**Special notes for your reviewer**:


