### PR TITLE
Pause Single Cluster Upgrade work until stable.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -233,15 +233,6 @@ steps:
   # End to end tests
   #
 
-  # Build and Push upgrade test
-  - name: make-docker
-    id: push-upgrade-test
-    dir: test/upgrade
-    env: ['REGISTRY=${_REGISTRY}']
-    args: [push]
-    waitFor:
-      - push-images
-
   # Wait for us to be the oldest ongoing build before we run upgrade and e2e tests
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: wait-to-become-leader
@@ -266,18 +257,6 @@ steps:
       - CLOUDSDK_CORE_PROJECT=$PROJECT_ID
       - BUILD_ID=$BUILD_ID
       - TRIGGER_NAME=$TRIGGER_NAME
-
-  # Run the upgrade tests parallel, fail this step if any of the tests fail
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    id: submit-upgrade-test-cloud-build
-    entrypoint: bash
-    args:
-      - build/e2e_upgrade_test.sh
-      - ${_BASE_VERSION}
-      - ${PROJECT_ID}
-    waitFor:
-      - wait-to-become-leader
-      - push-upgrade-test
 
   # cancel all the orphan e2e test cloud builds, fail to cancel any of the build will fail this whole build
   - name: gcr.io/cloud-builders/gcloud

--- a/site/content/en/docs/Installation/upgrading.md
+++ b/site/content/en/docs/Installation/upgrading.md
@@ -58,6 +58,12 @@ for the period of your upgrade, as there will be a short period in which Agones 
 Work is ongoing for [In-Place Agones Upgrades](https://github.com/googleforgames/agones/issues/3766),
 and the feature is currently in `Beta`. Please continue to use the multi-cluster strategy for
 production critical upgrades. Feedback on this `Beta` feature is welcome and appreciated.
+
+**Due to an inability to reliably test this functionality, work on in-place upgrades on hiatus and has been removed
+from the continuous integration pipeline until such time
+that it can be entered back in a stable state.**
+
+We recommend testing thoroughly before applying to production.
 {{< /alert >}}
 
 For In-Place Agones Upgrades we highly recommend installing using Helm. Helm has a significant


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

For ~6 months the upgrade CI has been flaky/broken, making it unreliable and slowing community contribution and overall project momentum.

This change:
- removes the build/push + submission steps for upgrade tests from cloudbuild.yaml to reduce noise and unblock CI reliability;
- updates the upgrading guide to clearly state that in-place upgrades are on hiatus due to lack of reliable testing and were removed from CI, and recommends thorough testing (multi-cluster remains the recommended production strategy).


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

We should re-enable upgrade tests once they can have someone dedicated to the workstream again, and they can run reliably and provide signal again.

With CI being this unstable we can't actually guarantee this functionality actually works at this stage anyway, so I don't think there's any reason to keep it running in CI.
