### PR TITLE
Changed the sidecar requests rate limiter from exponential to a constant one

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -139,6 +139,8 @@ spec:
           value: {{ .Values.agones.image.sdk.memoryLimit | quote }}
         - name: SIDECAR_RUN_AS_USER
           value: "1000"
+        - name: SIDECAR_REQUESTS_RATE_LIMIT
+          value: {{ .Values.agones.controller.sdk.requestsRateLimit | quote }}
         - name: SDK_SERVICE_ACCOUNT
           value: {{ .Values.agones.serviceaccount.sdk.name | quote }}
         - name: PROMETHEUS_EXPORTER

--- a/install/helm/agones/values.schema.json
+++ b/install/helm/agones/values.schema.json
@@ -437,6 +437,14 @@
             "allocationBatchWaitTime": {
               "type": "string"
             },
+            "sdk": {
+              "type": "object",
+              "properties": {
+                "requestsRateLimit": {
+                  "type": "string"
+                }
+              }
+            },
             "customCertSecretPath": {
               "type": "array"
             },

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -95,6 +95,8 @@ agones:
       failureThreshold: 3
       timeoutSeconds: 1
     allocationBatchWaitTime: 500ms
+    sdk:
+      requestsRateLimit: 1s
     replicas: 2
     pdb:
         minAvailable: 1

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -1316,12 +1316,14 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			assert.Equal(t, sidecarContainer.Resources.Requests.Cpu(), &c.sidecarCPURequest)
 			assert.Equal(t, sidecarContainer.Resources.Limits.Memory(), &c.sidecarMemoryLimit)
 			assert.Equal(t, sidecarContainer.Resources.Requests.Memory(), &c.sidecarMemoryRequest)
-			assert.Len(t, sidecarContainer.Env, 4, "4 env vars")
+			assert.Len(t, sidecarContainer.Env, 5, "5 env vars")
 			assert.Equal(t, "GAMESERVER_NAME", sidecarContainer.Env[0].Name)
 			assert.Equal(t, fixture.ObjectMeta.Name, sidecarContainer.Env[0].Value)
 			assert.Equal(t, "POD_NAMESPACE", sidecarContainer.Env[1].Name)
 			assert.Equal(t, "FEATURE_GATES", sidecarContainer.Env[2].Name)
 			assert.Equal(t, "LOG_LEVEL", sidecarContainer.Env[3].Name)
+			assert.Equal(t, "REQUESTS_RATE_LIMIT", sidecarContainer.Env[4].Name)
+			assert.Equal(t, "500ms", sidecarContainer.Env[4].Value)
 			assert.Equal(t, string(fixture.Spec.SdkServer.LogLevel), sidecarContainer.Env[3].Value)
 			assert.Equal(t, *sidecarContainer.SecurityContext.AllowPrivilegeEscalation, false)
 			assert.Equal(t, *sidecarContainer.SecurityContext.RunAsNonRoot, true)
@@ -2297,7 +2299,7 @@ func newFakeController() (*Controller, agtesting.Mocks) {
 		map[string]portallocator.PortRange{agonesv1.DefaultPortRange: {MinPort: 10, MaxPort: 20}},
 		"sidecar:dev", false,
 		resource.MustParse("0.05"), resource.MustParse("0.1"),
-		resource.MustParse("50Mi"), resource.MustParse("100Mi"), sidecarRunAsUser, "sdk-service-account",
+		resource.MustParse("50Mi"), resource.MustParse("100Mi"), sidecarRunAsUser, 500*time.Millisecond, "sdk-service-account",
 		m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -205,7 +205,7 @@ func TestSidecarRun(t *testing.T) {
 				return true, gsCopy, nil
 			})
 
-			sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080)
+			sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
 			stop := make(chan struct{})
 			defer close(stop)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -462,7 +462,7 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 	t.Parallel()
 
 	m := agtesting.NewMocks()
-	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080)
+	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
 	require.NoError(t, err)
 
 	gs := agonesv1.GameServer{
@@ -613,7 +613,7 @@ func TestSidecarHealthy(t *testing.T) {
 
 func TestSidecarHTTPHealthCheck(t *testing.T) {
 	m := agtesting.NewMocks()
-	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080)
+	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
 	require.NoError(t, err)
 
 	now := time.Now().Add(time.Hour).UTC()
@@ -2388,7 +2388,7 @@ func TestSDKServerGracefulTerminationGameServerStateChannel(t *testing.T) {
 }
 
 func defaultSidecar(m agtesting.Mocks) (*SDKServer, error) {
-	server, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080)
+	server, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
 	if err != nil {
 		return server, err
 	}

--- a/pkg/util/workerqueue/workerqueue.go
+++ b/pkg/util/workerqueue/workerqueue.go
@@ -92,6 +92,14 @@ func FastRateLimiter(maxDelay time.Duration) workqueue.TypedRateLimiter[any] {
 	return workqueue.NewTypedItemFastSlowRateLimiter[any](fastDelay, maxDelay, numFastRetries)
 }
 
+// ConstantRateLimiter returns a rate limiter without exponential back-off, with constant retry delay.
+func ConstantRateLimiter(maxDelay time.Duration) workqueue.TypedRateLimiter[any] {
+	const numFastRetries = 0                 // only constant delay
+	const fastDelay = 200 * time.Millisecond // not needed
+
+	return workqueue.NewTypedItemFastSlowRateLimiter[any](fastDelay, maxDelay, numFastRetries)
+}
+
 // NewWorkerQueue returns a new worker queue for a given name
 func NewWorkerQueue(handler Handler, logger *logrus.Entry, keyName logfields.ResourceType, queueName string) *WorkerQueue {
 	return NewWorkerQueueWithRateLimiter(handler, logger, keyName, queueName, workqueue.DefaultTypedControllerRateLimiter[any]())


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

During high allocation rate tests, I noticed that the sessions list is updated very very slow (at 15 minutes interval sometimes). The lists were updated by the game server logic following the start or termination of allocated sessions. A high failure rate of PATCH requests made the retry interval to hit the 1000 seconds limit which is very high (there is a nice article here regarding how rate limiters work: https://danielmangum.com/posts/controller-runtime-client-go-rate-limiting/#the-default-controller-rate-limiter). The Agones controllers use a fast/slow rate limiter but for some reason that I am missing the sidecar is using the default one. 

Using a constant rate limiter gave better results: the sessions are updated and there is no storm of PATCH failures. 500ms are chosen to match the allocator batch wait time, the logic being that the allocator pushes allocations, the game server acknowledges somehow. This value can be configured from the controller helm values as I think it is related to the system performance. For example, my tests were better with 1 second.

Note: the one per 500 ms request is actually for each type of update that the sidecar implements: state, labels, annotations, player capacity, connected players, counter and lists. So in theory there could be up to 7 requests per 500 ms coming from the sidecar.

**Which issue(s) this PR fixes**:

The issue is not open yet, it is described above.

**Special notes for your reviewer**:


