### PR TITLE
Adds explicit permissions for github workflows

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     name: Label the PR size
     steps:
       - uses: codelytv/pr-size-labeler@v1

--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -24,6 +24,9 @@ on:
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Automatically update PR
         uses: adRise/update-pr-branch@v0.6.0


### PR DESCRIPTION
**What type of PR is this?**

/kind hotfix

**What this PR does / Why we need it**:

GitHub is now enforcing explicit permissions in workflows, causing the labeler and pr_update workflows to fail.

This adds the permissions to write to a PR, using the same permissions as the existing labeler-pr workflow.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


