### PR TITLE
Adds clusters for the in place upgrades tests

### DIFF
--- a/build/terraform/e2e/gke-autopilot/module.tf
+++ b/build/terraform/e2e/gke-autopilot/module.tf
@@ -32,6 +32,7 @@ terraform {
 
 variable "project" {}
 variable "kubernetesVersion" {}
+variable "testName" {}
 variable "location" {}
 variable "releaseChannel" {}
 
@@ -39,11 +40,12 @@ module "gke_cluster" {
   source = "../../../../install/terraform/modules/gke-autopilot"
 
   cluster = {
-    "name"                          = format("gke-autopilot-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
+    "name"                          = format("gke-autopilot-%s-test-cluster-%s", var.testName, replace(var.kubernetesVersion, ".", "-"))
     "project"                       = var.project
     "location"                      = var.location
     "releaseChannel"                = var.releaseChannel
     "kubernetesVersion"             = var.kubernetesVersion
+    "testName"                      = var.testName
     "deletionProtection"            = false
     "maintenanceExclusionStartTime" = timestamp()
     "maintenanceExclusionEndTime"   = timeadd(timestamp(), "2640h") # 110 days

--- a/build/terraform/e2e/gke-standard/module.tf
+++ b/build/terraform/e2e/gke-standard/module.tf
@@ -32,15 +32,13 @@ terraform {
 
 variable "project" {}
 variable "kubernetesVersion" {}
+variable "testName" {}
 variable "location" {}
 variable "releaseChannel" {}
+variable "initialNodeCount" {}
 
 variable "machineType" {
   default = "e2-standard-4"
-}
-
-variable "initialNodeCount" {
-  default = 10
 }
 
 variable "overrideName" {
@@ -51,7 +49,7 @@ module "gke_cluster" {
   source = "../../../../install/terraform/modules/gke"
 
   cluster = {
-    "name"                          = var.overrideName != "" ? var.overrideName : format("standard-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
+    "name"                          = var.overrideName != "" ? var.overrideName : format("standard-%s-test-cluster-%s", var.testName, replace(var.kubernetesVersion, ".", "-"))
     "location"                      = var.location
     "releaseChannel"                = var.releaseChannel
     "machineType"                   = var.machineType
@@ -59,6 +57,7 @@ module "gke_cluster" {
     "enableImageStreaming"          = true
     "project"                       = var.project
     "kubernetesVersion"             = var.kubernetesVersion
+    "testName"                      = var.testName
     "maintenanceExclusionStartTime" = timestamp()
     "maintenanceExclusionEndTime"   = timeadd(timestamp(), "2640h") # 110 days
   }

--- a/build/terraform/e2e/gke-standard/module.tf
+++ b/build/terraform/e2e/gke-standard/module.tf
@@ -32,13 +32,15 @@ terraform {
 
 variable "project" {}
 variable "kubernetesVersion" {}
-variable "testName" {}
 variable "location" {}
 variable "releaseChannel" {}
-variable "initialNodeCount" {}
 
 variable "machineType" {
   default = "e2-standard-4"
+}
+
+variable "initialNodeCount" {
+  default = 10
 }
 
 variable "overrideName" {
@@ -49,7 +51,7 @@ module "gke_cluster" {
   source = "../../../../install/terraform/modules/gke"
 
   cluster = {
-    "name"                          = var.overrideName != "" ? var.overrideName : format("standard-%s-test-cluster-%s", var.testName, replace(var.kubernetesVersion, ".", "-"))
+    "name"                          = var.overrideName != "" ? var.overrideName : format("standard-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
     "location"                      = var.location
     "releaseChannel"                = var.releaseChannel
     "machineType"                   = var.machineType
@@ -57,7 +59,6 @@ module "gke_cluster" {
     "enableImageStreaming"          = true
     "project"                       = var.project
     "kubernetesVersion"             = var.kubernetesVersion
-    "testName"                      = var.testName
     "maintenanceExclusionStartTime" = timestamp()
     "maintenanceExclusionEndTime"   = timeadd(timestamp(), "2640h") # 110 days
   }

--- a/build/terraform/e2e/state-bucket/main.tf
+++ b/build/terraform/e2e/state-bucket/main.tf
@@ -22,7 +22,7 @@
 // tfstate, delete your local .terraform and .tfstate files. You may need to run
 // `sudo chown -R yourusername .` to be able to delete them. Then navigate to this directory and run
 // `terraform init`. Pull in the tfstate file from gcloud with
-// `terraform import google_storage_bucket.default agones-images-e2e-infra-bucket-tfstate`.
+// `terraform import google_storage_bucket.default "<YOUR_GCP_ProjectID>"-e2e-infra-bucket-tfstate`.
 
 // # GCS bucket for holding the Terraform state of the e2e Terraform config.
 

--- a/build/terraform/upgrade/gke-autopilot/module.tf
+++ b/build/terraform/upgrade/gke-autopilot/module.tf
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC All Rights Reserved.
+// Copyright 2024 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module "gke_cluster" {
   source = "../../../../install/terraform/modules/gke-autopilot"
 
   cluster = {
-    "name"                          = format("gke-autopilot-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
+    "name"                          = format("gke-autopilot-upgrade-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
     "project"                       = var.project
     "location"                      = var.location
     "releaseChannel"                = var.releaseChannel

--- a/build/terraform/upgrade/gke-standard/module.tf
+++ b/build/terraform/upgrade/gke-standard/module.tf
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC All Rights Reserved.
+// Copyright 2024 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,16 +35,30 @@ variable "kubernetesVersion" {}
 variable "location" {}
 variable "releaseChannel" {}
 
+variable "machineType" {
+  default = "e2-standard-4"
+}
+
+variable "initialNodeCount" {
+  default = 4
+}
+
+variable "overrideName" {
+  default = ""
+}
+
 module "gke_cluster" {
-  source = "../../../../install/terraform/modules/gke-autopilot"
+  source = "../../../../install/terraform/modules/gke"
 
   cluster = {
-    "name"                          = format("gke-autopilot-e2e-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
-    "project"                       = var.project
+    "name"                          = var.overrideName != "" ? var.overrideName : format("standard-upgrade-test-cluster-%s", replace(var.kubernetesVersion, ".", "-"))
     "location"                      = var.location
     "releaseChannel"                = var.releaseChannel
+    "machineType"                   = var.machineType
+    "initialNodeCount"              = var.initialNodeCount
+    "enableImageStreaming"          = true
+    "project"                       = var.project
     "kubernetesVersion"             = var.kubernetesVersion
-    "deletionProtection"            = false
     "maintenanceExclusionStartTime" = timestamp()
     "maintenanceExclusionEndTime"   = timeadd(timestamp(), "2640h") # 110 days
   }

--- a/build/terraform/upgrade/module.tf
+++ b/build/terraform/upgrade/module.tf
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC All Rights Reserved.
+// Copyright 2024 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 
 // Run:
-//  terraform init -backend-config="bucket=<YOUR_GCP_ProjectID>-e2e-infra-bucket-tfstate" -backend-config="prefix=terraform/state"
+//  terraform init -backend-config="bucket=<YOUR_GCP_ProjectID>-upgrade-infra-bucket-tfstate" -backend-config="prefix=terraform/state"
 //  terraform apply -var project="<YOUR_GCP_ProjectID>"
 
 terraform {
@@ -35,7 +35,7 @@ terraform {
 
 variable "project" {}
 variable "kubernetes_versions" {
-  description = "Create e2e test clusters with these k8s versions in these regions"
+  description = "Create upgrade test clusters with these k8s versions in these regions"
   type        = map(list(string))
   default     = {
     "1.28" = ["us-west1", "RAPID"]

--- a/build/terraform/upgrade/state-bucket/main.tf
+++ b/build/terraform/upgrade/state-bucket/main.tf
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Run:
+//  terraform apply -var project="<YOUR_GCP_ProjectID>"
+
+// GCS bucket for holding the Terraform state of the upgrade test Terraform config.
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.25.0"
+    }
+  }
+}
+
+variable "project" {}
+
+resource "google_storage_bucket" "default" {
+  project                     = var.project
+  name                        = "${var.project}-upgrade-infra-bucket-tfstate"
+  force_destroy               = false
+  uniform_bucket_level_access = true
+  location                    = "US"
+  storage_class               = "STANDARD"
+  versioning {
+    enabled = true
+  }
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

Adds GKE Autopilot and GKE Standard test cluster for use in the In Place Upgrades tests. The clusters follow the same pattern as the existing e2e test clusters. The Upgrades standard cluster do not require as much compute as the e2e clusters, so the initial node count is lower than for the e2e tests.

**Which issue(s) this PR fixes**:

Working on #3795 

**Special notes for your reviewer**:


