### PR TITLE
Updates the upgrade test to print any fatal error messages to the job pod termination log

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -241,6 +241,7 @@ steps:
     args: [push]
     waitFor:
       - push-images
+    timeout: 5400s  # 1.5h
 
   # Wait for us to be the oldest ongoing build before we run upgrade and e2e tests
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk

--- a/test/upgrade/go.mod
+++ b/test/upgrade/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.2
 
 require (
 	agones.dev/agones v1.49.0
+	golang.org/x/sync v0.15.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1

--- a/test/upgrade/go.sum
+++ b/test/upgrade/go.sum
@@ -141,6 +141,8 @@ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKl
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/test/upgrade/upgradeTest.yaml
+++ b/test/upgrade/upgradeTest.yaml
@@ -21,13 +21,14 @@ metadata:
     app: upgrade-test-runner
 spec:
   backoffLimit: 0
-  ttlSecondsAfterFinished: 100
+  ttlSecondsAfterFinished: 240
   template:
     spec:
       containers:
         - name: upgrade-test-controller
           image: us-docker.pkg.dev/agones-images/ci/upgrade-test-controller:${DevVersion}
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: PodName
               valueFrom:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

The upgrade main.go is refactored to pass back any fatal errors, cancel context, and cleanup resources on a fatal error. This way we can see exactly what Fatal error caused the test to fail. This will not include all failure scenarios (i.e. our recent failure scenario of a finalizer not being removed from the ping service), but will still make it easier to debug.

Additional wait timeouts are added to prevent the test from hanging.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


