### PR TITLE
Adds tests to confirm that Fleet, Fleet Autoscaler, and Fleet Allocation apply defaults code is idempotent

### DIFF
--- a/pkg/apis/agones/v1/fleet_test.go
+++ b/pkg/apis/agones/v1/fleet_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"agones.dev/agones/pkg"
 	"agones.dev/agones/pkg/apis"
 	"agones.dev/agones/pkg/util/runtime"
 )
@@ -108,6 +109,16 @@ func TestFleetApplyDefaults(t *testing.T) {
 	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxSurge.String())
 	assert.Equal(t, apis.Packed, f.Spec.Scheduling)
 	assert.Equal(t, int32(0), f.Spec.Replicas)
+	assert.Equal(t, pkg.Version, f.ObjectMeta.Annotations[VersionAnnotation])
+
+	// Test apply defaults is idempotent -- calling ApplyDefaults more than one time does not change the original result.
+	f.ApplyDefaults()
+	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, f.Spec.Strategy.Type)
+	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxUnavailable.String())
+	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxSurge.String())
+	assert.Equal(t, apis.Packed, f.Spec.Scheduling)
+	assert.Equal(t, int32(0), f.Spec.Replicas)
+	assert.Equal(t, pkg.Version, f.ObjectMeta.Annotations[VersionAnnotation])
 }
 
 func TestFleetUpperBoundReplicas(t *testing.T) {

--- a/pkg/apis/allocation/v1/gameserverallocation_test.go
+++ b/pkg/apis/allocation/v1/gameserverallocation_test.go
@@ -139,6 +139,14 @@ func TestGameServerSelectorApplyDefaults(t *testing.T) {
 	assert.NotNil(t, s.Counters)
 	assert.NotNil(t, s.Lists)
 
+	// Test apply defaults is idempotent -- calling ApplyDefaults more than one time does not change the original result.
+	s.ApplyDefaults()
+	assert.Equal(t, agonesv1.GameServerStateReady, *s.GameServerState)
+	assert.Equal(t, int64(0), s.Players.MinAvailable)
+	assert.Equal(t, int64(0), s.Players.MaxAvailable)
+	assert.NotNil(t, s.Counters)
+	assert.NotNil(t, s.Lists)
+
 	state := agonesv1.GameServerStateAllocated
 	// set values
 	s = &GameServerSelector{
@@ -147,6 +155,19 @@ func TestGameServerSelectorApplyDefaults(t *testing.T) {
 		Counters:        map[string]CounterSelector{"foo": {MinAvailable: 1, MaxAvailable: 10}},
 		Lists:           map[string]ListSelector{"bar": {MinAvailable: 2}},
 	}
+	s.ApplyDefaults()
+	assert.Equal(t, state, *s.GameServerState)
+	assert.Equal(t, int64(10), s.Players.MinAvailable)
+	assert.Equal(t, int64(20), s.Players.MaxAvailable)
+	assert.Equal(t, int64(0), s.Counters["foo"].MinCount)
+	assert.Equal(t, int64(0), s.Counters["foo"].MaxCount)
+	assert.Equal(t, int64(1), s.Counters["foo"].MinAvailable)
+	assert.Equal(t, int64(10), s.Counters["foo"].MaxAvailable)
+	assert.Equal(t, int64(2), s.Lists["bar"].MinAvailable)
+	assert.Equal(t, int64(0), s.Lists["bar"].MaxAvailable)
+	assert.Equal(t, "", s.Lists["bar"].ContainsValue)
+
+	// Test apply defaults is idempotent -- calling ApplyDefaults more than one time does not change the original result.
 	s.ApplyDefaults()
 	assert.Equal(t, state, *s.GameServerState)
 	assert.Equal(t, int64(10), s.Players.MinAvailable)

--- a/pkg/apis/autoscaling/v1/fleetautoscaler.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler.go
@@ -121,7 +121,7 @@ const (
 	// FixedIntervalSyncType is a simple fixed interval based strategy for trigger autoscaling
 	FixedIntervalSyncType FleetAutoscalerSyncType = "FixedInterval"
 
-	defaultIntervalSyncSeconds = 30
+	defaultIntervalSyncSeconds int32 = 30
 )
 
 // BufferPolicy controls the desired behavior of the buffer policy.

--- a/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
@@ -456,6 +456,24 @@ func TestFleetAutoscalerListValidateUpdate(t *testing.T) {
 	}
 }
 
+func TestFleetAutoscalerApplyDefaults(t *testing.T) {
+	fas := &FleetAutoscaler{}
+
+	// gate
+	assert.Nil(t, fas.Spec.Sync)
+
+	fas.ApplyDefaults()
+	assert.NotNil(t, fas.Spec.Sync)
+	assert.Equal(t, FixedIntervalSyncType, fas.Spec.Sync.Type)
+	assert.Equal(t, defaultIntervalSyncSeconds, fas.Spec.Sync.FixedInterval.Seconds)
+
+	// Test apply defaults is idempotent -- calling ApplyDefaults more than one time does not change the original result.
+	fas.ApplyDefaults()
+	assert.NotNil(t, fas.Spec.Sync)
+	assert.Equal(t, FixedIntervalSyncType, fas.Spec.Sync.Type)
+	assert.Equal(t, defaultIntervalSyncSeconds, fas.Spec.Sync.FixedInterval.Seconds)
+}
+
 func defaultFixture() *FleetAutoscaler {
 	return customFixture(BufferPolicyType)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

Adds tests to confirm that calling Fleet, Fleet Autoscaler, and Fleet Allocation ApplyDefaults more than one time does not change the original result. 

**Which issue(s) this PR fixes**:

Working on #3771

**Special notes for your reviewer**:

This does not change the Game Server ApplyDefaults code, or expect the Game Server ApplyDefaults code to be idempotent.