### PR TITLE
Drop CountsAndLists Data from the Fleet and Game Server Set When the Flag is False

### DIFF
--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -678,6 +678,13 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 		fCopy.Status.Counters = make(map[string]agonesv1.AggregatedCounterStatus)
 		fCopy.Status.Lists = make(map[string]agonesv1.AggregatedListStatus)
 	}
+	// Drop Counters and Lists status if the feature flag has been set to false
+	if !runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
+		if len(fCopy.Status.Counters) != 0 || len(fCopy.Status.Lists) != 0 {
+			fCopy.Status.Counters = map[string]agonesv1.AggregatedCounterStatus{}
+			fCopy.Status.Lists = map[string]agonesv1.AggregatedListStatus{}
+		}
+	}
 
 	for _, gsSet := range list {
 		fCopy.Status.Replicas += gsSet.Status.Replicas

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -635,6 +635,13 @@ func computeStatus(list []*agonesv1.GameServer) agonesv1.GameServerSetStatus {
 			status.ReservedReplicas++
 		}
 
+		// Drop Counters and Lists status if the feature flag has been set to false
+		if !runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
+			if len(status.Counters) != 0 || len(status.Lists) != 0 {
+				status.Counters = map[string]agonesv1.AggregatedCounterStatus{}
+				status.Lists = map[string]agonesv1.AggregatedListStatus{}
+			}
+		}
 		// Aggregates all Counters and Lists only for GameServer all states (except IsBeingDeleted)
 		if runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
 			status.Counters = aggregateCounters(status.Counters, gs.Status.Counters, gs.Status.State)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

When the CountsAndLists FeatureGate is turned from on (true) to off (false) during a `helm upgrade`, the Fleet and Game Server Set stop aggregating CountsAndLists data. However, they currently still show (`kubectl describe fleet` or `kubectl describe gss`)  the old static AggregatedCounterStatus and AggregatedListStatus from before the flag was turned off. 

This PR drops the AggregatedCounterStatus and AggregatedListStatus from the Fleet and Game Server Set Status when the FeatureGate CountsAndLists is turned off. The Status will be recalculated if the flag is turned back on.

**Which issue(s) this PR fixes**:

Working on In-place Agones Upgrades: Storage Compatibility #3771

**Special notes for your reviewer**:


