### PR TITLE
Add Shutdown Delay Seconds to the sdk-client-test containers

### DIFF
--- a/test/sdk/go/Makefile
+++ b/test/sdk/go/Makefile
@@ -29,7 +29,7 @@ project_path := $(dir $(mkfile_path))
 root_path = $(realpath $(project_path)/)
 # Because go mod init in the Dockerfile installs the most recently released version of Agones, this
 # will need to be built and pushed post-release. During DEV it will be built at DEV - 1.
-release_version = 1.43.0
+release_version = 1.44.0
 server_tag := $(REGISTRY)/sdk-client-test:$(release_version)
 
 #   _____                    _

--- a/test/sdk/go/sdk-client-test.go
+++ b/test/sdk/go/sdk-client-test.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,16 +28,37 @@ import (
 
 	pkgSdk "agones.dev/agones/pkg/sdk"
 	"agones.dev/agones/pkg/util/runtime"
+	"agones.dev/agones/pkg/util/signals"
 	goSdk "agones.dev/agones/sdks/go"
 )
 
 func main() {
+	sigCtx, _ := signals.NewSigKillContext()
+	shutdownDelaySec := pflag.Int("shutdownDelaySec", 0, "Delay before calling sdk.Shutdown()")
+	gracefulTerminationDelaySec := pflag.Int("gracefulTerminationDelaySec", 0, "Delay after we've been asked to terminate (by SIGKILL or sdk.Shutdown)")
+
 	viper.AllowEmptyEnv(true)
 	runtime.FeaturesBindFlags()
 	pflag.Parse()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	runtime.Must(runtime.FeaturesBindEnv())
 	runtime.Must(runtime.ParseFeaturesFromEnv())
+
+	// Use to delays to prevent Game Servers from churning too quickly on a running cluster.
+	if sds := os.Getenv("SHUTDOWN_DELAY_SECONDS"); sds != "" {
+		sec, err := strconv.Atoi(sds)
+		if err != nil {
+			log.Fatalf("Could not parse SHUTDOWN_DELAY_SECONDS: %v", err)
+		}
+		shutdownDelaySec = &sec
+	}
+	if gtds := os.Getenv("GRACEFUL_TERMINATION_DELAY_SECONDS"); gtds != "" {
+		sec, err := strconv.Atoi(gtds)
+		if err != nil {
+			log.Fatalf("Could not parse GRACEFUL_TERMINATION_DELAY_SECONDS: %v", err)
+		}
+		gracefulTerminationDelaySec = &sec
+	}
 
 	log.SetFlags(log.Lshortfile)
 	log.Println("Client is starting")
@@ -105,13 +127,18 @@ func main() {
 		testLists(sdk)
 	}
 
-	// Delay before shutdown to prevent Game Servers from churning too quickly on a running cluster
-	time.Sleep(8 * time.Second)
+	log.Printf("Waiting %d seconds before shutting down game server", *shutdownDelaySec)
+	time.Sleep(time.Duration(*shutdownDelaySec) * time.Second)
 
 	err = sdk.Shutdown()
 	if err != nil {
 		log.Fatalf("Could not shutdown GameServer: %s", err)
 	}
+
+	<-sigCtx.Done()
+	log.Printf("Waiting %d seconds before exiting", *gracefulTerminationDelaySec)
+	time.Sleep(time.Duration(*gracefulTerminationDelaySec) * time.Second)
+	os.Exit(0)
 }
 
 func testPlayerTracking(sdk *goSdk.SDK) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

Adds dynamic shutdown delay and graceful termination delay to the sdk-client-test. The will allow the user to dynamically set delays when creating a game server without needing to rebuild the container. These delays are important for preventing Game Servers from churning too quickly on a running cluster.

This will not affect the current conformance test that uses this test as the defaults are 0 for both delays.

**Which issue(s) this PR fixes**:

Working on #3795

**Special notes for your reviewer**:


