### PR TITLE
Updates upgrade test to install multiple versions of Agones on a cluster in succession

### DIFF
--- a/test/upgrade/Dockerfile
+++ b/test/upgrade/Dockerfile
@@ -12,6 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM gcr.io/cloud-builders/gcloud AS builder
+
+RUN apt-get update && \
+    apt-get clean
+
+WORKDIR /usr/local
+
+# install kubectl
+ENV KUBECTL_VER=1.29.7
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/linux/amd64/kubectl && \
+    chmod go+rx ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
+
+# install Helm package manager
+ENV HELM_VER=3.14.3
+ENV HELM_URL=https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz
+RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
+    && tar -zxvf /tmp/helm.tar.gz -C /tmp \
+    && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
+    && chmod go+rx /usr/local/bin/helm \
+    && rm /tmp/helm.tar.gz && rm -rf /tmp/linux-amd64
+
 # Build the Go image from source
 FROM golang:1.22.6 AS build-stage
 
@@ -30,6 +52,7 @@ FROM gcr.io/distroless/static-debian12:nonroot AS build-release-stage
 WORKDIR /
 
 COPY --from=build-stage /upgrade-test /upgrade-test
+COPY --from=builder /usr/local /usr/local
 
 USER nonroot:nonroot
 

--- a/test/upgrade/main.go
+++ b/test/upgrade/main.go
@@ -190,16 +190,6 @@ func runExecCommand(cmd string, args ...string) ([]byte, error) {
 	return out, err
 }
 
-// Install Agones to the cluster using the install.yaml file.
-// kubectl create namespace agones-system
-// kubectl apply --server-side -f https://raw.githubusercontent.com/googleforgames/agones/release-1.43.0/install/yaml/install.yaml
-func installYaml() error {
-	installArgs := []string{"apply", "--server-side", "-f", "https://raw.githubusercontent.com/googleforgames/agones/release-1.43.0/install/yaml/install.yaml"}
-
-	_, err := runExecCommand(KUBECTL_CMD, installArgs...)
-	return err
-}
-
 // Adds public Helm Agones releases to the cluster
 func addAgonesRepo() {
 	installArgs := [][]string{{"repo", "add", "agones", "https://agones.dev/chart/stable"},

--- a/test/upgrade/main.go
+++ b/test/upgrade/main.go
@@ -21,24 +21,37 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-func main() {
-	validConfigs := ConfigTestSetup()
-
-	// TODO(igooch): Replace this with the deterministic config walker
-	for i, validConfig := range validConfigs {
-		log.Printf("validConfig %d: %v", i+1, validConfig)
-	}
-}
+const (
+	// HELM_CMD is the command line invocation of helm
+	HELM_CMD = "helm"
+	// KUBECTL_CMD is the command line invocation of kubectl
+	KUBECTL_CMD = "kubectl"
+	// IMAGE_PULL_POLICY sets the Agones Helm configuration to always pull the image
+	IMAGE_PULL_POLICY = "Always"
+	// SIDECAR_PULL_POLICY sets the Agones Helm configuration to always pull the SDK image
+	SIDECAR_PULL_POLICY = "true"
+	// LOG_LEVEL sets the Agones Helm configuration log level
+	LOG_LEVEL = "debug"
+	// HELM_CHART is the helm chart for the public Agones releases
+	HELM_CHART = "agones/agones"
+	// AGONES_REGISTRY is the public registry for Agones releases
+	AGONES_REGISTRY = "us-docker.pkg.dev/agones-images/release"
+)
 
 var (
+	// TODO: Get the build version of dev (i.e. 1.44.0-dev-b765f49)
 	// DEV is the current development version of Agones
 	DEV = os.Getenv("DEV")
 	// POD_NAME the name of the pod this container is running in
@@ -48,6 +61,14 @@ var (
 	// VERSION_MAPPINGS are the valid Kubernetes, Agones, and Feature Gate version configurations
 	VERSION_MAPPINGS = os.Getenv("version-mappings.json")
 )
+
+func main() {
+	ctx := context.Background()
+
+	validConfigs := ConfigTestSetup(ctx)
+	addAgonesRepo()
+	runConfigWalker(ctx, validConfigs)
+}
 
 type versionMappings struct {
 	K8sToAgonesVersions       map[string][]string     `json:"k8sToAgonesVersions"`
@@ -60,17 +81,26 @@ type featureGates struct {
 }
 
 type configTest struct {
-	k8sVersion    string
 	agonesVersion string
 	featureGates  string
 }
 
+type helmStatuses []struct {
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	Revision   string `json:"revision"`
+	Updated    string `json:"updated"`
+	Status     string `json:"status"`
+	Chart      string `json:"chart"`
+	AppVersion string `json:"app_version"`
+}
+
 // Determine test scenario to run
-func ConfigTestSetup() []*configTest {
+func ConfigTestSetup(ctx context.Context) []*configTest {
 	versionMap := versionMappings{}
 
 	// Find the Kubernetes version of the node that this test is running on.
-	k8sVersion := findK8sVersion()
+	k8sVersion := findK8sVersion(ctx)
 
 	// Get the mappings of valid Kubernetes, Agones, and Feature Gate versions from the configmap.
 	err := json.Unmarshal([]byte(VERSION_MAPPINGS), &versionMap)
@@ -82,9 +112,11 @@ func ConfigTestSetup() []*configTest {
 	configTests := []*configTest{}
 	for _, agonesVersion := range versionMap.K8sToAgonesVersions[k8sVersion] {
 		ct := configTest{}
-		ct.k8sVersion = k8sVersion
 		ct.agonesVersion = agonesVersion
-		ct.featureGates = defaultGates(versionMap.AgonesVersionFeatureGates[agonesVersion])
+		if agonesVersion == "DEV" {
+			ct.agonesVersion = DEV
+		}
+		// TODO: create different valid config based off of available feature gates
 		configTests = append(configTests, &ct)
 	}
 
@@ -93,7 +125,7 @@ func ConfigTestSetup() []*configTest {
 
 // Finds the Kubernetes version of the Kubelet on the node that the current pod is running on.
 // The Kubelet version is the same version as the node.
-func findK8sVersion() string {
+func findK8sVersion(ctx context.Context) string {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		log.Fatal("Could not create in cluster config", cfg)
@@ -104,16 +136,31 @@ func findK8sVersion() string {
 		log.Fatal("Could not create the kubernetes api clientset", err)
 	}
 
-	ctx := context.Background()
+	// Wait to get pod and node as these may take a while to start on a new Autopilot cluster.
+	var pod *v1.Pod
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 7*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pod, err = kubeClient.CoreV1().Pods(POD_NAMESPACE).Get(ctx, POD_NAME, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
 
-	pod, err := kubeClient.CoreV1().Pods(POD_NAMESPACE).Get(ctx, POD_NAME, metav1.GetOptions{})
-	if err != nil {
-		log.Fatal("Could not get pod", err)
+		return true, nil
+	})
+	if pod == nil || pod.Spec.NodeName == "" {
+		log.Fatalf("PollUntilContextTimeout timed out. Could not get Pod: %s", err)
 	}
 
-	node, err := kubeClient.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
-	if err != nil {
-		log.Fatal("Could not get node", err)
+	var node *v1.Node
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		node, err = kubeClient.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if node == nil || node.Status.NodeInfo.KubeletVersion == "" {
+		log.Fatalf("PollUntilContextTimeout timed out. Could not get Node: %s", err)
 	}
 
 	// Finds the major.min version. I.e. k8sVersion 1.30 from gkeVersion v1.30.2-gke.1587003
@@ -121,33 +168,132 @@ func findK8sVersion() string {
 	log.Println("KubeletVersion", gkeVersion)
 	r, err := regexp.Compile("\\d*\\.\\d*")
 	if err != nil {
-		log.Fatal("Could not compile regex", err)
+		log.Fatal("Could not compile regex: ", err)
 	}
 
 	return r.FindString(gkeVersion)
 }
 
-// Takes in featureGates struct and returns a string of the default feature gates that can be passed
-// to the Agones installation command line argument `featureWithGate=`
-func defaultGates(fg featureGates) string {
-	var featureWithGate strings.Builder
+// runExecCommand executes the command with the given arguments.
+func runExecCommand(cmd string, args ...string) ([]byte, error) {
+	log.Println("Running command", cmd, args)
+	execCommand := exec.Command(cmd, args...)
 
-	for i, featureGate := range fg.AlphaGates {
-		// Only append the & if there is another featureGate following the current featureGate
-		if i < (len(fg.AlphaGates)-1) || len(fg.BetaGates) != 0 {
-			fmt.Fprintf(&featureWithGate, "%s=false&", featureGate)
-		} else {
-			fmt.Fprintf(&featureWithGate, "%s=false", featureGate)
-		}
+	out, err := execCommand.CombinedOutput()
+	if err != nil {
+		log.Printf("CombinedOutput: %s", string(out))
+		log.Printf("CombinedOutput err: %s", err)
+	} else {
+		log.Printf("CombinedOutput: %s", string(out))
 	}
 
-	for i, featureGate := range fg.BetaGates {
-		if i < (len(fg.BetaGates) - 1) {
-			fmt.Fprintf(&featureWithGate, "%s=true&", featureGate)
-		} else {
-			fmt.Fprintf(&featureWithGate, "%s=true", featureGate)
+	return out, err
+}
+
+// Install Agones to the cluster using the install.yaml file.
+// kubectl create namespace agones-system
+// kubectl apply --server-side -f https://raw.githubusercontent.com/googleforgames/agones/release-1.43.0/install/yaml/install.yaml
+func installYaml() error {
+	installArgs := []string{"apply", "--server-side", "-f", "https://raw.githubusercontent.com/googleforgames/agones/release-1.43.0/install/yaml/install.yaml"}
+
+	_, err := runExecCommand(KUBECTL_CMD, installArgs...)
+	return err
+}
+
+// Adds public Helm Agones releases to the cluster
+func addAgonesRepo() {
+	installArgs := [][]string{{"repo", "add", "agones", "https://agones.dev/chart/stable"},
+		{"repo", "update"}}
+
+	for _, args := range installArgs {
+		_, err := runExecCommand(HELM_CMD, args...)
+		if err != nil {
+			log.Fatalf("Could not add Agones helm repo: %s", err)
 		}
 	}
+}
 
-	return featureWithGate.String()
+func installAgonesRelease(version, registry, featureGates, imagePullPolicy, sidecarPullPolicy,
+	logLevel, chart string) error {
+
+	// TODO: Include feature gates. (Current issue with Helm and string formatting of the feature gates.)
+	// 		"--set agones.featureGates=%s "+
+
+	helmString := fmt.Sprintf(
+		"upgrade --install --atomic --wait --timeout=10m --namespace=agones-system --create-namespace --version %s "+
+			"--set agones.image.tag=%s "+
+			"--set agones.image.registry=%s "+
+			"--set agones.image.allocator.pullPolicy=%s "+
+			"--set agones.image.controller.pullPolicy=%s "+
+			"--set agones.image.extensions.pullPolicy=%s "+
+			"--set agones.image.ping.pullPolicy=%s "+
+			"--set agones.image.sdk.alwaysPull=%s "+
+			"--set agones.controller.logLevel=%s "+
+			"agones %s",
+		version, version, registry, imagePullPolicy, imagePullPolicy, imagePullPolicy, imagePullPolicy,
+		sidecarPullPolicy, logLevel, chart,
+	)
+
+	helmArgs := strings.Split(helmString, " ")
+
+	_, err := runExecCommand(HELM_CMD, helmArgs...)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func runConfigWalker(ctx context.Context, validConfigs []*configTest) {
+	for _, config := range validConfigs {
+		registry := AGONES_REGISTRY
+		chart := HELM_CHART
+		if config.agonesVersion == DEV {
+			// TODO: Update to templated value for registry and chart for Dev build
+			continue
+		}
+
+		err := installAgonesRelease(config.agonesVersion, registry, config.featureGates, IMAGE_PULL_POLICY,
+			SIDECAR_PULL_POLICY, LOG_LEVEL, chart)
+		if err != nil {
+			log.Printf("installAgonesRelease err: %s", err)
+		}
+
+		// Wait for the helm release to install. Waits the same amount of time as the Helm timeout.
+		var helmStatus string
+		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			helmStatus = checkHelmStatus(config.agonesVersion)
+			if helmStatus == "deployed" {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil || helmStatus != "deployed" {
+			log.Fatalf("PollUntilContextTimeout timed out while attempting upgrade to Agones version %s. Helm Status %s",
+				config.agonesVersion, helmStatus)
+		}
+	}
+}
+
+// checkHelmStatus returns the status of the Helm release at a specified agonesVersion if it exists.
+func checkHelmStatus(agonesVersion string) string {
+	helmStatus := helmStatuses{}
+	checkStatus := []string{"list", "-a", "-nagones-system", "-ojson"}
+	out, err := runExecCommand(HELM_CMD, checkStatus...)
+	if err != nil {
+		log.Fatalf("Could not run command %s %s, err: %s", KUBECTL_CMD, checkStatus, err)
+	}
+
+	err = json.Unmarshal(out, &helmStatus)
+	if err != nil {
+		log.Fatal("Could not Unmarshal", err)
+	}
+
+	for _, status := range helmStatus {
+		if status.AppVersion == agonesVersion {
+			return status.Status
+		}
+	}
+	return ""
 }

--- a/test/upgrade/permissions.yaml
+++ b/test/upgrade/permissions.yaml
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agones-sa
+  namespace: default
+---
 # Based off of https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-example
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -33,7 +39,7 @@ metadata:
   namespace: default
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: agones-sa
     namespace: default
 roleRef:
   # "roleRef" specifies the binding to a Role / ClusterRole
@@ -57,9 +63,432 @@ metadata:
   name: read-nodes
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: agones-sa
     namespace: default
 roleRef:
   kind: ClusterRole
   name: node-reader
   apiGroup: rbac.authorization.k8s.io
+---
+# Prevent the controller pod from being evicted
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000001
+globalDefault: false
+description: "This priority class should be used for upgrade-test-runner pods only."
+---
+# Helm needs to be able to create namespaces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: namespace-creator
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-namespaces
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: namespace-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Helm needs to be able to create secrets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: agones-system
+  name: secret-creator
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-secrets
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: secret-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Helm needs to be able to create priorityclasses
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: agones-system
+  name: priorityclass-creator
+rules:
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-priorityclasses
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: priorityclass-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones controller needs to be able to create poddisruptionbudgets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: agones-system
+  name: poddisruptionbudget-creator
+rules:
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-poddisruptionbudgets
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: poddisruptionbudget-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones needs to be able to create serviceaccounts and services
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: agones-system
+  name: serviceaccount-manager
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "services"]
+    verbs: ["get", "watch", "list", "create", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manage-serviceaccounts
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: serviceaccount-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones needs to be able to create apiservices
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: apiservices-creator
+rules:
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-apiservices
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: apiservices-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones needs to be able to create Agones CustomResourceDefinitions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: agones-system
+  name: crd-creator
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-crds
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: crd-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones needs to be able to create clusterroles, clusterrolebindings, and rolebindings
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterrole-creator
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "rolebindings"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-clusterroles
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: clusterrole-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones needs to be able to create deployments
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: agones-system
+  name: deployment-creator
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-deployments
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: deployment-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Agones needs to be able to create mutatingwebhookconfigurations and validatingwebhookconfigurations
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhookconfiguration-creator
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "watch", "list", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: create-webhookconfigurations
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: webhookconfiguration-creator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Below are agones specific bindings from install.yaml
+#
+# Source: agones/templates/service/allocation.yaml
+# Create a ClusterRole in that grants access to the agones allocation api
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allocator
+  labels:
+    app: agones
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["allocation.agones.dev"]
+    resources: ["gameserverallocations"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["nodes", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["agones.dev"]
+    resources: ["gameservers", "gameserversets"]
+    verbs: ["get", "list", "update", "watch"]
+  - apiGroups: ["agones.dev"]
+    resources: ["gameservers"]
+    verbs: ["patch"]
+  - apiGroups: ["multicluster.agones.dev"]
+    resources: ["gameserverallocationpolicies"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: agones/templates/serviceaccounts/controller.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: controller
+  labels:
+    app: agones
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "update", "delete", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes", "secrets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]  # only needed for cloudProduct detection
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get"]
+  - apiGroups: ["agones.dev"]
+    resources: ["gameservers", "gameserversets"]
+    verbs: ["create", "delete", "get", "list", "update", "watch"]
+  - apiGroups: ["agones.dev"]
+    resources: ["gameservers"]
+    verbs: ["patch"]
+  - apiGroups: ["agones.dev"]
+    resources: ["fleets"]
+    verbs: ["get", "list", "update", "watch"]
+  - apiGroups: ["agones.dev"]
+    resources: ["fleets/status", "gameserversets/status"]
+    verbs: ["update"]
+  - apiGroups: ["agones.dev"]
+    resources: ["fleets/finalizers", "gameserversets/finalizers", "gameservers/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["multicluster.agones.dev"]
+    resources: ["gameserverallocationpolicies"]
+    verbs: ["create", "delete", "get", "list", "update", "watch"]
+  - apiGroups: ["autoscaling.agones.dev"]
+    resources: ["fleetautoscalers"]
+    verbs: ["get", "list", "update", "watch"]
+  - apiGroups: ["autoscaling.agones.dev"]
+    resources: ["fleetautoscalers/status"]
+    verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "get", "list", "update", "watch"]
+---
+# Source: agones/templates/serviceaccounts/sdk.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sdk
+  labels:
+    app: agones
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["agones.dev"]
+    resources: ["gameservers"]
+    verbs: ["list", "patch", "watch"]
+---
+# Source: agones/templates/service/allocation.yaml
+# Bind the agones-allocator ServiceAccount to the agones-allocator ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allocator
+  labels:
+    app: agones
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allocator
+---
+# Source: agones/templates/serviceaccounts/controller.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: controller-access
+  labels:
+    app: agones
+subjects:
+  - kind: User
+    name: system:serviceaccount:default:agones-sa
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: controller
+---
+# Source: agones/templates/serviceaccounts/controller.yaml
+#
+# RBACs for APIService
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: controller:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+---
+# Source: agones/templates/serviceaccounts/controller.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: agones-sa
+    namespace: default
+---
+# Source: agones/templates/serviceaccounts/sdk.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sdk-access
+  namespace: default
+  labels:
+    app: agones
+subjects:
+  - kind: User
+    name: system:serviceaccount:default:agones-sa
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sdk

--- a/test/upgrade/upgradeTest.yaml
+++ b/test/upgrade/upgradeTest.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     app: upgrade-test-runner
 spec:
+  backoffLimit: 0
   ttlSecondsAfterFinished: 100
   template:
     spec:
@@ -40,4 +41,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: version-map
+      priorityClassName: high-priority
       restartPolicy: Never
+      serviceAccountName: agones-sa

--- a/test/upgrade/versionMap.yaml
+++ b/test/upgrade/versionMap.yaml
@@ -18,98 +18,105 @@ kind: ConfigMap
 metadata:
   name: version-map
 data:
-  DEV: 1.43.0-dev
+  DEV: 1.44.0-dev
   version-mappings.json: |
     {
       "k8sToAgonesVersions": {
         "1.25": [
-          "1.33",
-          "1.34",
-          "1.35"
+          "1.33.0",
+          "1.34.0",
+          "1.35.0"
         ],
         "1.26": [
-          "1.33",
-          "1.34",
-          "1.35",
-          "1.36",
-          "1.37",
-          "1.38",
-          "1.39"
+          "1.33.0",
+          "1.34.0",
+          "1.35.0",
+          "1.36.0",
+          "1.37.0",
+          "1.38.0",
+          "1.39.0"
         ],
         "1.27": [
-          "1.34",
-          "1.35",
-          "1.36",
-          "1.37",
-          "1.38",
-          "1.39",
-          "1.40",
-          "1.41",
-          "1.42"
+          "1.34.0",
+          "1.35.0",
+          "1.36.0",
+          "1.37.0",
+          "1.38.0",
+          "1.39.0",
+          "1.40.0",
+          "1.41.0",
+          "1.42.0"
         ],
         "1.28": [
-          "1.36",
-          "1.37",
-          "1.38",
-          "1.39",
-          "1.40",
-          "1.41",
-          "1.42",
+          "1.36.0",
+          "1.37.0",
+          "1.38.0",
+          "1.39.0",
+          "1.40.0",
+          "1.41.0",
+          "1.42.0",
+          "1.43.0",
           "DEV"
         ],
         "1.29": [
-          "1.40",
-          "1.41",
-          "1.42",
+          "1.40.0",
+          "1.41.0",
+          "1.42.0",
+          "1.43.0",
           "DEV"
         ],
         "1.30": [
+          "1.43.0",
           "DEV"
         ]
       },
       "agonesVersionFeatureGates": {
-        "1.33": {
+        "1.33.0": {
           "alphaGates": ["PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.34": {
+        "1.34.0": {
           "alphaGates": ["PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.35": {
+        "1.35.0": {
           "alphaGates": ["PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.36": {
+        "1.36.0": {
           "alphaGates": ["PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.37": {
+        "1.37.0": {
           "alphaGates": ["CountsAndLists", "DisableResyncOnSDKServer", "GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.38": {
+        "1.38.0": {
           "alphaGates": ["CountsAndLists", "DisableResyncOnSDKServer", "GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.39": {
+        "1.39.0": {
           "alphaGates": ["CountsAndLists", "DisableResyncOnSDKServer", "GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": []
         },
-        "1.40": {
+        "1.40.0": {
           "alphaGates": ["CountsAndLists", "GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking"],
           "betaGates": ["DisableResyncOnSDKServer"]
         },
-        "1.41": {
+        "1.41.0": {
           "alphaGates": ["AutopilotPassthroughPort", "GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking", "PortPolicyNone", "PortRanges", "RollingUpdateFix"],
           "betaGates": ["CountsAndLists", "DisableResyncOnSDKServer"]
         },
-        "1.42": {
+        "1.42.0": {
           "alphaGates": ["AutopilotPassthroughPort", "GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking", "PortPolicyNone", "PortRanges", "RollingUpdateFix"],
           "betaGates": ["CountsAndLists", "DisableResyncOnSDKServer"]
+        },
+        "1.43.0": {
+          "alphaGates": ["GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking", "PortPolicyNone", "PortRanges", "RollingUpdateFix"],
+          "betaGates": ["AutopilotPassthroughPort", "CountsAndLists", "DisableResyncOnSDKServer"]
         },
         "DEV": {
-          "alphaGates": ["GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking", "PortPolicyNone", "PortRanges", "RollingUpdateFix"],
+          "alphaGates": ["GKEAutopilotExtendedDurationPods", "PlayerAllocationFilter", "PlayerTracking", "PortPolicyNone", "PortRanges", "RollingUpdateFix", "ScheduledAutoscaler"],
           "betaGates": ["AutopilotPassthroughPort", "CountsAndLists", "DisableResyncOnSDKServer"]
         }
       }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

This creates a basic config walker that installs all versions of Agones that are valid for a cluster on a particular Kubernetes versions. One valid version of Agones is installed, and the controller waits until the Helm release (Agones installation) is ready (deployed) before installing the next version.

**Which issue(s) this PR fixes**:

Working on #3795

**Special notes for your reviewer:**

The `upgrade-test-runner` Job runs a pod that is effectively a controller uses Helm to install Agones into the `agones-system` namespace on the same cluster. This Job needs to have all of the permissions of both Helm and Agones in order to use and create those resources.

Wait groups do not work for waiting on Kubernetes or Helm, so we use `wait.PollUntilContextTimeout` instead, similar to other e2e tests in Agones.

There are a number of `//TODO`s in the main file denoting pieces that are not included in this particular PR, but will need to be included in future PRs.

To run:

- Have a running Kubernetes cluster
- Have `REGISTRY` set to your artifact registry
- The `$(REGISTRY)` value in upgradeTest.yaml currently needs to be manually set to your registry
- make build && make push to your registry
- `kubectl apply -f permissions.yaml` for reading Pod and Node and installing Agones
- `kubectl apply -f versionMap.yaml` to load the configmap
- `kubectl apply -f upgradeTest.yaml` to run the test runner
- You should be able to see logs in logs explorer with filter `resource.labels.container_name="upgrade-test-controller"`
- Run `kubectl get po -n agones-system` to see the Agones pods. These are expected to crash loop a couple times when running on an Autopilot cluster as the Autopilot cluster needs to scale up to accommodate the pods. 
- Check `kubectl get jobs --watch` to see if the job is still running.
- Once the job is finished you should be able to see all of the previously installed Helm revisions by running `helm history agones -n agones-system`. Example for a Kubernetes version 1.29 cluster:

```
me@me:~/agones/test/upgrade$ helm list -aA
NAME  	NAMESPACE    	REVISION	UPDATED                                	STATUS  	CHART        	APP VERSION
agones	agones-system	4       	2024-09-10 21:24:12.099119645 +0000 UTC	deployed	agones-1.43.0	1.43.0
me@me:~/agones/test/upgrade$ helm history agones -n agones-system
REVISION	UPDATED                 	STATUS    	CHART        	APP VERSION	DESCRIPTION
1       	Tue Sep 10 21:18:53 2024	superseded	agones-1.40.0	1.40.0     	Install complete
2       	Tue Sep 10 21:21:42 2024	superseded	agones-1.41.0	1.41.0     	Upgrade complete
3       	Tue Sep 10 21:23:23 2024	superseded	agones-1.42.0	1.42.0     	Upgrade complete
4       	Tue Sep 10 21:24:12 2024	deployed  	agones-1.43.0	1.43.0     	Upgrade complete
```
