### PR TITLE
Exclude InactiveScheduleError for error logging

### DIFF
--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -87,7 +87,7 @@ func computeDesiredFleetSize(pol autoscalingv1.FleetAutoscalerPolicy, f *agonesv
 		err = errors.New("wrong policy type, should be one of: Buffer, Webhook, Counter, List, Schedule, Chain")
 	}
 
-	if err != nil {
+	if err != nil && !errors.Is(err, InactiveScheduleError{}) {
 		loggerForFleetAutoscalerKey(fasLog.fas.ObjectMeta.Name, fasLog.baseLogger).
 			Debugf("Failed to apply policy type %q: %v", pol.Type, err)
 	}
@@ -481,7 +481,7 @@ func applyChainPolicy(c autoscalingv1.ChainPolicy, f *agonesv1.Fleet, gameServer
 			// Every other policy type we just want to compute the desired fleet and return it
 			replicas, limited, err = computeDesiredFleetSize(entry.FleetAutoscalerPolicy, f, gameServerNamespacedLister, nodeCounts, fasLog)
 
-			if err != nil {
+			if err != nil && !errors.Is(err, InactiveScheduleError{}) {
 				loggerForFleetAutoscalerKey(fasLog.fas.ObjectMeta.Name, fasLog.baseLogger).Debugf(
 					"Failed to apply %s ID=%s in ChainPolicy: %v", entry.Type, entry.ID, err)
 			}
@@ -494,7 +494,7 @@ func applyChainPolicy(c autoscalingv1.ChainPolicy, f *agonesv1.Fleet, gameServer
 		}
 	}
 
-	if err != nil {
+	if err != nil && !errors.Is(err, InactiveScheduleError{}) {
 		emitChainPolicyEvent(fasLog, "Unknown", "")
 		loggerForFleetAutoscalerKey(fasLog.fas.ObjectMeta.Name, fasLog.baseLogger).Debug("Failed to apply ChainPolicy: no valid policy applied")
 		return replicas, limited, err


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

Exclude InactiveScheduleError for error logging as it's expected behavior when iterating through the chain.
This will prevent unnecessary noise as we are already logging events for policies that are being applied and don't want to log Schedule policies that are **not** being applied.

**Which issue(s) this PR fixes**:
This is a follow-up to #4179

**Special notes for your reviewer**:


