### PR TITLE
Adoption of Sidecar Containers

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -72,7 +72,7 @@ GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.3
 BETA_FEATURE_GATES ?= "AutopilotPassthroughPort=true&CountsAndLists=true&DisableResyncOnSDKServer=true&GKEAutopilotExtendedDurationPods=true"
 
 # Enable all alpha feature gates. Keep in sync with `false` (alpha) entries in pkg/util/runtime/features.go:featureDefaults
-ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&FleetAutoscaleRequestMetaData=true&PlayerTracking=true&RollingUpdateFix=true&PortRanges=true&PortPolicyNone=true&ScheduledAutoscaler=true&Example=true"
+ALPHA_FEATURE_GATES ?= "PlayerAllocationFilter=true&FleetAutoscaleRequestMetaData=true&PlayerTracking=true&RollingUpdateFix=true&PortRanges=true&PortPolicyNone=true&ScheduledAutoscaler=true&SidecarContainers=true&Example=true"
 
 # Build with Windows support
 WITH_WINDOWS=1

--- a/build/Makefile
+++ b/build/Makefile
@@ -333,7 +333,7 @@ test-e2e-integration: GO_E2E_TEST_INTEGRATION_ARGS ?=\
 test-e2e-integration: $(ensure-build-image)
 	echo "Starting e2e integration test!"
 ifdef E2E_USE_GOTESTSUM
-	$(GOTESTSUM) --packages=$(agones_package)/test/e2e -- $(go_test_args) -timeout=30m $(ARGS) -args \
+	$(GOTESTSUM) --packages=$(agones_package)/test/e2e -- $(go_test_args) -timeout=45m $(ARGS) -args \
 		$(GO_E2E_TEST_ARGS) $(GO_E2E_TEST_INTEGRATION_ARGS)
 else
 	$(GO_TEST) -timeout=30m $(ARGS) $(agones_package)/test/e2e -args \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -440,7 +440,7 @@ steps:
         declare -A versionsAndRegions=( [1.30]=asia-east1 [1.31]=us-east1 [1.32]=us-west1 )
 
         # Keep in sync with (the inverse of) pkg/util/runtime/features.go:featureDefaults
-        featureWithGate="PlayerAllocationFilter=true&FleetAutoscaleRequestMetaData=true&PlayerTracking=true&CountsAndLists=false&RollingUpdateFix=true&PortRanges=true&PortPolicyNone=true&ScheduledAutoscaler=true&DisableResyncOnSDKServer=false&AutopilotPassthroughPort=false&GKEAutopilotExtendedDurationPods=false&Example=true"
+        featureWithGate="PlayerAllocationFilter=true&FleetAutoscaleRequestMetaData=true&PlayerTracking=true&CountsAndLists=false&RollingUpdateFix=true&PortRanges=true&PortPolicyNone=true&ScheduledAutoscaler=true&DisableResyncOnSDKServer=false&AutopilotPassthroughPort=false&GKEAutopilotExtendedDurationPods=false&SidecarContainers=true&Example=true"
         featureWithoutGate=""
 
         # Use this if specific feature gates can only be supported on specific Kubernetes versions.

--- a/install/helm/agones/defaultfeaturegates.yaml
+++ b/install/helm/agones/defaultfeaturegates.yaml
@@ -28,9 +28,9 @@ RollingUpdateFix: false
 PortRanges: false
 PortPolicyNone: false
 ScheduledAutoscaler: false
+SidecarContainers: false
 
 # Dev features
-SidecarContainers: false
 
 # Example feature
 Example: false

--- a/install/helm/agones/defaultfeaturegates.yaml
+++ b/install/helm/agones/defaultfeaturegates.yaml
@@ -30,6 +30,7 @@ PortPolicyNone: false
 ScheduledAutoscaler: false
 
 # Dev features
+SidecarContainers: false
 
 # Example feature
 Example: false

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -955,11 +955,37 @@ func (c *Controller) syncGameServerRequestReadyState(ctx context.Context, gs *ag
 		}
 	}
 
+	gsCopy, err = c.applyGameServerReadyContainerIDAnnotation(ctx, gsCopy, pod)
+	if err != nil {
+		return gs, err
+	}
+
+	gsCopy.Status.State = agonesv1.GameServerStateReady
+	gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
+	if err != nil {
+		return gs, errors.Wrapf(err, "error setting Ready, Port and address on GameServer %s Status", gs.ObjectMeta.Name)
+	}
+
+	if addressPopulated {
+		c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Address and port populated")
+	}
+	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "SDK.Ready() complete")
+	return gs, nil
+}
+
+// applyGameServerReadyContainerIDAnnotation updates the GameServer and its corresponding Pod with an annotation
+// indicating the ID of the container that is running the game server, once it's in a Running state.
+func (c *Controller) applyGameServerReadyContainerIDAnnotation(ctx context.Context, gsCopy *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, error) {
+	// if there is a sidecar container, we escape right away. On move to stable, this method can be deleted.
+	if runtime.FeatureEnabled(runtime.FeatureSidecarContainers) {
+		return gsCopy, nil
+	}
+
 	// track the ready gameserver container, so we can determine that after this point, we should move to Unhealthy
 	// if there is a container crash/restart after we move to Ready
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == gs.Spec.Container {
-			if _, ok := gs.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation]; !ok {
+		if cs.Name == gsCopy.Spec.Container {
+			if _, ok := gsCopy.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation]; !ok {
 				// check to make sure this container is actually running. If there was a recent crash, the cache may
 				// not yet have the newer, running container.
 				if cs.State.Running == nil {
@@ -984,22 +1010,11 @@ func (c *Controller) syncGameServerRequestReadyState(ctx context.Context, gs *ag
 		}
 
 		podCopy.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation] = gsCopy.ObjectMeta.Annotations[agonesv1.GameServerReadyContainerIDAnnotation]
-		if _, err = c.podGetter.Pods(pod.ObjectMeta.Namespace).Update(ctx, podCopy, metav1.UpdateOptions{}); err != nil {
-			return gs, errors.Wrapf(err, "error updating ready annotation on Pod: %s", pod.ObjectMeta.Name)
+		if _, err := c.podGetter.Pods(pod.ObjectMeta.Namespace).Update(ctx, podCopy, metav1.UpdateOptions{}); err != nil {
+			return nil, errors.Wrapf(err, "error updating ready annotation on Pod: %s", pod.ObjectMeta.Name)
 		}
 	}
-
-	gsCopy.Status.State = agonesv1.GameServerStateReady
-	gs, err = c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
-	if err != nil {
-		return gs, errors.Wrapf(err, "error setting Ready, Port and address on GameServer %s Status", gs.ObjectMeta.Name)
-	}
-
-	if addressPopulated {
-		c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Address and port populated")
-	}
-	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "SDK.Ready() complete")
-	return gs, nil
+	return gsCopy, nil
 }
 
 // syncGameServerShutdownState deletes the GameServer (and therefore the backing Pod) if it is in shutdown state

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -70,6 +70,9 @@ const (
 	// FeatureScheduledAutoscaler is a feature flag to enable/disable scheduled fleet autoscaling.
 	FeatureScheduledAutoscaler Feature = "ScheduledAutoscaler"
 
+	// FeatureSidecarContainers is a feature flag to enable/disable k8s sidecar containers for the sdkserver
+	FeatureSidecarContainers = "SidecarContainers"
+
 	////////////////
 	// Dev features
 
@@ -144,6 +147,7 @@ var (
 		FeaturePortRanges:                    false,
 		FeaturePortPolicyNone:                false,
 		FeatureScheduledAutoscaler:           false,
+		FeatureSidecarContainers:             false,
 
 		// Dev features
 

--- a/test/e2e/allocator_test.go
+++ b/test/e2e/allocator_test.go
@@ -72,7 +72,8 @@ func TestAllocatorWithDeprecatedRequired(t *testing.T) {
 	} else {
 		flt, err = helper.CreateFleet(ctx, framework.Namespace, framework)
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer framework.AgonesClient.AgonesV1().Fleets(framework.Namespace).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
 	request := &pb.AllocationRequest{
@@ -146,7 +147,7 @@ func TestAllocatorWithDeprecatedRequired(t *testing.T) {
 		return true, nil
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestAllocatorWithSelectors(t *testing.T) {
@@ -168,6 +169,7 @@ func TestAllocatorWithSelectors(t *testing.T) {
 		flt, err = helper.CreateFleet(ctx, framework.Namespace, framework)
 	}
 	assert.NoError(t, err)
+	defer framework.AgonesClient.AgonesV1().Fleets(framework.Namespace).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
 	request := &pb.AllocationRequest{
@@ -250,6 +252,8 @@ func TestRestAllocatorWithDeprecatedRequired(t *testing.T) {
 		return
 	}
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+	defer framework.AgonesClient.AgonesV1().Fleets(framework.Namespace).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
+
 	request := &pb.AllocationRequest{
 		Namespace:                    framework.Namespace,
 		RequiredGameServerSelector:   &pb.GameServerSelector{MatchLabels: map[string]string{agonesv1.FleetNameLabel: flt.ObjectMeta.Name}},
@@ -328,7 +332,9 @@ func TestAllocatorWithCountersAndLists(t *testing.T) {
 		}
 	})
 	assert.NoError(t, err)
+	defer framework.AgonesClient.AgonesV1().Fleets(framework.Namespace).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+
 	request := &pb.AllocationRequest{
 		Namespace: framework.Namespace,
 		GameServerSelectors: []*pb.GameServerSelector{{
@@ -413,7 +419,9 @@ func TestRestAllocatorWithCountersAndLists(t *testing.T) {
 		}
 	})
 	assert.NoError(t, err)
+	defer framework.AgonesClient.AgonesV1().Fleets(framework.Namespace).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+
 	request := &pb.AllocationRequest{
 		Namespace: framework.Namespace,
 		GameServerSelectors: []*pb.GameServerSelector{{
@@ -498,10 +506,10 @@ func TestRestAllocatorWithSelectors(t *testing.T) {
 	tlsCA := helper.RefreshAllocatorTLSCerts(ctx, t, ip, framework)
 
 	flt, err := helper.CreateFleet(ctx, framework.Namespace, framework)
-	if !assert.Nil(t, err) {
-		return
-	}
+	require.NoError(t, err)
+	defer framework.AgonesClient.AgonesV1().Fleets(framework.Namespace).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+
 	request := &pb.AllocationRequest{
 		Namespace:           framework.Namespace,
 		GameServerSelectors: []*pb.GameServerSelector{{MatchLabels: map[string]string{agonesv1.FleetNameLabel: flt.ObjectMeta.Name}}},
@@ -608,6 +616,8 @@ func TestAllocatorCrossNamespace(t *testing.T) {
 		return
 	}
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+	defer framework.AgonesClient.AgonesV1().Fleets(namespaceB).Delete(ctx, flt.Name, metav1.DeleteOptions{}) // nolint: errcheck
+
 	request := &pb.AllocationRequest{
 		Namespace: namespaceA,
 		// Enable multi-cluster setting

--- a/test/e2e/examples_test.go
+++ b/test/e2e/examples_test.go
@@ -15,8 +15,10 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
+	e2eframework "agones.dev/agones/test/e2e/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +30,9 @@ import (
 
 func TestSuperTuxKartGameServerReady(t *testing.T) {
 	t.Parallel()
+
+	log := e2eframework.TestLogger(t)
+
 	gs := &agonesv1.GameServer{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "supertuxkart-",
@@ -61,10 +66,20 @@ func TestSuperTuxKartGameServerReady(t *testing.T) {
 
 	// Use the e2e framework's function to create the GameServer and wait until it's ready
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
+	if err != nil {
+		log.Info("Game Server Events:")
+		framework.LogEvents(t, log, readyGs.ObjectMeta.Namespace, readyGs)
+
+		// Get pod and log events
+		log.Info("Game Server Pod Events:")
+		pod, err := framework.KubeClient.CoreV1().Pods(framework.Namespace).Get(context.Background(), readyGs.ObjectMeta.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		framework.LogEvents(t, log, pod.ObjectMeta.Namespace, pod)
+	}
 	require.NoError(t, err)
 
 	// Assert that the GameServer is in the expected state
-	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
+	require.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 }
 
 func TestRustGameServerReady(t *testing.T) {

--- a/test/e2e/examples_test.go
+++ b/test/e2e/examples_test.go
@@ -45,6 +45,10 @@ func TestSuperTuxKartGameServerReady(t *testing.T) {
 				PortPolicy:    agonesv1.Dynamic,
 				Protocol:      corev1.ProtocolUDP,
 			}},
+			Health: agonesv1.Health{
+				PeriodSeconds:       60,
+				InitialDelaySeconds: 30,
+			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -1484,6 +1484,9 @@ func TestListAutoscalerAllocated(t *testing.T) {
 			defer fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 
 			framework.AssertFleetCondition(t, flt, func(_ *logrus.Entry, fleet *agonesv1.Fleet) bool {
+				log.WithField("readyReplicas", fleet.Status.ReadyReplicas).WithField("wantReady", testCase.wantReadyGs).
+					WithField("allocatedReplicas", fleet.Status.AllocatedReplicas).WithField("wantAllocated", testCase.wantAllocatedGs).
+					Info("Checking for first allocation")
 				return fleet.Status.AllocatedReplicas == testCase.wantAllocatedGs && fleet.Status.ReadyReplicas == testCase.wantReadyGs
 			})
 		})

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -226,7 +226,7 @@ func (f *Framework) CreateGameServerAndWaitUntilReady(t *testing.T, ns string, g
 	readyGs, err := f.WaitForGameServerState(t, newGs, agonesv1.GameServerStateReady, f.WaitForState)
 
 	if err != nil {
-		return nil, fmt.Errorf("waiting for %v GameServer instance readiness timed out (%v): %v",
+		return readyGs, fmt.Errorf("waiting for %v GameServer instance readiness timed out (%v): %v",
 			gs.Spec, gs.Name, err)
 	}
 
@@ -240,7 +240,7 @@ func (f *Framework) CreateGameServerAndWaitUntilReady(t *testing.T, ns string, g
 	}
 
 	if len(readyGs.Status.Ports) != expectedPortCount {
-		return nil, fmt.Errorf("ready GameServer instance has %d port(s), want %d", len(readyGs.Status.Ports), expectedPortCount)
+		return readyGs, fmt.Errorf("ready GameServer instance has %d port(s), want %d", len(readyGs.Status.Ports), expectedPortCount)
 	}
 
 	logrus.WithField("gs", newGs.ObjectMeta.Name).Info("GameServer Ready")

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -818,15 +818,14 @@ func TestGameServerEvicted(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse("0Mi")
 
 	newGs, err := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Create(ctx, gs, metav1.CreateOptions{})
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("creating %v GameServer instances failed (%v): %v", gs.Spec, gs.Name, err))
-	}
-
+	require.NoError(t, err)
 	logrus.WithField("name", newGs.ObjectMeta.Name).Info("GameServer created, waiting for being Evicted and Unhealthy")
 
-	_, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 5*time.Minute)
+	_, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 10*time.Minute)
+	require.NoError(t, err, fmt.Sprintf("waiting for [%v] GameServer Unhealthy state timed out (%v)", gs.Status.State, gs.Name))
 
-	assert.Nil(t, err, fmt.Sprintf("waiting for %v GameServer Unhealthy state timed out (%v): %v", gs.Spec, gs.Name, err))
+	fmt.Println("SLEEP!")
+	time.Sleep(5 * time.Minute)
 }
 
 func TestGameServerPassthroughPort(t *testing.T) {

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -823,9 +823,6 @@ func TestGameServerEvicted(t *testing.T) {
 
 	_, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 10*time.Minute)
 	require.NoError(t, err, fmt.Sprintf("waiting for [%v] GameServer Unhealthy state timed out (%v)", gs.Status.State, gs.Name))
-
-	fmt.Println("SLEEP!")
-	time.Sleep(5 * time.Minute)
 }
 
 func TestGameServerPassthroughPort(t *testing.T) {

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -826,16 +826,16 @@ func TestGameServerEvicted(t *testing.T) {
 	pod, err := pods.Get(ctx, newGs.ObjectMeta.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
+	eviction := &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+	}
 	go func() {
 		time.Sleep(3 * time.Second) // just make sure it comes in later
-		eviction := &policyv1.Eviction{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pod.Name,
-				Namespace: pod.Namespace,
-			},
-		}
-		log.WithField("name", pod.ObjectMeta.Name).Info("Evicting pod!")
-		err = pods.EvictV1(ctx, eviction)
+		log.WithField("name", eviction.ObjectMeta.Name).Info("Evicting pod!")
+		err := pods.EvictV1(context.Background(), eviction)
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>

/kind breaking

> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

This is a breaking change for both how health checking works and to the SDK lifecycles, but behind the `SidecarContainer` feature flag.

1. This moves the sdkserver into a initContainer with a `RestartPolicy` of always. This means that it will be alive for the entirety of the main Pod's containers.
2. There is no waiting for the Shutdown signal any more for the sidecar container before shutting down since it now natively waits for the main Pod containers.
3. The RestartPolicy of the `gameserver` container defaults to `Never` (although it can be changed), and no longer restarts before the `Ready` state to simplify lifecycle health checking.
4. Various hacky health checks are now simplified to "is the Pod in a `Failed` state.", and therefore we no longer need to do as much text searching for edge cases.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #3642

**Special notes for your reviewer**:

Next: Write the docs to wrap up this work.
