### PR TITLE
Updates Rust version

### DIFF
--- a/build/build-sdk-images/rust/Dockerfile
+++ b/build/build-sdk-images/rust/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get --allow-releaseinfo-change update && \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.71.1
+    RUST_VERSION=1.90.0
 RUN wget -q https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION && \


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind hotfix

**What this PR does / Why we need it**:

Step 19: tests fails on CI / CD builds with:

```
make: *** [includes/sdk.mk:78: run-sdk-command-rust] Error 2
make[1]: *** [includes/sdk.mk:91: run-sdk-command] Error 101
/usr/bin/make ensure-image IMAGE_TAG=agones-build:795b8da520 BUILD_TARGET=build-build-image
...
make[1]: Entering directory '/workspace/build'
  Determining projects to restore...
where `ver` is the latest version of `indexmap` supporting rustc 1.71.1
cargo update -p indexmap@2.12.0 --precise ver
Either upgrade to rustc 1.82 or newer, or use
error: package `indexmap v2.12.0` cannot be built because it requires rustc 1.82 or newer, while the currently active rustc version is 1.71.1
```

This updates Rust to the latest stable version.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


