### PR TITLE
Allowing list based fleet autoscaler to scale up from 0 replicas

### DIFF
--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -582,9 +582,14 @@ func scaleUp(replicas int32, capacity, count, aggCapacity, availableCapacity, ma
 	additionalReplicas := int32(math.Ceil((float64(buffer) - float64(availableCapacity)) / float64(replicaCapacity)))
 
 	// Check to make sure we're not limited (over Max Capacity)
-	limited, _ := isLimited(aggCapacity+(int64(additionalReplicas)*capacity), minCapacity, maxCapacity)
+	limited, scale := isLimited(aggCapacity+(int64(additionalReplicas)*capacity), minCapacity, maxCapacity)
 	if limited {
-		additionalReplicas = int32((maxCapacity - aggCapacity) / capacity)
+		if scale == -1 {
+			additionalReplicas = int32(math.Ceil((float64(maxCapacity) - float64(aggCapacity)) / float64(capacity)))
+		} else {
+			additionalReplicas = int32(math.Ceil((float64(minCapacity) - float64(aggCapacity)) / float64(capacity)))
+		}
+
 	}
 
 	return replicas + additionalReplicas, limited, nil

--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -355,7 +355,7 @@ func applyCounterOrListPolicy(c *autoscalingv1.CounterPolicy, l *autoscalingv1.L
 		}
 		return replicas, false, nil
 	case availableCapacity < buffer: // Scale Up
-		if limited { // Case where we want to scale up but we're already limited by MaxCapacity or MinCapacity.
+		if limited { // Case where we want to scale up but we're already limited by MaxCapacity.
 			return scaleLimited(scale, f, gameServerLister, nodeCounts, key, isCounter, replicas,
 				capacity, aggCapacity, minCapacity, maxCapacity)
 		}

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -1171,7 +1171,7 @@ func TestApplyCounterPolicy(t *testing.T) {
 				BufferSize:  intstr.FromInt(10),
 			},
 			want: expected{
-				replicas: 15,
+				replicas: 14,
 				limited:  true,
 				wantErr:  false,
 			},
@@ -1591,7 +1591,7 @@ func TestApplyListPolicy(t *testing.T) {
 			},
 			want: expected{
 				replicas: 2,
-				limited:  false,
+				limited:  true,
 				wantErr:  false,
 			},
 		},
@@ -1885,7 +1885,7 @@ func TestApplyListPolicy(t *testing.T) {
 				BufferSize:  intstr.FromString("50%"),
 			},
 			want: expected{
-				replicas: 5,
+				replicas: 4,
 				limited:  true,
 				wantErr:  false,
 			},

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -1171,7 +1171,7 @@ func TestApplyCounterPolicy(t *testing.T) {
 				BufferSize:  intstr.FromInt(10),
 			},
 			want: expected{
-				replicas: 14,
+				replicas: 15,
 				limited:  true,
 				wantErr:  false,
 			},
@@ -1885,7 +1885,7 @@ func TestApplyListPolicy(t *testing.T) {
 				BufferSize:  intstr.FromString("50%"),
 			},
 			want: expected{
-				replicas: 4,
+				replicas: 5,
 				limited:  true,
 				wantErr:  false,
 			},

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -676,7 +676,7 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 	fCopy.Status.AllocatedReplicas = 0
 	if runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
 		fCopy.Status.Counters = make(map[string]agonesv1.AggregatedCounterStatus)
-		fCopy.Status.Lists = c.createInitialListStatus(fleet)
+		fCopy.Status.Lists = make(map[string]agonesv1.AggregatedListStatus)
 	}
 	// Drop Counters and Lists status if the feature flag has been set to false
 	if !runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
@@ -711,14 +711,6 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 
 	_, err = c.fleetGetter.Fleets(fCopy.ObjectMeta.Namespace).UpdateStatus(ctx, fCopy, metav1.UpdateOptions{})
 	return errors.Wrapf(err, "error updating status of fleet %s", fCopy.ObjectMeta.Name)
-}
-
-func (c *Controller) createInitialListStatus(fleet *agonesv1.Fleet) map[string]agonesv1.AggregatedListStatus {
-	list := make(map[string]agonesv1.AggregatedListStatus)
-	for name := range fleet.Spec.Template.Spec.Lists {
-		list[name] = agonesv1.AggregatedListStatus{}
-	}
-	return list
 }
 
 // filterGameServerSetByActive returns the active GameServerSet (or nil if it

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -676,7 +676,7 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 	fCopy.Status.AllocatedReplicas = 0
 	if runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
 		fCopy.Status.Counters = make(map[string]agonesv1.AggregatedCounterStatus)
-		fCopy.Status.Lists = make(map[string]agonesv1.AggregatedListStatus)
+		fCopy.Status.Lists = c.createInitialListStatus(fleet)
 	}
 	// Drop Counters and Lists status if the feature flag has been set to false
 	if !runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
@@ -711,6 +711,14 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 
 	_, err = c.fleetGetter.Fleets(fCopy.ObjectMeta.Namespace).UpdateStatus(ctx, fCopy, metav1.UpdateOptions{})
 	return errors.Wrapf(err, "error updating status of fleet %s", fCopy.ObjectMeta.Name)
+}
+
+func (c *Controller) createInitialListStatus(fleet *agonesv1.Fleet) map[string]agonesv1.AggregatedListStatus {
+	list := make(map[string]agonesv1.AggregatedListStatus)
+	for name, _ := range fleet.Spec.Template.Spec.Lists {
+		list[name] = agonesv1.AggregatedListStatus{}
+	}
+	return list
 }
 
 // filterGameServerSetByActive returns the active GameServerSet (or nil if it

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -715,7 +715,7 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 
 func (c *Controller) createInitialListStatus(fleet *agonesv1.Fleet) map[string]agonesv1.AggregatedListStatus {
 	list := make(map[string]agonesv1.AggregatedListStatus)
-	for name, _ := range fleet.Spec.Template.Spec.Lists {
+	for name := range fleet.Spec.Template.Spec.Lists {
 		list[name] = agonesv1.AggregatedListStatus{}
 	}
 	return list

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -1980,12 +1980,23 @@ func defaultFleet(namespace string) *agonesv1.Fleet {
 	return fleetWithGameServerSpec(&gs.Spec, namespace)
 }
 
+// defaultEmptyFleet returns a default fleet configuration with no replicas.
+func defaultEmptyFleet(namespace string) *agonesv1.Fleet {
+	gs := framework.DefaultGameServer(namespace)
+	return fleetWithGameServerSpecAndReplicas(&gs.Spec, namespace, 0)
+}
+
 // fleetWithGameServerSpec returns a fleet with specified gameserver spec
 func fleetWithGameServerSpec(gsSpec *agonesv1.GameServerSpec, namespace string) *agonesv1.Fleet {
+	return fleetWithGameServerSpecAndReplicas(gsSpec, namespace, replicasCount)
+}
+
+// fleetWithGameServerSpecAndReplicas returns a fleet with specified gameserver spec and specified replica count
+func fleetWithGameServerSpecAndReplicas(gsSpec *agonesv1.GameServerSpec, namespace string, replicas int32) *agonesv1.Fleet {
 	return &agonesv1.Fleet{
 		ObjectMeta: metav1.ObjectMeta{GenerateName: "simple-fleet-1.0", Namespace: namespace},
 		Spec: agonesv1.FleetSpec{
-			Replicas: replicasCount,
+			Replicas: replicas,
 			Template: agonesv1.GameServerTemplateSpec{
 				Spec: *gsSpec,
 			},

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -1209,6 +1209,87 @@ func TestListAutoscaler(t *testing.T) {
 	}
 }
 
+func TestListAutoscalerWithNoReplicas(t *testing.T) {
+	if !runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	client := framework.AgonesClient.AgonesV1()
+	log := e2e.TestLogger(t)
+
+	flt := defaultEmptyFleet(framework.Namespace)
+	flt.Spec.Template.Spec.Lists = map[string]agonesv1.ListStatus{
+		"games": {
+			Capacity: 5,
+		},
+	}
+
+	flt, err := client.Fleets(framework.Namespace).Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer client.Fleets(framework.Namespace).Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
+	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+
+	fleetautoscalers := framework.AgonesClient.AutoscalingV1().FleetAutoscalers(framework.Namespace)
+
+	listFas := func(f func(fap *autoscalingv1.FleetAutoscalerPolicy)) *autoscalingv1.FleetAutoscaler {
+		fas := autoscalingv1.FleetAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: flt.ObjectMeta.Name + "-list-autoscaler", Namespace: framework.Namespace},
+			Spec: autoscalingv1.FleetAutoscalerSpec{
+				FleetName: flt.ObjectMeta.Name,
+				Policy: autoscalingv1.FleetAutoscalerPolicy{
+					Type: autoscalingv1.ListPolicyType,
+				},
+				Sync: &autoscalingv1.FleetAutoscalerSync{
+					Type: autoscalingv1.FixedIntervalSyncType,
+					FixedInterval: autoscalingv1.FixedIntervalSync{
+						Seconds: 1,
+					},
+				},
+			},
+		}
+		f(&fas.Spec.Policy)
+		return &fas
+	}
+	testCases := map[string]struct {
+		fas          *autoscalingv1.FleetAutoscaler
+		wantFasErr   bool
+		wantReplicas int32
+	}{
+		"Scale Up to MinCapacity": {
+			fas: listFas(func(fap *autoscalingv1.FleetAutoscalerPolicy) {
+				fap.List = &autoscalingv1.ListPolicy{
+					Key:         "games",
+					BufferSize:  intstr.FromInt(3),
+					MinCapacity: 16,
+					MaxCapacity: 100,
+				}
+			}),
+			wantFasErr:   false,
+			wantReplicas: 4, // Capacity:20
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+
+			fas, err := fleetautoscalers.Create(ctx, testCase.fas, metav1.CreateOptions{})
+			if testCase.wantFasErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(testCase.wantReplicas))
+			fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
+
+			// Return to starting 0 replicas
+			framework.ScaleFleet(t, log, flt, 0)
+			framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(0))
+		})
+	}
+}
+
 func TestListAutoscalerAllocated(t *testing.T) {
 	if !runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
 		t.SkipNow()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
Updated the controller to initialize the list status map with empty AggregatedListStatus from fleet spec. 
This allows scaling up if replicas is set to 0. Which is usually the case when deployed via Gitops systems ex. Flux.

Additionally updated the `scaleUp` function does limited scale to MinCapacity as well. Added this since I saw the desired capacity being set to Max first and then brought back to min! (This could be dangerous if the max is set to a high value)

I see that in most of the places we round up for calculating the number of replicas. This was missing for limited scaling using lists which is causing values to flap a bit for which I added a fix. Some of the tests were failing. Ex. to have a target max capacity of 45 with capacity of 10, the system was calculating 4 instead of 5. Let me know if that change is okay. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #3943

**Special notes for your reviewer**:


