### PR TITLE
fleetautoscaler.md references metadata incorrectly

### DIFF
--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -374,8 +374,10 @@ type FleetAutoscaleRequest struct {
 	Namespace string `json:"namespace"`
 	// The Fleet's status values
 	Status v1.FleetStatus `json:"status"`
-	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-	MetaData *metav1.ObjectMeta `json:"metadata,omitempty"`
+	// Standard map labels; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels.
+	Labels map[string]string `json:"labels,omitempty"`
+	// Standard map annotations; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type FleetAutoscaleResponse struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

I started to write my own Webhook Autoscaler using the documentation as a reference and never saw a `metadata` key in my scaling requests from Agones. I started researching the codebase and read through https://github.com/googleforgames/agones/pull/3957 and the associated issues. I think this error in documentation slipped through during the code review and it was not updated to what actually shipped in that PR.

This change updates the documentation to match the struct again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


