### PR TITLE
docs: clarify FleetAutoscaler webhook response structure

### DIFF
--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -348,8 +348,8 @@ The `spec` field of the `FleetAutoscaler` is composed as follows:
 A webhook based `FleetAutoscaler` sends an HTTP POST request to the webhook endpoint every sync period (default is 30s) 
 with a JSON body, and scale the target fleet based on the data that is returned.
 
-The JSON payload that is sent is a `FleetAutoscaleReview` data structure and a `FleetAutoscaleResponse` data 
-structure is expected to be returned. 
+The JSON payload that is sent is a `FleetAutoscaleReview` data structure and a `FleetAutoscaleReview` with a populated 
+`FleetAutoscaleResponse` data structure is expected to be returned. 
 
 The `FleetAutoscaleResponse`'s `Replica` field is used to set the target `Fleet` count with each sync interval, thereby
 providing the autoscaling functionality.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Fix the FleetAutoscaler webhook reference to state that the webhook returns a FleetAutoscaleReview with a populated FleetAutoscaleResponse. This clarifies the expected JSON payload/response pairing for external webhook integrations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A
