### PR TITLE
remove ctx within the condition func

### DIFF
--- a/test/e2e/allocator/pod_termination_test.go
+++ b/test/e2e/allocator/pod_termination_test.go
@@ -92,16 +92,10 @@ func TestAllocatorAfterDeleteReplica(t *testing.T) {
 
 	// Wait and keep making calls till we know the draining time has passed
 	_ = wait.PollUntilContextTimeout(context.Background(), retryInterval, retryTimeout, true, func(ctx context.Context) (bool, error) {
-		ctx, cancelCtx := context.WithTimeout(ctx, retryInterval*2)
-		defer cancelCtx()
-
-		response, err := grpcClient.Allocate(ctx, request)
+		response, err := grpcClient.Allocate(context.Background(), request)
 		logger.Infof("err = %v (code = %v), response = %v", err, status.Code(err), response)
-		if assert.NoError(t, err, "Failed grpc allocation request") {
-			helper.ValidateAllocatorResponse(t, response)
-			err = helper.DeleteAgonesPod(ctx, response.GameServerName, framework.Namespace, framework)
-			assert.NoError(t, err, "Failed to delete game server pod %s", response.GameServerName)
-		}
+		helper.ValidateAllocatorResponse(t, response)
+		require.NoError(t, err, "Failed grpc allocation request")
 		return false, nil
 	})
 }


### PR DESCRIPTION
The `ctx` and `cancelCtx` was added to avoid `helper.DeleteAgonesPod` from failing from deadline exceeded. However, it doesn't work as desired because `ctx` can get cancelled by `retryTimeout`, which will in turn fail the `grpc.Allocate(ctx, request)`. We actually don't even need to call `helper.DeleteAgonesPod` thanks to the namespace clean up in main_test.go,  so I removed it, along with the `ctx` and `cancelCtx`.

Tested by patching #3933 and running the test.

Towards #3919 

