### PR TITLE
Changes for GitHub/Cloud Build app integration

### DIFF
--- a/build/always/always-be-building.yaml
+++ b/build/always/always-be-building.yaml
@@ -32,6 +32,6 @@ steps:
         exit 0
       fi
       echo "== Build queue empty, starting `main` build =="
-      gcloud builds triggers run da003bb8-e9bb-4983-a556-e77fb92f17ca --branch=main
+      gcloud builds triggers run 709790cf-29e1-4350-9407-de7cb5b1dc9e --branch=main
 tags: [always-be-building]
 timeout: 300s  # generous time in case builds take a while to list

--- a/ci/perf-test-cloudbuild.yaml
+++ b/ci/perf-test-cloudbuild.yaml
@@ -108,7 +108,7 @@ substitutions:
   _TEST_DURATION: "10m"
   _TEST_CLIENTS: "50"
   _TEST_INTERVAL: "1000"
-tags: [ci, 'commit-${COMMIT_SHA}']
+tags: [perf, 'commit-${COMMIT_SHA}']
 timeout: 7200s  # 2h
 queueTtl: 10800s  # 3h
 options:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -232,11 +232,9 @@ steps:
       TS='date --utc +%FT%TZ'  # e.g. 2023-01-26T13:30:37Z
       echo "$(${TS}): Waiting to become oldest running build"
       while true; do
-        # Filter to running builds within the same TRIGGER_NAME. We use the trigger name to
-        # filter rather than buildTriggerId because there is no substitution available for
-        # buildTriggerId.
-        TRIGGER_FILTER="status=WORKING AND substitutions[TRIGGER_NAME]='${TRIGGER_NAME}'"
-        OLDEST=$(gcloud builds list --filter "${TRIGGER_FILTER}" --format="value(id,startTime)" --sort-by=startTime --limit=1)
+        # Filter to running builds with tag 'ci', which covers any builds running e2es.
+        BUILD_FILTER="status=WORKING AND tags='ci'"
+        OLDEST=$(gcloud builds list --filter "${BUILD_FILTER}" --format="value(id,startTime)" --sort-by=startTime --limit=1)
         echo "$(${TS}): Oldest is (id startTime): ${OLDEST}"
         if echo ${OLDEST} | grep -q "${BUILD_ID}"; then
           echo "$(${TS}): That's us, we're done!"


### PR DESCRIPTION
There are now two triggers, a branch build trigger and a PR build trigger. So:

* Fix always-be-building to use the branch build trigger
* Change the tags on perf test so it's 'perf' instead of 'ci'
* Use the 'ci' tag instead of the trigger for the filter when waiting for e2es (there are now two triggers running e2es)

