### PR TITLE
Fix the build-e2e error

### DIFF
--- a/build/e2e-image/Dockerfile
+++ b/build/e2e-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud
 
 RUN apt-get update && \
-    apt-get install -y wget psmisc make gcc python jq zip && \
+    apt-get install -y wget psmisc make gcc jq zip && \
     apt-get clean
 
 # install go


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
Currently all the ci failed at step `build e2e` with error `Package 'python' has no installation candidate`. Eg: https://pantheon.corp.google.com/cloud-build/builds/b0183fd6-46bf-43a5-8191-3ee9bb2593c4?project=agones-images&e=13803378&mods=build_data. Not sure why this started happening from yesterday, but looks like we don't need to install `python` in this step, so remove it to fix the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


