### PR TITLE
Correct CI check for examples and add a unit test

### DIFF
--- a/build/scripts/example-version-checker/version.go
+++ b/build/scripts/example-version-checker/version.go
@@ -12,7 +12,7 @@ import (
 
 const examplesDir = "examples"
 
-var excludedPatterns = [...]string{"*.md", "*.yaml", "OWNERS", ".gitignore"}
+var excludedPatterns = [...]string{"*.md", "*.yaml", "*.yml", "OWNERS", ".gitignore"}
 
 func dirIsExample(dirName string) bool {
 	makefileName := fmt.Sprintf("%s/Makefile", dirName)
@@ -80,8 +80,10 @@ func filenameIsIrrelevant(filename string, exampleNames []string) bool {
 		return true
 	}
 
+	_, splitname := filepath.Split(filename)
+
 	for _, excludedName := range excludedPatterns {
-		matches, err := filepath.Match(excludedName, filename)
+		matches, err := filepath.Match(excludedName, splitname)
 		if err != nil {
 			log.Fatalf("Unknown error: %s", err)
 		}

--- a/build/scripts/example-version-checker/version_test.go
+++ b/build/scripts/example-version-checker/version_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"testing"
+)
+
+func TestFilenameIsIrrelevant(t *testing.T) {
+	exampleNames := []string{"inner", "first"}
+
+	irrelevantMap := map[string]bool{
+		// in deny-list
+		"README.md":       true,
+		"cloudbuild.yaml": true,
+		// in deny-list and inside an example
+		"examples/inner/outer/EXAMPLE.md":      true,
+		"examples/first/second/third/test.yml": true,
+		// not in deny list, but outside examples
+		"outside/test.txt": true,
+		"1/2/3/4/5.go":     true,
+		// in examples and relevant
+		"examples/inner/main.go": false,
+	}
+
+	for filename, expected := range irrelevantMap {
+		observed := filenameIsIrrelevant(filename, exampleNames)
+		if observed != expected {
+			log.Fatalf("%s was expected to be: %t", filename, expected)
+		}
+	}
+}


### PR DESCRIPTION
This fixes a bug within the CI check for unversioned changes to examples, involving an exclude pattern not matching relevant file paths that contain separators.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

My previous PR #3940 - which was merged and is now live - is causing CI pipelines to fail when any changes are made to YAML files in an example, even though these were supposed to have been excluded by a deny list.

This PR provides:

1. A unit test that reproduces the bug (on previous code)
2. A small code fix, that operates the `filepath.Match()` call on the filename (from `filepath.Split()`) and not the full path.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #4042 

**Special notes for your reviewer**:

I am very sorry about this, and hope this hasn't left a bad impression.