### PR TITLE
Remove former agones collaborator from github action

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -20,4 +20,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/ISSUE_TEMPLATE/golang_version_upgrade.md
-          assignees: 0xaravindh, kamaljeeti
+          assignees: 0xaravindh


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

GitHub workflow ["Create update dependency issue once every six weeks"](https://github.com/googleforgames/agones/actions/runs/16254987607/job/45889909015#step:4:95) failed when it should have created an issue. One of the assignees is no longer a contributor to Agones, and that caused the workflow to fail to run. This PR removes the former member from the action.

```
An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE/golang_version_upgrade.md!

Validation Failed: {"value":"kamaljeeti","resource":"Issue","field":"assignees","code":"invalid"}
```

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


