### PR TITLE
Increase wait time for upgrade test runner

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -377,7 +377,7 @@ steps:
             kubectl wait --for=condition=ready pod -l job-name=upgrade-test-runner --timeout=5m
 
             echo Wait for job upgrade-test-runner to complete or fail on cluster "${testCluster}"
-            kubectl wait job/upgrade-test-runner --timeout=20m --for jsonpath='{.status.conditions[*].status}'=True -o jsonpath='{.status.conditions[*].type}' | tee "${tmpdir}"/"${testCluster}".log &
+            kubectl wait job/upgrade-test-runner --timeout=30m --for jsonpath='{.status.conditions[*].status}'=True -o jsonpath='{.status.conditions[*].type}' | tee "${tmpdir}"/"${testCluster}".log &
             waitPid=$!
             pids+=( "$waitPid" )
             waitPids[$waitPid]="${tmpdir}"/"${testCluster}".log


### PR DESCRIPTION
**What type of PR is this?**

/kind hotfix

**What this PR does / Why we need it**:

Given that we now have 8 versions https://github.com/googleforgames/agones/blob/7cf11e40ac366c5a3519679d73e7c31a58c80301/test/upgrade/versionMap.yaml#L26-L36 running in the upgrade test cluster, the test is now taking approximately 21 minutes to finish successfully. The test is currently set to time out at 20 minutes. This PR is to update the timeout to 30 minutes to prevent flakes.

<img width="1072" alt="Screenshot 2025-02-12 at 2 17 28 PM" src="https://github.com/user-attachments/assets/3ac34a74-d5cd-48ff-b96b-3f01566fa558" />


**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


