### PR TITLE
fix: broken websocket connection after upgrading github.com/grpc-ecosystem/grpc-gateway/v2

### DIFF
--- a/build/includes/sdk.mk
+++ b/build/includes/sdk.mk
@@ -146,8 +146,10 @@ run-sdk-conformance-no-build: FEATURE_GATES ?=
 run-sdk-conformance-no-build: ensure-agones-sdk-image
 run-sdk-conformance-no-build: ensure-build-sdk-image
 	DOCKER_RUN_ARGS="--net host -e AGONES_SDK_GRPC_PORT=$(GRPC_PORT) -e AGONES_SDK_HTTP_PORT=$(HTTP_PORT) -e FEATURE_GATES='$(FEATURE_GATES)' $(DOCKER_RUN_ARGS)" COMMAND=sdktest $(MAKE) run-sdk-command & \
+	CONFORMANCE_TEST_PID=$$! && \
 	docker run -p $(GRPC_PORT):$(GRPC_PORT) -p $(HTTP_PORT):$(HTTP_PORT) -e "FEATURE_GATES=$(FEATURE_GATES)" -e "ADDRESS=" -e "TEST=$(TESTS)" -e "SDK_NAME=$(SDK_FOLDER)" -e "TIMEOUT=$(TIMEOUT)" -e "DELAY=$(DELAY)" \
-	--net=host $(sidecar_linux_amd64_tag) --grpc-port $(GRPC_PORT) --http-port $(HTTP_PORT)
+	--net=host $(sidecar_linux_amd64_tag) --grpc-port $(GRPC_PORT) --http-port $(HTTP_PORT) && \
+	wait $$CONFORMANCE_TEST_PID
 
 # Run SDK conformance test for a specific SDK_FOLDER
 run-sdk-conformance-test: TRIES=5

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -252,7 +252,7 @@ func runGrpc(grpcServer *grpc.Server, grpcEndpoint string) {
 // runGateway runs the grpc-gateway
 func runGateway(ctx context.Context, grpcEndpoint string, mux *gwruntime.ServeMux, httpServer *http.Server) {
 	// nolint: staticcheck
-	conn, err := grpc.DialContext(ctx, grpcEndpoint, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(grpcEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		logger.WithError(err).Fatal("Could not dial grpc server...")
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.24.0
 
 toolchain go1.24.4
 
+// Hotfix to address websocket connection issues with github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.2 and above.
+// See: https://github.com/grpc-ecosystem/grpc-gateway/issues/5326, https://github.com/googleforgames/agones/issues/4248
+replace github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 => github.com/swermin/grpc-websocket-proxy v0.1.0
+
 require (
 	cloud.google.com/go/cloudbuild v1.15.1
 	cloud.google.com/go/compute/metadata v0.7.0
@@ -39,6 +43,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0
 	google.golang.org/api v0.220.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250826171959-ef028d996bc1
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.8
 	gopkg.in/fsnotify.v1 v1.4.7
@@ -113,7 +118,6 @@ require (
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 // indirect
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -430,9 +430,9 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/swermin/grpc-websocket-proxy v0.1.0 h1:ZksvYTkIoA9JmBD0XjFHByc5C0816+brKGniJWBS3no=
+github.com/swermin/grpc-websocket-proxy v0.1.0/go.mod h1:YTnYrneJv15JeY4m+oGQuWD6FNs6YCU9mobAFGvUel8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
-github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/github.com/tmc/grpc-websocket-proxy/wsproxy/websocket_proxy.go
+++ b/vendor/github.com/tmc/grpc-websocket-proxy/wsproxy/websocket_proxy.go
@@ -2,6 +2,7 @@ package wsproxy
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -183,8 +184,8 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	requestBodyR, requestBodyW := io.Pipe()
-	request, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), requestBodyR)
+	_, requestBodyW := io.Pipe()
+	request, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), bytes.NewBuffer([]byte("")))
 	if err != nil {
 		p.logger.Warnln("error preparing request:", err)
 		return

--- a/vendor/github.com/tmc/grpc-websocket-proxy/wsproxy/websocket_proxy.go
+++ b/vendor/github.com/tmc/grpc-websocket-proxy/wsproxy/websocket_proxy.go
@@ -2,7 +2,6 @@ package wsproxy
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -187,12 +186,10 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 	_, requestBodyW := io.Pipe()
 	// github.com/grpc-ecosystem/grpc-gateway/v2 introduced a change in v2.26.2 that caused the server
 	// stream methods with no body defined to drain the req.Body.
-	// To work around this, we send a non-nil empty body so that it can be drained and the call can proceed
-	// as normal.
-	// Warning; this may have unintended consequences if the server is expecting a body.
-	// However this is the least bad option available at the moment considering that the
-	// sdk server only ever exposes the websocket to watch for gameserver changes.
-	request, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), bytes.NewBuffer([]byte("")))
+	// To work around this, we send at least a non-nil empty body so that it can be drained and the call can proceed as normal.
+	// Since the initial call to connect a websocket is determined by the request method and body
+	// we only need to pass the request's body together with the method to complete the call.
+	request, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
 	if err != nil {
 		p.logger.Warnln("error preparing request:", err)
 		return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -356,7 +356,7 @@ github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 ## explicit
 github.com/subosito/gotenv
-# github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75
+# github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 => github.com/swermin/grpc-websocket-proxy v0.1.0
 ## explicit; go 1.15
 github.com/tmc/grpc-websocket-proxy/wsproxy
 # github.com/x448/float16 v0.8.4


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
This PR introduces a change to the `tmc/grpc-websocket-proxy` to fix a deadlock when trying to establish a websocket connection to gRPC code that was generated by `github.com/grpc-ecosystem/grpc-gateway/v2` on version 2.26.2 and above.

`github.com/grpc-ecosystem/grpc-gateway/v2` on version 2.26.2 introduced this change [PR 5240](https://github.com/grpc-ecosystem/grpc-gateway/pull/5240) that causes request that has empty body specified to drain the body before proceeding with the call. This change was introduced back in April 2025 and the maintainer of the `tmc/grpc-websocket-proxy` has not been active for a while, making this breaking bug lingering and blocks projects that has websocket support as a requirement to be able to upgrade to newer agones versions.

As a workaround, due to critical functionality is broken, this PR introduces a fix in the vendor folder, so that we can unblock agones upgrades for projects that are depending on the websocket connection to work.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #4248

**Special notes for your reviewer**:
This is just a fix for the watch gameserver websocket connection, as it only ever sends data from the sidecar to the gameserver executable. That is fine for this current setup. If we need bi-directional support whatsoever from the websocket connection then this change will not work as there is no functionality exposed to send data through the proxy.