### PR TITLE
Return GameServerAllocationUnAllocated when an game server update error occurs

### DIFF
--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -496,7 +496,8 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 	_, err := a.allocate(ctx, gsa.DeepCopy())
 	log.WithError(err).Info("allocate (private): failed allocation")
 	require.NotEqual(t, ErrNoGameServer, err)
-	require.EqualError(t, err, "error updating allocated gameserver: failed to update")
+	require.True(t, errors.Is(err, ErrGameServerUpdateConflict))
+	require.EqualError(t, err, "Could not update the selected GameServer\nfailed to update")
 
 	// make sure we aren't in the same batch!
 	time.Sleep(2 * a.batchWaitTime)
@@ -511,7 +512,8 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 	log.WithField("result", result).WithError(err).Info("Allocate (public): failed allocation")
 	require.Nil(t, result)
 	require.NotEqual(t, ErrNoGameServer, err)
-	require.EqualError(t, err, "error updating allocated gameserver: failed to update")
+	require.True(t, errors.Is(err, ErrGameServerUpdateConflict))
+	require.EqualError(t, err, "Could not update the selected GameServer\nfailed to update")
 }
 
 func TestAllocatorRunLocalAllocations(t *testing.T) {
@@ -966,7 +968,8 @@ func TestControllerAllocationUpdateWorkers(t *testing.T) {
 		r = <-r.request.response
 
 		assert.True(t, updated)
-		assert.EqualError(t, r.err, "error updating allocated gameserver: something went wrong")
+		assert.True(t, errors.Is(r.err, ErrGameServerUpdateConflict))
+		assert.EqualError(t, r.err, "Could not update the selected GameServer\nsomething went wrong")
 		assert.Equal(t, gs1, r.gs)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
/kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
End the game server allocation with the state GameServerAllocationUnAllocated when an update error occurs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes https://github.com/googleforgames/agones/issues/4258

**Special notes for your reviewer**:


