### PR TITLE
Fleet autoscaler threads maintain state

### DIFF
--- a/pkg/fleetautoscalers/controller_test.go
+++ b/pkg/fleetautoscalers/controller_test.go
@@ -315,6 +315,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -366,6 +367,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -425,6 +427,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -473,6 +476,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -525,6 +529,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -569,6 +574,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -603,6 +609,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, fas.ObjectMeta.Name)
 		assert.Nil(t, err)
@@ -632,6 +639,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		assert.Nil(t, err)
@@ -659,6 +667,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		if assert.NotNil(t, err) {
@@ -688,6 +697,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		if assert.NotNil(t, err) {
@@ -721,6 +731,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		if assert.NotNil(t, err) {
@@ -748,6 +759,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.fleetAutoscalerSynced)
 		defer cancel()
+		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
 		if assert.NotNil(t, err) {
@@ -771,6 +783,18 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 
 		require.NoError(t, c.syncFleetAutoscaler(ctx, "default/fas-1"))
 	})
+}
+
+// fleetAutoscalerThreadEventually waits to see if a thread is started for the given fleet autoscaler
+// this is a sign that the informer has been started and the fleet autoscaler has been processed
+// by the informer.
+func fleetAutoscalerThreadEventually(t *testing.T, c *Controller, fas *autoscalingv1.FleetAutoscaler) {
+	require.Eventually(t, func() bool {
+		c.fasThreadMutex.Lock()
+		defer c.fasThreadMutex.Unlock()
+		_, ok := c.fasThreads[fas.ObjectMeta.UID]
+		return ok
+	}, 5*time.Second, 100*time.Millisecond, "fleet autoscaler controller didn't start the sync thread")
 }
 
 func TestControllerScaleFleet(t *testing.T) {

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -17,6 +17,7 @@
 package fleetautoscalers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -185,6 +186,7 @@ func TestComputeDesiredFleetSize(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.Background()
 			fas.Spec.Policy = tc.policy
 			f.Spec.Replicas = tc.specReplicas
 			f.Status.Replicas = tc.statusReplicas
@@ -207,7 +209,7 @@ func TestComputeDesiredFleetSize(t *testing.T) {
 				currChainEntry: &fas.Status.LastAppliedPolicy,
 			}
 
-			replicas, limited, err := computeDesiredFleetSize(fas.Spec.Policy, f, gameServers.Lister().GameServers(f.ObjectMeta.Namespace), nc, &fasLog)
+			replicas, limited, err := computeDesiredFleetSize(ctx, map[string]any{}, fas.Spec.Policy, f, gameServers.Lister().GameServers(f.ObjectMeta.Namespace), nc, &fasLog)
 
 			if tc.expected.err != "" && assert.NotNil(t, err) {
 				assert.Equal(t, tc.expected.err, err.Error())
@@ -2507,6 +2509,7 @@ func TestApplySchedulePolicy(t *testing.T) {
 			err := utilruntime.ParseFeatures(tc.featureFlags)
 			assert.NoError(t, err)
 
+			ctx := context.Background()
 			fas, f := defaultFixtures()
 			m := agtesting.NewMocks()
 			fasLog := FasLogger{
@@ -2515,7 +2518,7 @@ func TestApplySchedulePolicy(t *testing.T) {
 				recorder:       m.FakeRecorder,
 				currChainEntry: &fas.Status.LastAppliedPolicy,
 			}
-			replicas, limited, err := applySchedulePolicy(tc.sp, f, nil, nil, tc.now, &fasLog)
+			replicas, limited, err := applySchedulePolicy(ctx, map[string]any{}, tc.sp, f, nil, nil, tc.now, &fasLog)
 
 			if tc.want.wantErr {
 				assert.NotNil(t, err)
@@ -2698,6 +2701,7 @@ func TestApplyChainPolicy(t *testing.T) {
 			err := utilruntime.ParseFeatures(tc.featureFlags)
 			assert.NoError(t, err)
 
+			ctx := context.Background()
 			fas, f := defaultFixtures()
 			m := agtesting.NewMocks()
 			fasLog := FasLogger{
@@ -2706,7 +2710,7 @@ func TestApplyChainPolicy(t *testing.T) {
 				recorder:       m.FakeRecorder,
 				currChainEntry: &fas.Status.LastAppliedPolicy,
 			}
-			replicas, limited, err := applyChainPolicy(*tc.cp, f, nil, nil, tc.now, &fasLog)
+			replicas, limited, err := applyChainPolicy(ctx, map[string]any{}, *tc.cp, f, nil, nil, tc.now, &fasLog)
 
 			if tc.want.wantErr {
 				assert.NotNil(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

This is necessary refactoring pre-work for #4080.

We need somewhere to store the wasm plugin when loaded for each fleet autoscaler CRD instance that is defined. This change both provides that arbitrary state as part of `fastThread` (which now means any new autoscaling ability can have state! Someone want to do predictive math over time?), and also having a ctx pass through since anything with state will likely need to be closed (the wasm plugins need it) at shutdown time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #4080

**Special notes for your reviewer**:

N/A
