### PR TITLE
featuregate: adds validation if PortPolicyNone is not enabled

### DIFF
--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -528,6 +528,14 @@ func (gss *GameServerSpec) validateFeatureGates(fldPath *field.Path) field.Error
 		}
 	}
 
+	if !runtime.FeatureEnabled(runtime.FeaturePortPolicyNone) {
+		for i, p := range gss.Ports {
+			if p.PortPolicy == None {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("ports").Index(i).Child("portPolicy"), fmt.Sprintf("Value cannot be set to %s unless feature flag %s is enabled", None, runtime.FeaturePortPolicyNone)))
+			}
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -1256,6 +1256,52 @@ func TestGameServerValidateFeatures(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "PortPolicyNone is disabled, PortPolicy field set to None",
+			feature:     fmt.Sprintf("%s=false", runtime.FeaturePortPolicyNone),
+			gs: GameServer{
+				Spec: GameServerSpec{
+					Ports: []GameServerPort{
+						{
+							Name:          "main",
+							ContainerPort: 7777,
+							PortPolicy:    None,
+						},
+					},
+					Container: "testing",
+					Lists:     map[string]ListStatus{},
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "testing", Image: "testing/image"}}},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec.ports[0].portPolicy"),
+					"Value cannot be set to None unless feature flag PortPolicyNone is enabled",
+				),
+			},
+		},
+		{
+			description: "PortPolicyNone is enabled, PortPolicy field set to None",
+			feature:     fmt.Sprintf("%s=true", runtime.FeaturePortPolicyNone),
+			gs: GameServer{
+				Spec: GameServerSpec{
+					Ports: []GameServerPort{
+						{
+							Name:          "main",
+							ContainerPort: 7777,
+							PortPolicy:    None,
+						},
+					},
+					Container: "testing",
+					Lists:     map[string]ListStatus{},
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "testing", Image: "testing/image"}}},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1499,7 +1545,8 @@ func TestGameServerPassthroughPortAnnotation(t *testing.T) {
 					{Name: "containerOne", Image: "container/image"},
 					{Name: "containerTwo", Image: "container/image"},
 					{Name: "containerThree", Image: "container/image"},
-					{Name: "containerFour", Image: "container/image"}},
+					{Name: "containerFour", Image: "container/image"},
+				},
 			},
 		},
 	}}


### PR DESCRIPTION
When the feature gate PortPolicyNone is used, validation should fail if the PortPolicy field is set to the value None.

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
Without this validation, then the Container Port is set to 0 and it silently fails.

**Which issue(s) this PR fixes**:
Closes #3867

**Special notes for your reviewer**:


