### PR TITLE
Add Wasm autoscaler policy support to FleetAutoscaler CRDs YAML

### DIFF
--- a/install/helm/agones/templates/crds/_fleetautoscalerpolicy.yaml
+++ b/install/helm/agones/templates/crds/_fleetautoscalerpolicy.yaml
@@ -13,6 +13,32 @@
 # limitations under the License.
 
 ---
+{{/* schema for a URL configuration for webhooks and wasm */}}
+{{- define "url.configuration" }}
+type: object
+nullable: true
+properties:
+  url:
+    type: string
+  service:
+    type: object
+    required:
+      - namespace
+      - name
+    properties:
+      namespace:
+        type: string
+      name:
+        type: string
+      path:
+        type: string
+      port:
+        type: integer
+  caBundle:
+    type: string
+    format: byte
+{{- end }}
+
 {{/* schema for a fleet autoscaler policy */}}
 {{- define "fleetautoscaler.policy" }}
 {{- if .includePolicy }}
@@ -29,6 +55,7 @@ policy:
       - Webhook
       - Counter
       - List
+      - Wasm
       {{- if .includeSchedulePolicy }}
       - Schedule
       {{- end }}
@@ -53,28 +80,7 @@ policy:
             - type: integer
             - type: string
     webhook:
-      type: object
-      nullable: true
-      properties:
-        url:
-          type: string
-        service:
-          type: object
-          required:
-            - namespace
-            - name
-          properties:
-            namespace:
-              type: string
-            name:
-              type: string
-            path:
-              type: string
-            port:
-              type: integer
-        caBundle:
-          type: string
-          format: byte
+      {{- include "url.configuration" . | indent 6 }}
     counter:
       type: object
       nullable: true
@@ -158,4 +164,27 @@ policy:
             type: string
           {{- include "fleetautoscaler.policy" (dict "includeChainPolicy" false "includeSchedulePolicy" true "includePolicy" false) | indent 6 }} # Defines which policy to apply during the active period. Required.
     {{- end }}
+    wasm:
+      type: object
+      nullable: true
+      required:
+        - from
+      properties:
+        function: # The exported function to call in the wasm module, defaults to 'scale'
+          type: string
+          default: "scale"
+        config: # Config values to pass to the wasm program on startup
+          type: object
+          additionalProperties:
+            type: string
+        from:
+          type: object
+          required:
+            - url
+          properties:
+            url:
+          {{- include "url.configuration" . | indent 14 }}
+        hash: # optional sha256 hash to match against wasm file (it's optional, but recommended)
+          type: string
+          pattern: "^[a-fA-F0-9]{64}$"
 {{- end }}

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -6076,6 +6076,7 @@ spec:
                       - Webhook
                       - Counter
                       - List
+                      - Wasm
                       - Schedule
                       - Chain
                     buffer:
@@ -6095,7 +6096,7 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                    webhook:
+                    webhook:      
                       type: object
                       nullable: true
                       properties:
@@ -6196,6 +6197,7 @@ spec:
                               - Webhook
                               - Counter
                               - List
+                              - Wasm
                             buffer:
                               type: object
                               nullable: true
@@ -6213,7 +6215,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                            webhook:
+                            webhook:      
                               type: object
                               nullable: true
                               properties:
@@ -6278,6 +6280,50 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
+                            wasm:
+                              type: object
+                              nullable: true
+                              required:
+                                - from
+                              properties:
+                                function: # The exported function to call in the wasm module, defaults to 'scale'
+                                  type: string
+                                  default: "scale"
+                                config: # Config values to pass to the wasm program on startup
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                from:
+                                  type: object
+                                  required:
+                                    - url
+                                  properties:
+                                    url:              
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        url:
+                                          type: string
+                                        service:
+                                          type: object
+                                          required:
+                                            - namespace
+                                            - name
+                                          properties:
+                                            namespace:
+                                              type: string
+                                            name:
+                                              type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              type: integer
+                                        caBundle:
+                                          type: string
+                                          format: byte
+                                hash: # optional sha256 hash to match against wasm file (it's optional, but recommended)
+                                  type: string
+                                  pattern: "^[a-fA-F0-9]{64}$"
                     chain:
                       type: array
                       nullable: true
@@ -6296,6 +6342,7 @@ spec:
                             - Webhook
                             - Counter
                             - List
+                            - Wasm
                             - Schedule
                           buffer:
                             type: object
@@ -6314,7 +6361,7 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                          webhook:
+                          webhook:      
                             type: object
                             nullable: true
                             properties:
@@ -6415,6 +6462,7 @@ spec:
                                     - Webhook
                                     - Counter
                                     - List
+                                    - Wasm
                                   buffer:
                                     type: object
                                     nullable: true
@@ -6432,7 +6480,7 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                  webhook:
+                                  webhook:      
                                     type: object
                                     nullable: true
                                     properties:
@@ -6496,7 +6544,139 @@ spec:
                                         x-kubernetes-int-or-string: true
                                         anyOf:
                                           - type: integer
-                                          - type: string # Defines which policy to apply during the active period. Required.
+                                          - type: string
+                                  wasm:
+                                    type: object
+                                    nullable: true
+                                    required:
+                                      - from
+                                    properties:
+                                      function: # The exported function to call in the wasm module, defaults to 'scale'
+                                        type: string
+                                        default: "scale"
+                                      config: # Config values to pass to the wasm program on startup
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      from:
+                                        type: object
+                                        required:
+                                          - url
+                                        properties:
+                                          url:              
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              url:
+                                                type: string
+                                              service:
+                                                type: object
+                                                required:
+                                                  - namespace
+                                                  - name
+                                                properties:
+                                                  namespace:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    type: integer
+                                              caBundle:
+                                                type: string
+                                                format: byte
+                                      hash: # optional sha256 hash to match against wasm file (it's optional, but recommended)
+                                        type: string
+                                        pattern: "^[a-fA-F0-9]{64}$"
+                          wasm:
+                            type: object
+                            nullable: true
+                            required:
+                              - from
+                            properties:
+                              function: # The exported function to call in the wasm module, defaults to 'scale'
+                                type: string
+                                default: "scale"
+                              config: # Config values to pass to the wasm program on startup
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              from:
+                                type: object
+                                required:
+                                  - url
+                                properties:
+                                  url:              
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      url:
+                                        type: string
+                                      service:
+                                        type: object
+                                        required:
+                                          - namespace
+                                          - name
+                                        properties:
+                                          namespace:
+                                            type: string
+                                          name:
+                                            type: string
+                                          path:
+                                            type: string
+                                          port:
+                                            type: integer
+                                      caBundle:
+                                        type: string
+                                        format: byte
+                              hash: # optional sha256 hash to match against wasm file (it's optional, but recommended)
+                                type: string
+                                pattern: "^[a-fA-F0-9]{64}$" # Defines which policy to apply during the active period. Required.
+                    wasm:
+                      type: object
+                      nullable: true
+                      required:
+                        - from
+                      properties:
+                        function: # The exported function to call in the wasm module, defaults to 'scale'
+                          type: string
+                          default: "scale"
+                        config: # Config values to pass to the wasm program on startup
+                          type: object
+                          additionalProperties:
+                            type: string
+                        from:
+                          type: object
+                          required:
+                            - url
+                          properties:
+                            url:              
+                              type: object
+                              nullable: true
+                              properties:
+                                url:
+                                  type: string
+                                service:
+                                  type: object
+                                  required:
+                                    - namespace
+                                    - name
+                                  properties:
+                                    namespace:
+                                      type: string
+                                    name:
+                                      type: string
+                                    path:
+                                      type: string
+                                    port:
+                                      type: integer
+                                caBundle:
+                                  type: string
+                                  format: byte
+                        hash: # optional sha256 hash to match against wasm file (it's optional, but recommended)
+                          type: string
+                          pattern: "^[a-fA-F0-9]{64}$"
                 sync:
                   type: object
                   required:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

- Add 'Wasm' as a new policy type option for FleetAutoscaler
- Create reusable 'url.configuration' template for webhook and wasm URL configs
- Add wasm policy schema with function, config, from.url, and hash fields
- Refactor webhook policy to use shared url.configuration template
- Update generated install.yaml with corresponding CRD changes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #4080

**Special notes for your reviewer**:

N/A