### PR TITLE
Prepend sidecars to existing init containers

### DIFF
--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	"agones.dev/agones/pkg"
@@ -798,7 +799,7 @@ func (gs *GameServer) Pod(apiHooks APIHooks, sidecars ...corev1.Container) (*cor
 
 		// addSidecarsAsInitContainers puts the sidecars in the initContainers list so that they can have their own independent
 		// container restart policies.
-		pod.Spec.InitContainers = append(pod.Spec.InitContainers, sidecars...)
+		pod.Spec.InitContainers = slices.Concat(sidecars, pod.Spec.InitContainers)
 
 		// default GameServer container should also be Restart: Never
 		if len(pod.Spec.RestartPolicy) == 0 {


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Replacement of #4240 with an accompanying unit test.

As stated in that issue, if you want to use other init container sidecar, they should have access to the SDK server if they want it.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #4239

**Special notes for your reviewer**:


