### PR TITLE
Change Slack channel description from #developers to #development

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -154,7 +154,7 @@ desc = "Chat with other project users in #users"
 	name = "Slack"
 	url = "https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWU3ODAyZjdjMjNlYWIxZTAwODkxMGY3YWEyZjNjMjc4YWM1Zjk0OThlMGU2ZmUyMzRlMDljNDJiNmZlMGQ1M2U"
 	icon = "fab fa-slack"
-	desc = "Chat with other project developers in #developers"
+	desc = "Chat with other project developers in #development"
 [[params.links.developer]]
 	name ="Community Meetings"
 	url = "https://www.youtube.com/playlist?list=PLhkWKwFGACw2dFpdmwxOyUCzlGP2-n7uF"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind documentation


**What this PR does / Why we need it**:
This PR updates the Slack channel description in the `config.toml` file to the correct channel name. The description is changed from `#developers` to `#development`.

On the [community](https://agones.dev/site/community/) page it says to contribute on the slack channel `#developers`
![image](https://github.com/googleforgames/agones/assets/36856538/275d455c-2a2a-4571-9188-41ee7a29ff23)

Though in slack the name of the channel is actually `#development`:
![image](https://github.com/googleforgames/agones/assets/36856538/f5dd2958-8218-49ae-b11a-8cf1e9f480ca)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
None

