### PR TITLE
Controller for Pod in Succeeded state.

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -99,6 +99,7 @@ type Controller struct {
 	healthController       *HealthController
 	migrationController    *MigrationController
 	missingPodController   *MissingPodController
+	succeededController    *SucceededController
 	workerqueue            *workerqueue.WorkerQueue
 	creationWorkerQueue    *workerqueue.WorkerQueue // handles creation only
 	deletionWorkerQueue    *workerqueue.WorkerQueue // handles deletion only
@@ -152,6 +153,7 @@ func NewController(
 		healthController:       NewHealthController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory, controllerHooks.WaitOnFreePorts()),
 		migrationController:    NewMigrationController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory, controllerHooks.SyncPodPortsToGameServer),
 		missingPodController:   NewMissingPodController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
+		succeededController:    NewSucceededController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
 	}
 
 	c.baseLogger = runtime.NewLoggerWithType(c)
@@ -415,6 +417,15 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 			c.baseLogger.WithError(err).Error("error running missing pod controller")
 		}
 	}()
+
+	// Run the Succeeded Controller
+	if runtime.FeatureEnabled(runtime.FeatureSidecarContainers) {
+		go func() {
+			if err := c.succeededController.Run(ctx, workers); err != nil {
+				c.baseLogger.WithError(err).Error("error running succeeded controller")
+			}
+		}()
+	}
 
 	// start work queues
 	var wg sync.WaitGroup

--- a/pkg/gameservers/succeeded.go
+++ b/pkg/gameservers/succeeded.go
@@ -1,0 +1,164 @@
+// Copyright 2025 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameservers
+
+import (
+	"context"
+
+	"agones.dev/agones/pkg/apis/agones"
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"agones.dev/agones/pkg/client/clientset/versioned"
+	"agones.dev/agones/pkg/client/clientset/versioned/scheme"
+	getterv1 "agones.dev/agones/pkg/client/clientset/versioned/typed/agones/v1"
+	"agones.dev/agones/pkg/client/informers/externalversions"
+	listerv1 "agones.dev/agones/pkg/client/listers/agones/v1"
+	"agones.dev/agones/pkg/util/logfields"
+	"agones.dev/agones/pkg/util/runtime"
+	"agones.dev/agones/pkg/util/workerqueue"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+// SucceededController changes the state of a GameServer to Shutdown
+// when its Pod has a backing state of Succeeded.
+type SucceededController struct {
+	baseLogger       *logrus.Entry
+	podSynced        cache.InformerSynced
+	podLister        corelisterv1.PodLister
+	gameServerSynced cache.InformerSynced
+	gameServerGetter getterv1.GameServersGetter
+	gameServerLister listerv1.GameServerLister
+	workerqueue      *workerqueue.WorkerQueue
+	recorder         record.EventRecorder
+}
+
+func NewSucceededController(health healthcheck.Handler,
+	kubeClient kubernetes.Interface,
+	agonesClient versioned.Interface,
+	kubeInformerFactory informers.SharedInformerFactory,
+	agonesInformerFactory externalversions.SharedInformerFactory) *SucceededController {
+	podInformer := kubeInformerFactory.Core().V1().Pods().Informer()
+	gameServers := agonesInformerFactory.Agones().V1().GameServers()
+
+	c := &SucceededController{
+		podSynced:        podInformer.HasSynced,
+		podLister:        kubeInformerFactory.Core().V1().Pods().Lister(),
+		gameServerSynced: gameServers.Informer().HasSynced,
+		gameServerGetter: agonesClient.AgonesV1(),
+		gameServerLister: gameServers.Lister(),
+	}
+
+	c.baseLogger = runtime.NewLoggerWithType(c)
+	c.workerqueue = workerqueue.NewWorkerQueue(c.syncGameServer, c.baseLogger, logfields.GameServerKey, agones.GroupName+".SucceededController")
+	health.AddLivenessCheck("gameserver-succeeded-workerqueue", healthcheck.Check(c.workerqueue.Healthy))
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(c.baseLogger.Debugf)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	c.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "succeeded-controller"})
+
+	_, _ = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod := obj.(*corev1.Pod)
+			if isGameServerPod(pod) && pod.Status.Phase == corev1.PodSucceeded {
+				c.workerqueue.Enqueue(pod)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			pod := newObj.(*corev1.Pod)
+			if isGameServerPod(pod) && pod.Status.Phase == corev1.PodSucceeded {
+				c.workerqueue.Enqueue(pod)
+			}
+		},
+	})
+
+	return c
+}
+
+func (c *SucceededController) Run(ctx context.Context, workers int) error {
+	c.baseLogger.Debug("Wait for cache sync")
+	if !cache.WaitForCacheSync(ctx.Done(), c.gameServerSynced, c.podSynced) {
+		return errors.New("failed to wait for caches to sync")
+	}
+
+	c.workerqueue.Run(ctx, workers)
+	return nil
+}
+
+func (c *SucceededController) loggerForGameServerKey(key string) *logrus.Entry {
+	return logfields.AugmentLogEntry(c.baseLogger, logfields.GameServerKey, key)
+}
+
+// syncGameServer changes a GameServer to Shutdown state when its Pod is in Succeeded state
+func (c *SucceededController) syncGameServer(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		// don't return an error, as we don't want this retried
+		runtime.HandleError(c.loggerForGameServerKey(key), errors.Wrapf(err, "invalid resource key"))
+		return nil
+	}
+
+	// check if the pod exists and is in Succeeded state
+	pod, err := c.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return errors.Wrapf(err, "error retrieving Pod %s from namespace %s", name, namespace)
+		}
+		// If the pod doesn't exist, we don't need to do anything
+		return nil
+	}
+
+	// If the pod exists but is not in Succeeded state, we don't need to do anything
+	if !isGameServerPod(pod) || pod.Status.Phase != corev1.PodSucceeded {
+		return nil
+	}
+
+	c.loggerForGameServerKey(key).Debug("Pod is in Succeeded state. Moving GameServer to Shutdown.")
+
+	gs, err := c.gameServerLister.GameServers(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			c.loggerForGameServerKey(key).Debug("GameServer is no longer available for syncing")
+			return nil
+		}
+		return errors.Wrapf(err, "error retrieving GameServer %s from namespace %s", name, namespace)
+	}
+
+	// already on the way out, so no need to do anything.
+	if gs.IsBeingDeleted() || gs.Status.State == agonesv1.GameServerStateShutdown {
+		c.loggerForGameServerKey(key).WithField("state", gs.Status.State).Debug("GameServer already being deleted/shutdown. Skipping.")
+		return nil
+	}
+
+	gsCopy := gs.DeepCopy()
+	gsCopy.Status.State = agonesv1.GameServerStateShutdown
+	gs, err = c.gameServerGetter.GameServers(gsCopy.ObjectMeta.Namespace).Update(ctx, gsCopy, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrap(err, "error updating GameServer to Shutdown")
+	}
+
+	c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Pod is in Succeeded state")
+	return nil
+}

--- a/pkg/gameservers/succeeded.go
+++ b/pkg/gameservers/succeeded.go
@@ -54,6 +54,7 @@ type SucceededController struct {
 	recorder         record.EventRecorder
 }
 
+// NewSucceededController creates a new SucceededController and sets up event handlers.
 func NewSucceededController(health healthcheck.Handler,
 	kubeClient kubernetes.Interface,
 	agonesClient versioned.Interface,
@@ -97,6 +98,7 @@ func NewSucceededController(health healthcheck.Handler,
 	return c
 }
 
+// Run starts the SucceededController worker queue after ensuring caches are synced.
 func (c *SucceededController) Run(ctx context.Context, workers int) error {
 	c.baseLogger.Debug("Wait for cache sync")
 	if !cache.WaitForCacheSync(ctx.Done(), c.gameServerSynced, c.podSynced) {

--- a/pkg/gameservers/succeeded_test.go
+++ b/pkg/gameservers/succeeded_test.go
@@ -108,9 +108,46 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
 			},
 		},
+		"game server is in Error state": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateError
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"game server is in Unhealthy state": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateUnhealthy
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
 		"pod is not a gameserver pod": {
 			setup: func(gs *agonesv1.GameServer, _ *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
 				pod := &corev1.Pod{ObjectMeta: gs.ObjectMeta}
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"pod is in terminating state": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
 				pod.Status.Phase = corev1.PodSucceeded
 				return gs, pod
 			},

--- a/pkg/gameservers/succeeded_test.go
+++ b/pkg/gameservers/succeeded_test.go
@@ -1,0 +1,214 @@
+// Copyright 2025 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gameservers
+
+import (
+	"testing"
+	"time"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	agtesting "agones.dev/agones/pkg/testing"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestSucceededControllerSyncGameServer(t *testing.T) {
+	type expected struct {
+		updated     bool
+		updateTests func(t *testing.T, gs *agonesv1.GameServer)
+		postTests   func(t *testing.T, mocks agtesting.Mocks)
+	}
+	fixtures := map[string]struct {
+		setup    func(*agonesv1.GameServer, *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod)
+		expected expected
+	}{
+		"pod exists but not in Succeeded state": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"pod exists and is in Succeeded state": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					require.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
+				},
+				postTests: func(t *testing.T, m agtesting.Mocks) {
+					agtesting.AssertEventContains(t, m.FakeRecorder.Events, "Normal Shutdown Pod is in Succeeded state")
+				},
+			},
+		},
+		"pod doesn't exist": {
+			setup: func(gs *agonesv1.GameServer, _ *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				return gs, nil
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"game server not found": {
+			setup: func(_ *agonesv1.GameServer, _ *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				return nil, nil
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"game server is being deleted": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				now := metav1.Now()
+				gs.ObjectMeta.DeletionTimestamp = &now
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"game server is already in Shutdown state": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateShutdown
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"pod is not a gameserver pod": {
+			setup: func(gs *agonesv1.GameServer, _ *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				pod := &corev1.Pod{ObjectMeta: gs.ObjectMeta}
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+	}
+
+	for k, v := range fixtures {
+		t.Run(k, func(t *testing.T) {
+			m := agtesting.NewMocks()
+			c := NewSucceededController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
+			c.recorder = m.FakeRecorder
+
+			gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{}}
+			gs.ApplyDefaults()
+
+			pod, err := gs.Pod(agtesting.FakeAPIHooks{})
+			require.NoError(t, err)
+
+			gs, pod = v.setup(gs, pod)
+			m.AgonesClient.AddReactor("list", "gameservers", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+				if gs != nil {
+					return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{*gs}}, nil
+				}
+				return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{}}, nil
+			})
+			m.KubeClient.AddReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+				if pod != nil {
+					return true, &corev1.PodList{Items: []corev1.Pod{*pod}}, nil
+				}
+				return true, &corev1.PodList{Items: []corev1.Pod{}}, nil
+			})
+
+			updated := false
+			m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				updated = true
+				ua := action.(k8stesting.UpdateAction)
+				gs := ua.GetObject().(*agonesv1.GameServer)
+				v.expected.updateTests(t, gs)
+				return true, gs, nil
+			})
+
+			// Use context explicitly to avoid unused import warning
+			ctx, cancel := agtesting.StartInformers(m, c.gameServerSynced, c.podSynced)
+			defer cancel()
+
+			err = c.syncGameServer(ctx, "default/test")
+			require.NoError(t, err)
+			require.Equal(t, v.expected.updated, updated)
+			v.expected.postTests(t, m)
+		})
+	}
+}
+
+func TestSucceededControllerRun(t *testing.T) {
+	m := agtesting.NewMocks()
+	c := NewSucceededController(healthcheck.NewHandler(), m.KubeClient, m.AgonesClient, m.KubeInformerFactory, m.AgonesInformerFactory)
+
+	gs := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{}}
+	gs.ApplyDefaults()
+
+	pod, err := gs.Pod(agtesting.FakeAPIHooks{})
+	require.NoError(t, err)
+	pod.Status.Phase = corev1.PodSucceeded
+
+	m.AgonesClient.AddReactor("list", "gameservers", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{*gs}}, nil
+	})
+	m.KubeClient.AddReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &corev1.PodList{Items: []corev1.Pod{*pod}}, nil
+	})
+
+	updated := make(chan bool, 10)
+	m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua := action.(k8stesting.UpdateAction)
+		gs := ua.GetObject().(*agonesv1.GameServer)
+		updated <- gs.Status.State == agonesv1.GameServerStateShutdown
+		return true, gs, nil
+	})
+
+	ctx, cancel := agtesting.StartInformers(m, c.gameServerSynced, c.podSynced)
+	defer cancel()
+
+	go func() {
+		err := c.Run(ctx, 1)
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "timeout waiting for GameServer to be marked as Shutdown")
+	case value := <-updated:
+		require.True(t, value)
+	}
+}

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -313,17 +313,14 @@ func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 	defer gsClient.Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
 	pod, err := podClient.Get(ctx, readyGs.ObjectMeta.Name, metav1.GetOptions{})
-	if err != nil {
-		assert.FailNow(t, "Failed to get a pod", err.Error())
-	}
-
-	assert.True(t, metav1.IsControlledBy(pod, readyGs))
+	require.NoError(t, err)
+	require.True(t, metav1.IsControlledBy(pod, readyGs))
 
 	err = podClient.Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = framework.WaitForGameServerState(t, readyGs, agonesv1.GameServerStateUnhealthy, 3*time.Minute)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGameServerRestartBeforeReadyCrash(t *testing.T) {

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -488,6 +488,10 @@ func TestGameServerUnhealthyAfterReadyCrash(t *testing.T) {
 }
 
 func TestGameServerPodCompletedAfterCleanExit(t *testing.T) {
+	if !runtime.FeatureEnabled(runtime.FeatureSidecarContainers) {
+		t.SkipNow()
+	}
+
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

When sidecar containers are enabled, if a Pod `exit(0)`s, then it will end up in a Succeeded state, and the backing GameServer will not get deleted.

This introduces a new controller to check for this Pod state and move the `GameServer` to a `Shutdown` state.

Also updates all records of simple-game-server to the latest version, since we need it to test that this fix works.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #4188

**Special notes for your reviewer**:

Won't pass until https://us-docker.pkg.dev/agones-images/examples/simple-game-server:0.38 is published. 

