### PR TITLE
build: upgrade MetalLB to v0.15.2 and use helm upgrade --install

### DIFF
--- a/build/includes/kind.mk
+++ b/build/includes/kind.mk
@@ -33,7 +33,7 @@ kind-test-cluster: $(ensure-build-image)
 kind-metallb-helm-install:
 	helm repo add metallb https://metallb.github.io/metallb
 	helm repo update
-	helm install metallb metallb/metallb --namespace metallb-system --create-namespace --version 0.13.12 --wait --timeout 180s
+	helm upgrade metallb metallb/metallb --install --namespace metallb-system --create-namespace --version 0.15.2 --wait --timeout 180s
 
 # kind-metallb-configure configures metallb with an ip address range based on the kind node IP
 kind-metallb-configure:

--- a/build/includes/minikube.mk
+++ b/build/includes/minikube.mk
@@ -37,7 +37,7 @@ minikube-test-cluster: $(ensure-build-image)
 minikube-metallb-helm-install:
 	helm repo add metallb https://metallb.github.io/metallb
 	helm repo update
-	helm install metallb metallb/metallb --namespace metallb-system --create-namespace --version 0.13.12 --wait --timeout 5m
+	helm upgrade metallb metallb/metallb --install --namespace metallb-system --create-namespace --version 0.15.2 --wait --timeout 5m
 
 # minikube-metallb-configure configures metallb with an ip address range based on the minikube ip
 minikube-metallb-configure:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

- Update MetalLB version from 0.13.12 to 0.15.2 in kind and minikube makefiles
- Change from 'helm install' to 'helm upgrade --install' for better idempotency
- This allows the command to work on both fresh installs and upgrades

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A
