### PR TITLE
A script enables developers to more easily run agones unity sdk tests

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+function unity_editor_path(){
+  local version=$1
+  case "$(uname -s)" in
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+      echo "C:\\Program Files\\Unity\\Hub\\Editor\\${version}\\Editor\\Unity.exe"
+      ;;
+    Darwin)
+      echo "/Applications/Unity/Hub/Editor/${version}/Unity.app/Contents/MacOS/Unity"
+      ;;
+    Linux)
+      echo "/opt/Unity/Hub/Editor/${version}/Editor/Unity"
+      ;;
+    *)
+      echo "Unsupported OS"
+      exit 1
+      ;;
+  esac
+}
+
+function agones_unity_sdk_tests(){
+  local unity_editor=$1
+  local project_path=$2
+  local edit_mode_results_file="$project_path/agones-unity-sdk-test-results.editmode.xml"
+  local play_mode_results_file="$project_path/agones-unity-sdk-test-results.playmode.xml"
+  echo "Agones Unity SDK test(s)"
+  "$unity_editor" -projectPath "$project_path" -runTests -testPlatform EditMode -testResults "$edit_mode_results_file"
+  "$unity_editor" -projectPath "$project_path" -runTests -testPlatform PlayMode -testResults "$play_mode_results_file"
+  cat "$edit_mode_results_file"
+  cat "$play_mode_results_file"
+}
+
+function main() {
+  repo_root=$(git rev-parse --show-toplevel)
+  unity_project_path="${repo_root}/test/sdk/unity"
+  unity_project_version_file="${unity_project_path}/ProjectSettings/ProjectVersion.txt"
+  echo "unity_project_path: $unity_project_path"
+  echo "unity_project_version_file: $unity_project_version_file"
+  unity_project_version=$(grep 'm_EditorVersion:' "$unity_project_version_file" | awk '{print $2}')
+  unity_editor=$(unity_editor_path $unity_project_version)
+
+  agones_unity_sdk_tests "$unity_editor" "$unity_project_path"
+}
+
+main "$@"

--- a/test/sdk/unity/.gitignore
+++ b/test/sdk/unity/.gitignore
@@ -1,3 +1,4 @@
+*[Rr]esults*.xml
 # This .gitignore file should be placed at the root of your Unity project directory
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
 /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
To allow contributors to more easily run the Agones Unity SDK tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:

I've run into some issues getting these tests able to be run from inside a container image (see https://github.com/googleforgames/agones/issues/3926). In that initial issue I suggested maybe a bash script to afford the same "easier to run tests" quality. Since I've had so much trouble getting it running, here's a draft of a script that calls the Unity Editor app directly.
