### PR TITLE
Unity SDK: Delay dispose of CancellationTokenSource when quitting

### DIFF
--- a/sdks/unity/AgonesSdk.cs
+++ b/sdks/unity/AgonesSdk.cs
@@ -71,6 +71,7 @@ namespace Agones
         {
             String port = Environment.GetEnvironmentVariable("AGONES_SDK_HTTP_PORT");
             sidecarAddress = "http://localhost:" + (port ?? "9358");
+            Application.quitting += OnApplicationQuitting;
         }
 
         private void Start()
@@ -79,9 +80,14 @@ namespace Agones
             HealthCheckAsync();
         }
 
-        private void OnApplicationQuit()
+        private void OnApplicationQuitting()
         {
             cancellationTokenSource.Dispose();
+        }
+
+        private void OnDestroy()
+        {
+	        Application.quitting -= OnApplicationQuitting;
         }
         #endregion
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
Quitting in Unity fires a number of events and callbacks. 

`MonoBehaviour.OnApplicationQuit` is called before `Application.wantsToQuit` which leads to undesired behaviour. `Application.wantsToQuit` can be used to interrupt a quit process, so you can shut down gracefully. If this is utilized, the AgonesSDK has already disposed the cancellation token and future calls will fail. 

We use this when controlling disruption https://agones.dev/site/docs/advanced/controlling-disruption/

Reference: https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Application-wantsToQuit.html

Same solution as in UniRX: https://github.com/neuecc/UniRx/pull/463

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


