### PR TITLE
Initialise FCounterResponse members

### DIFF
--- a/sdks/unreal/Agones/Source/Agones/Classes/Classes.h
+++ b/sdks/unreal/Agones/Source/Agones/Classes/Classes.h
@@ -423,10 +423,10 @@ struct FCounterResponse
 	}
 
 	UPROPERTY(BlueprintReadOnly, Category = "Agones")
-	int64 Count;
+	int64 Count = 0;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Agones")
-	int64 Capacity;
+	int64 Capacity = 0;
 
 	explicit FCounterResponse(const TSharedPtr<FJsonObject> JsonObject)
 	{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Initialising members to their default values prevents compiler warnings:

```
Int64Property FCounterResponse::Count is not initialized properly even though its struct probably has a custom default constructor. Module:Agones File:Classes/Classes.h
Int64Property FCounterResponse::Capacity is not initialized properly even though its struct probably has a custom default constructor. Module:Agones File:Classes/Classes.h
```

All other structs in this file do initialize their members, so this PR brings the FCounterResponse struct in-line with the others.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I've successfully built this change in my work project. I can also build it in a new blank UE4 project if required.

I'm hoping this change is simple enough to not need that though 🙏 
