### PR TITLE
Update Windows manifest handling in push-agones-sdk-manifest

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -711,16 +711,21 @@ endif
 ifeq ($(WITH_ARM64), 1)
 push-agones-sdk-image: push-agones-sdk-linux-image-arm64
 endif
-	$(MAKE) push-agones-sdk-manifest	
+	$(MAKE) push-agones-sdk-manifest
 
-push-agones-sdk-manifest:
+push-agones-sdk-manifest: 
 	docker manifest create --amend $(sidecar_tag) $(push_sidecar_manifest)
+	$(MAKE) push_windows_manifest
+	docker manifest push --purge $(sidecar_tag)
+
+push_windows_manifest:
+ifeq ($(WITH_WINDOWS), 1)
 	for osversion in $(WINDOWS_VERSIONS); do \
 		full_version=`docker manifest inspect ${BASE.windows}:$$osversion | grep "os.version" | head -n 1 | awk -F\" '{print $$4}'` || true; \
 		docker manifest annotate --os windows --arch amd64 --os-version $$full_version \
 		$(sidecar_tag) $(sidecar_tag)-windows_amd64-$$osversion; \
 	done
-	docker manifest push --purge $(sidecar_tag)
+endif
 
 push-agones-sdk-windows: WINDOWS_DOCKER_PUSH_ARGS=--push
 push-agones-sdk-windows: build-agones-sdk-image-windows


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

 /kind bug
 
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:

Fixes the issue where setting WITH_ARM=0 and WITH_WINDOWS=0 did not properly skip ARM and Windows builds

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #4135

**Special notes for your reviewer**:


