### PR TITLE
Specify exit code in simple-game-server CRASH

### DIFF
--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -39,7 +39,7 @@ WITH_ARM64 ?= 1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-version := 0.37
+version := 0.38
 ifeq ($(REPOSITORY),)
 	server_tag := simple-game-server:$(version)
 else

--- a/examples/simple-game-server/handlers.go
+++ b/examples/simple-game-server/handlers.go
@@ -187,7 +187,13 @@ func handleLabel(s *sdk.SDK, parts []string, _ ...context.CancelFunc) (response 
 
 func handleCrash(s *sdk.SDK, parts []string, _ ...context.CancelFunc) (response string, addACK bool, responseError error) {
 	log.Print("Crashing.")
-	os.Exit(1)
+	exitCode := 1
+	if len(parts) > 1 {
+		if code, err := strconv.Atoi(parts[1]); err == nil {
+			exitCode = code
+		}
+	}
+	os.Exit(exitCode)
 	return "", false, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

This change allows us to recreate the issues with Pods that are in a Succeeded state by providing a `CRASH 0` command to the simple game server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #4188

**Special notes for your reviewer**:

Once this is built and pushed to prod, I can push up the fixes for #4188.


