### PR TITLE
Update csharp.md to indicate ConnectAsync is deprecated

### DIFF
--- a/sdks/csharp/sdk/AgonesSDK.cs
+++ b/sdks/csharp/sdk/AgonesSDK.cs
@@ -103,18 +103,6 @@ namespace Agones
 			return beta;
 		}
 
-
-
-		/// <summary>
-		/// Connect the underlying gRPC channel.
-		/// </summary>
-		/// <returns>Always return true</returns>
-		[Obsolete("No need to call ConnectAsync anymore")]
-		public async Task<bool> ConnectAsync()
-		{
-			return true;
-		}
-
 		/// <summary>
 		/// Tells Agones that the Game Server is ready to take player connections
 		/// </summary>

--- a/sdks/csharp/sdk/IAgonesSDK.cs
+++ b/sdks/csharp/sdk/IAgonesSDK.cs
@@ -21,7 +21,6 @@ namespace Agones
 {
     public interface IAgonesSDK : IDisposable
     {
-        Task<bool> ConnectAsync();
         Task<Status> ReadyAsync();
         Task<Status> AllocateAsync();
         Task<Status> ReserveAsync(long seconds);

--- a/site/content/en/docs/Guides/Client SDKs/csharp.md
+++ b/site/content/en/docs/Guides/Client SDKs/csharp.md
@@ -77,7 +77,7 @@ var agones = new AgonesSDK();
 {{% feature expiryVersion="1.42.0" %}}
 ### Connection
 
-and will return `false` if there was an issue connecting. This is an obsolete function that now always returns true.
+The `ConnectAsync()` method is an obsolete function that now always returns true.
 
 ```csharp
 bool ok = await agones.ConnectAsync();

--- a/site/content/en/docs/Guides/Client SDKs/csharp.md
+++ b/site/content/en/docs/Guides/Client SDKs/csharp.md
@@ -77,8 +77,6 @@ var agones = new AgonesSDK();
 {{% feature expiryVersion="1.42.0" %}}
 ### Connection
 
-To connect to the SDK server, either locally or when running on Agones, run the `ConnectAsync()` method.
-This will wait for up to 30 seconds if the SDK server has not yet started and the connection cannot be made,
 and will return `false` if there was an issue connecting. This is an obsolete function that now always returns true.
 
 ```csharp

--- a/site/content/en/docs/Guides/Client SDKs/csharp.md
+++ b/site/content/en/docs/Guides/Client SDKs/csharp.md
@@ -357,7 +357,9 @@ bool isConnected = await agones.Alpha().IsPlayerConnectedAsync(playerId);
 ```
 
 ## Remarks
+{{% feature expiryVersion="1.42.0" %}}
 - All requests other than `ConnectAsync` will wait for up to 15 seconds before giving up, time to wait can also be set in the constructor.
+{{% /feature %}}
 - Default host & port are `localhost:9357`
 - Methods that do not return a data object such as `GameServer` will return a gRPC `Grpc.Core.Status` object. To check the state of the request, check `Status.StatusCode` & `Status.Detail`.
 Ex:

--- a/site/content/en/docs/Guides/Client SDKs/csharp.md
+++ b/site/content/en/docs/Guides/Client SDKs/csharp.md
@@ -76,9 +76,9 @@ var agones = new AgonesSDK();
 
 ### Connection
 
-To connect to the SDK server, either locally or when running on Agones, run the `ConnectAsync()` method.
+~To connect to the SDK server, either locally or when running on Agones, run the `ConnectAsync()` method.
 This will wait for up to 30 seconds if the SDK server has not yet started and the connection cannot be made,
-and will return `false` if there was an issue connecting.
+and will return `false` if there was an issue connecting.~ This is an obsolete function that now always returns true.
 
 ```csharp
 bool ok = await agones.ConnectAsync();

--- a/site/content/en/docs/Guides/Client SDKs/csharp.md
+++ b/site/content/en/docs/Guides/Client SDKs/csharp.md
@@ -74,16 +74,17 @@ To use the AgonesSDK, you will need to import the namespace by adding `using Ago
 var agones = new AgonesSDK();
 ```
 
+{{% feature expiryVersion="1.42.0" %}}
 ### Connection
 
-~To connect to the SDK server, either locally or when running on Agones, run the `ConnectAsync()` method.
+To connect to the SDK server, either locally or when running on Agones, run the `ConnectAsync()` method.
 This will wait for up to 30 seconds if the SDK server has not yet started and the connection cannot be made,
-and will return `false` if there was an issue connecting.~ This is an obsolete function that now always returns true.
+and will return `false` if there was an issue connecting. This is an obsolete function that now always returns true.
 
 ```csharp
 bool ok = await agones.ConnectAsync();
 ```
-
+{{% /feature %}}
 ### Ready
 
 To mark the game server as [ready to receive player connections]({{< relref "_index.md#ready" >}}), call the async method `ReadyAsync()`.

--- a/site/content/en/docs/Guides/Client SDKs/csharp.md
+++ b/site/content/en/docs/Guides/Client SDKs/csharp.md
@@ -360,6 +360,9 @@ bool isConnected = await agones.Alpha().IsPlayerConnectedAsync(playerId);
 {{% feature expiryVersion="1.42.0" %}}
 - All requests other than `ConnectAsync` will wait for up to 15 seconds before giving up, time to wait can also be set in the constructor.
 {{% /feature %}}
+{{% feature publishVersion="1.42.0" %}}
+- All requests will wait for up to 15 seconds before giving up. Time to wait can also be set in the constructor.
+{{% /feature %}}
 - Default host & port are `localhost:9357`
 - Methods that do not return a data object such as `GameServer` will return a gRPC `Grpc.Core.Status` object. To check the state of the request, check `Status.StatusCode` & `Status.Detail`.
 Ex:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind documentation


**What this PR does / Why we need it**:
As I was following the AgonesSDK C# guide I noticed that when I tried using `ConnectAsync` the function has actually been deprecated. It'd be good to get verbiage into the documentation so other Agones users know they don't have to use this method any longer.

![Screenshot 2024-06-11 at 12 08 18 PM](https://github.com/googleforgames/agones/assets/3106250/c7eec8d4-80a0-4a39-ba61-778947098010)
![Screenshot 2024-06-11 at 12 08 25 PM](https://github.com/googleforgames/agones/assets/3106250/bc16cb86-2de9-4951-b5f6-60966f26c749)
Source @ [agones/sdks/csharp/sdk/AgonesSDK.cs#112](https://github.com/googleforgames/agones/blob/main/sdks/csharp/sdk/AgonesSDK.cs#L112)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
Unsure if a strike through is desired or if the documentation block should just be completely removed. Let me know what you'd prefer. If I don't respond quickly enough please feel free to take on the documentation changes outside this PR.

