### PR TITLE
Creates Feature Flag to Prevent Removal of an Allocated Game Server from the Allocation Cache

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -448,6 +448,9 @@ install: $(ensure-build-image) install-custom-pull-secret
 		--set agones.featureGates=$(FEATURE_GATES) \
 		--set agones.allocator.service.loadBalancerIP=$(EXTERNAL_IP) \
 		--set agones.metrics.serviceMonitor.enabled=$(SERVICE_MONITOR) \
+		--set agones.controller.allocationBatchWaitTime=5ms \
+		--set agones.allocator.allocationBatchWaitTime=5ms \
+		--set agones.extensions.allocationBatchWaitTime=5ms \
 		$(HELM_ARGS) \
 		agones $(mount_path)/install/helm/agones/
 

--- a/examples/allocator-client/main.go
+++ b/examples/allocator-client/main.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 import (
@@ -21,11 +20,15 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
+	"sync"
+	"time"
 
 	pb "agones.dev/agones/pkg/allocation/go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func main() {
@@ -36,9 +39,9 @@ func main() {
 	port := flag.String("port", "443", "the port for allocator server")
 	namespace := flag.String("namespace", "default", "the game server kubernetes namespace")
 	multicluster := flag.Bool("multicluster", false, "set to true to enable the multi-cluster allocation")
-
+	requestsPerSecond := flag.String("requestsPerSecond", "5", "the rate limited number of game server allocation requests per second")
+	totalRequests := flag.String("totalRequests", "1000", "the total number of allocation requests to make")
 	flag.Parse()
-
 	endpoint := *externalIP + ":" + *port
 	cert, err := os.ReadFile(*certFile)
 	if err != nil {
@@ -52,13 +55,59 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	throttleRate, err := strconv.Atoi(*requestsPerSecond)
+	if err != nil {
+		panic(err)
+	}
+	numRequests, err := strconv.Atoi(*totalRequests)
+	if err != nil {
+		panic(err)
+	}
 
 	request := &pb.AllocationRequest{
 		Namespace: *namespace,
+		GameServerSelectors: []*pb.GameServerSelector{
+			{
+				GameServerState: pb.GameServerSelector_ALLOCATED,
+				MatchLabels: map[string]string{
+					"version": "1.2.3",
+				},
+				Counters: map[string]*pb.CounterSelector{
+					"players": {
+						MinAvailable: 1,
+					},
+				},
+			},
+			{
+				GameServerState: pb.GameServerSelector_READY,
+				MatchLabels: map[string]string{
+					"version": "1.2.3",
+				},
+				Counters: map[string]*pb.CounterSelector{
+					"players": {
+						MinAvailable: 1,
+					},
+				},
+			},
+		},
+		Counters: map[string]*pb.CounterAction{
+			"players": {
+				Action: &wrapperspb.StringValue{Value: "Increment"},
+				Amount: &wrapperspb.Int64Value{Value: 1},
+			},
+		},
 		MultiClusterSetting: &pb.MultiClusterSetting{
 			Enabled: *multicluster,
 		},
+		Priorities: []*pb.Priority{
+			{Type: pb.Priority_Counter,
+				Key:   "players",
+				Order: pb.Priority_Ascending},
+		},
+		Scheduling: pb.AllocationRequest_Distributed,
 	}
+	// 	Scheduling: pb.AllocationRequest_Packed,
+	// }
 
 	dialOpts, err := createRemoteClusterDialOption(cert, key, cacert)
 	if err != nil {
@@ -71,11 +120,40 @@ func main() {
 	defer conn.Close()
 
 	grpcClient := pb.NewAllocationServiceClient(conn)
-	response, err := grpcClient.Allocate(context.Background(), request)
-	if err != nil {
-		panic(err)
+	rateLimit := time.Second / time.Duration(throttleRate) // throttle rate of calls per second
+	fmt.Println("rateLimit", rateLimit)
+	throttle := time.Tick(rateLimit)
+	start :=  time.Now()
+	fails := 0
+	successes := 0
+
+	// Make numRequests number of concurrent rate-limited game server allocation requests.
+	// Rate limit to prevent failures due to resource conflicts.
+  var wg sync.WaitGroup
+	for range numRequests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-throttle  // rate limit client calls
+			err := allocateGameServer(grpcClient, request)
+			if err != nil {
+				fails += 1
+			} else {
+				successes += 1
+			}
+		}()
 	}
-	fmt.Printf("response: %s\n", response.String())
+	wg.Wait()
+	diff := time.Now().Sub(start)
+	fmt.Println("time spent", diff)
+	fmt.Println("successes", successes)
+	fmt.Println("fails", fails)
+}
+
+func allocateGameServer(client pb.AllocationServiceClient, request *pb.AllocationRequest) error {
+	ctx := context.Background()
+	_, err := client.Allocate(ctx, request)
+	return err
 }
 
 // createRemoteClusterDialOption creates a grpc client dial option with TLS configuration.
@@ -85,7 +163,6 @@ func createRemoteClusterDialOption(clientCert, clientKey, caCert []byte) (grpc.D
 	if err != nil {
 		return nil, err
 	}
-
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
 	if len(caCert) != 0 {
 		// Load CA cert, if provided and trust the server certificate.
@@ -95,6 +172,5 @@ func createRemoteClusterDialOption(clientCert, clientKey, caCert []byte) (grpc.D
 			return nil, errors.New("only PEM format is accepted for server CA")
 		}
 	}
-
 	return grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)), nil
 }

--- a/install/helm/agones/defaultfeaturegates.yaml
+++ b/install/helm/agones/defaultfeaturegates.yaml
@@ -20,7 +20,6 @@
 DisableResyncOnSDKServer: true
 
 # Beta features
-
 AutopilotPassthroughPort: true
 CountsAndLists: true
 GKEAutopilotExtendedDurationPods: true
@@ -35,6 +34,7 @@ RollingUpdateFix: false
 ScheduledAutoscaler: false
 
 # Dev features
+ReuseAllocated: false
 
 # Example feature
 Example: false

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -76,6 +76,10 @@ const (
 	////////////////
 	// Dev features
 
+	// FeatureReuseAllocated is a feature flag to keep an allocated game server in the allocation
+	// cache, so that the game server may be reallocated. Note that this may cause write conflicts.
+	FeatureReuseAllocated Feature = "ReuseAllocated"
+
 	////////////////
 	// Example feature
 
@@ -156,6 +160,7 @@ var (
 		FeatureScheduledAutoscaler:           false,
 
 		// Dev features
+		FeatureReuseAllocated: false,
 
 		// Example feature
 		FeatureExample: false,

--- a/tmp/allocate.sh
+++ b/tmp/allocate.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Generate the key, cert, and tls files from "Send allocation request" instructions
+# https://agones.dev/site/docs/advanced/allocator-service/
+NAMESPACE=default
+EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+KEY_FILE=client.key
+CERT_FILE=client.crt
+TLS_CA_FILE=ca.crt
+
+run_allocator_client () {
+  go run ../examples/allocator-client/main.go \
+    --ip "${EXTERNAL_IP}" \
+    --port 443 \
+    --namespace "${NAMESPACE}" \
+    --key "${KEY_FILE}" \
+    --cert "${CERT_FILE}" \
+    --cacert "${TLS_CA_FILE}" \
+    --requestsPerSecond 5 \
+    --totalRequests 1000
+}
+
+echo "Starting go runs 1"
+run_allocator_client &
+sleep 10s
+
+echo "Starting go runs 2"
+run_allocator_client &
+sleep 10s
+
+echo "Starting go runs 3"
+run_allocator_client &
+
+wait
+echo "All done"

--- a/tmp/fleet.yaml
+++ b/tmp/fleet.yaml
@@ -1,0 +1,44 @@
+---
+# Copyright 2025 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: agones.dev/v1
+kind: Fleet
+metadata:
+  name: simple-game-server
+spec:
+  replicas: 600
+  template:
+    metadata:
+      labels:
+        version: "1.2.3"
+    spec:
+      counters:
+        players:
+          count: 0
+          capacity: 50
+      ports:
+        - name: default
+          containerPort: 7654
+      template:
+        spec:
+          containers:
+            - name: simple-game-server
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.35
+              resources:
+                requests:
+                  memory: 32Mi
+                  cpu: 10m
+                limits:
+                  memory: 32Mi
+                  cpu: 10m


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / Why we need it**:

Removing a game server from the allocation cache when using Counters and Lists causes the allocator to allocate more game servers than needed. This PR adds a feature flag to prevent the removal of an allocated game server from the cache. 

Because the game server is not removed from the cache, and the intent of packing a game server until a Counter or List reaches capacity involves _wanting_ to allocate to the same game server, there will be resource (write) conflicts. In the sample allocation request we use a short `allocationBatchWaitTime` time, as well as throttling of current requests to control the rate of allocation and reduce the number of resource conflicts. These numbers should be tweaked during testing to find the best throughput of allocations for a particular game without overloading the Kubernetes control plane.

**Which issue(s) this PR fixes**:

Working on #3992

**Special notes for your reviewer**:

* This draft includes a sample fleet, sample allocation request, modification of the `allocationBatchWaitTime` of the dev installation, and debug statements that will not be included in the final PR.
