### PR TITLE
Fix: Cleanup finalizer for k8s (e2e pipeline)

### DIFF
--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -18,9 +18,22 @@ FEATURES=$1
 CLOUD_PRODUCT=$2
 REGISTRY=$3
 
+K8S_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | sed 's/+//')
+
 echo $FEATURES
 echo $REGISTRY
+echo $K8S_MINOR
 set -e
+
+# Ensure we cleanup the finalizers from k8s 1.33 until they patch it
+if [ "$K8S_MINOR" = "33" ]; then
+    echo "GKE 1.33 detected: cleaning up stuck service finalizers"
+
+    kubectl get svc -n agones-system -o json \
+    | jq -r '.items[] | select(.metadata.finalizers != null) | .metadata.name' \
+    | xargs -r -I {} kubectl patch svc -n agones-system -p '{"metadata":{"finalizers":null}}' --type=merge
+fi
+
 echo "installing current release"
 DOCKER_RUN= make install FEATURE_GATES='"'$FEATURES'"' REGISTRY='"'$REGISTRY'"' 
 echo "starting e2e test"

--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -31,8 +31,7 @@ if [ "$K8S_MINOR" = "33" ]; then
 
     kubectl get svc -n agones-system -o json \
     | jq -r '.items[] | select(.metadata.finalizers | length > 0) | .metadata.name' \
-    | awk 'NF' \
-    | xargs -r -I {} kubectl patch svc -n agones-system -p '{"metadata":{"finalizers":null}}' --type=merge
+    | xargs -r -I {} kubectl patch svc {} -n agones-system -p '{"metadata":{"finalizers":null}}' --type=merge
 fi
 
 echo "installing current release"

--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -30,7 +30,8 @@ if [ "$K8S_MINOR" = "33" ]; then
     echo "GKE 1.33 detected: cleaning up stuck service finalizers"
 
     kubectl get svc -n agones-system -o json \
-    | jq -r '.items[] | select(.metadata.finalizers != null) | .metadata.name' \
+    | jq -r '.items[] | select(.metadata.finalizers | length > 0) | .metadata.name' \
+    | awk 'NF' \
     | xargs -r -I {} kubectl patch svc -n agones-system -p '{"metadata":{"finalizers":null}}' --type=merge
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:
Cleanup the finalizer from the services before installing patched: https://github.com/kubernetes/cloud-provider-gcp/pull/887 and that the cluster used for e2e is upgraded 

Similar issue also happens on 1.32: https://console.cloud.google.com/cloud-build/builds/7146c171-ea46-4958-bf19-32083d84a50d?project=agones-images *

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->


**Special notes for your reviewer**:


