### PR TITLE
WIP: Using agones.crds.gameserver.lists.maxItems instead of a hardcoded limit

### DIFF
--- a/install/helm/agones/templates/crds/_gameserverspecschema.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecschema.yaml
@@ -191,12 +191,12 @@ properties:
               title: Max capacity of the array (can be less than or equal to value of maxItems)
               minimum: 0
               default: 1000
-              maximum: 1000 # must be equal to values.maxItems
+              maximum: {{ .Values.agones.crds.gameserver.lists.maxItems }} # must be equal to values.maxItems
             values:
               title: set of all the items in the list
               type: array
               x-kubernetes-list-type: set # Requires items in the array to be unique
-              maxItems: 1000 # max possible size of the value array (cannot be updated)
+              maxItems: {{ .Values.agones.crds.gameserver.lists.maxItems }} # max possible size of the value array (cannot be updated)
               items: # name of the item (player1, session1, room1, etc.)
                 type: string
               default: []

--- a/install/helm/agones/templates/crds/_gameserverstatus.yaml
+++ b/install/helm/agones/templates/crds/_gameserverstatus.yaml
@@ -106,12 +106,12 @@ status:
             type: integer
             minimum: 0
             default: 1000
-            maximum: 1000 # must be equal to values.maxItems
+            maximum: {{ .Values.agones.crds.gameserver.lists.maxItems }} # must be equal to values.maxItems
           values:
             title: Set of all the items in the list
             type: array
             x-kubernetes-list-type: set # Requires items in the array to be unique
-            maxItems: 1000 # max possible size of the value array (cannot be updated)
+            maxItems: {{ .Values.agones.crds.gameserver.lists.maxItems }} # max possible size of the value array (cannot be updated)
             items: # name of the item (player1, session1, room1, etc.)
               type: string
             default: []

--- a/install/helm/agones/values.schema.json
+++ b/install/helm/agones/values.schema.json
@@ -44,6 +44,19 @@
             "cleanupJobTTL": {
               "type": "integer",
               "minimum": 0
+            },
+            "gameserver": {
+              "type": "object",
+              "properties": {
+                "lists": {
+                  "type": "object",
+                  "properties": {
+                    "maxItems": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
             }
           },
           "if": {

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -33,6 +33,9 @@ agones:
     install: true
     cleanupOnDelete: true
     cleanupJobTTL: 60
+    gameserver:
+      lists:
+        maxItems: 1000
   serviceaccount:
     allocator:
       name: agones-allocator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
 /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

The number of items in a list are bounded to the hardcoded value of 1000. During load tests, this value seems too low so a mechanism to configure it was put in place using Helm values. The default is still 1000 to be backwards compatible.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes https://github.com/googleforgames/agones/issues/4192

**Special notes for your reviewer**:


