### PR TITLE
Small cleanup of incorrect comment in features.go file

### DIFF
--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -38,9 +38,6 @@ const (
 	// (a generic implenetation of the player tracking feature).
 	FeatureCountsAndLists Feature = "CountsAndLists"
 
-	////////////////
-	// Alpha features
-
 	// FeatureDisableResyncOnSDKServer is a feature flag to enable/disable resync on SDK server.
 	FeatureDisableResyncOnSDKServer Feature = "DisableResyncOnSDKServer"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Removes duplicate comment suggesting that `DisableResyncOnSDKServer` is an Alpha feature. It's a Beta feature.

https://github.com/googleforgames/agones/blob/ff4c2220669804de7f954ad643b809a08d3fb567/pkg/util/runtime/features.go#L133-L136

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


