### PR TITLE
fix: bump version of jsonpatch for lossy max int64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,3 +124,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace gomodules.xyz/jsonpatch/v2 => github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	golang.org/x/oauth2 v0.26.0
 	golang.org/x/time v0.9.0
 	golang.org/x/tools v0.29.0
-	gomodules.xyz/jsonpatch/v2 v2.4.0
+	gomodules.xyz/jsonpatch/v2 v2.5.0
 	google.golang.org/api v0.220.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250207221924-e9438ea467c6
 	google.golang.org/grpc v1.70.0
@@ -124,5 +124,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace gomodules.xyz/jsonpatch/v2 => github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712 h1:HR2sgBlQ9650M2v36F5lmSMKCKXsmrQkwhXx6ECPUe4=
-github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -722,6 +720,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0=
+gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/api v0.0.0-20180603000442-8e296ef26005/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/go.sum
+++ b/go.sum
@@ -312,6 +312,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712 h1:HR2sgBlQ9650M2v36F5lmSMKCKXsmrQkwhXx6ECPUe4=
+github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -720,8 +722,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
-gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/api v0.0.0-20180603000442-8e296ef26005/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/vendor/gomodules.xyz/jsonpatch/v2/jsonpatch.go
+++ b/vendor/gomodules.xyz/jsonpatch/v2/jsonpatch.go
@@ -70,12 +70,14 @@ func CreatePatch(a, b []byte) ([]Operation, error) {
 	}
 	var aI interface{}
 	var bI interface{}
-	err := json.Unmarshal(a, &aI)
-	if err != nil {
+	aDec := json.NewDecoder(bytes.NewReader(a))
+	aDec.UseNumber()
+	if err := aDec.Decode(&aI); err != nil {
 		return nil, errBadJSONDoc
 	}
-	err = json.Unmarshal(b, &bI)
-	if err != nil {
+	bDec := json.NewDecoder(bytes.NewReader(b))
+	bDec.UseNumber()
+	if err := bDec.Decode(&bI); err != nil {
 		return nil, errBadJSONDoc
 	}
 	return handleValues(aI, bI, "", []Operation{})
@@ -91,6 +93,11 @@ func matchesValue(av, bv interface{}) bool {
 	switch at := av.(type) {
 	case string:
 		bt, ok := bv.(string)
+		if ok && bt == at {
+			return true
+		}
+	case json.Number:
+		bt, ok := bv.(json.Number)
 		if ok && bt == at {
 			return true
 		}
@@ -212,7 +219,7 @@ func handleValues(av, bv interface{}, p string, patch []Operation) ([]Operation,
 		if err != nil {
 			return nil, err
 		}
-	case string, float64, bool:
+	case string, float64, bool, json.Number:
 		if !matchesValue(av, bv) {
 			patch = append(patch, NewOperation("replace", p, bv))
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -501,7 +501,7 @@ golang.org/x/tools/internal/gopathwalk
 golang.org/x/tools/internal/imports
 golang.org/x/tools/internal/modindex
 golang.org/x/tools/internal/stdlib
-# gomodules.xyz/jsonpatch/v2 v2.4.0 => github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712
+# gomodules.xyz/jsonpatch/v2 v2.5.0
 ## explicit; go 1.20
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/api v0.220.0
@@ -1201,4 +1201,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# gomodules.xyz/jsonpatch/v2 => github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -501,7 +501,7 @@ golang.org/x/tools/internal/gopathwalk
 golang.org/x/tools/internal/imports
 golang.org/x/tools/internal/modindex
 golang.org/x/tools/internal/stdlib
-# gomodules.xyz/jsonpatch/v2 v2.4.0
+# gomodules.xyz/jsonpatch/v2 v2.4.0 => github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712
 ## explicit; go 1.20
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/api v0.220.0
@@ -1201,3 +1201,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# gomodules.xyz/jsonpatch/v2 => github.com/lacroixthomas/jsonpatch/v2 v2.0.0-20250120171921-4c723fc27712


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:
This PR bump the version of the jsonpath module, which includes a fix for the lossy int64 max values

Currently, the jsonpath transform the int64 (big values, max int64 for example) as a float64 with scientific notation, when cast back to a int64, it losses precision / the int64 is not the same.

**Which issue(s) this PR fixes**:
Closes #3636 

**Special notes for your reviewer**:
A PR has been opened on the jsonpath repo: https://github.com/gomodules/jsonpatch/pull/40

The repo doesn't seems to be maintained, I open this draft PR to do some test by using by fork


