### PR TITLE
fix: remove bad character from metrics markdown

### DIFF
--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -46,7 +46,7 @@ Follow the [Google Cloud Monitoring installation steps](#google-cloud-monitoring
 
 
 | Name                                                  | Description                                                                                                                                                                                 | Type      |
-|-------------------------------------------------------|---------------------------------------------------------------------------p------------------------------------------------------------------------------------------------------------------|-----------|
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | agones_gameservers_count                              | The number of gameservers per fleet and status                                                                                                                                              | gauge     |
 | agones_gameserver_allocations_duration_seconds        | The distribution of gameserver allocation requests latencies                                                                                                                                | histogram |
 | agones_gameserver_allocations_retry_total             | The count of gameserver allocation retry until it succeeds | histogram |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

/kind bug

1. **What this PR does / Why we need it**: The metrics markdown page is broken due to an extra character

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #3976

**Special notes for your reviewer**:


