### PR TITLE
Removes assignees from github workflow

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -20,4 +20,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/ISSUE_TEMPLATE/golang_version_upgrade.md
-          assignees: 0xaravindh, Sivasankaran25


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / Why we need it**:

The "Update Dependencies" workflow keeps breaking as there is significant churn in the assignees. This removes the automatically added assignees from the workflow.

```
[Create update dependency issue once every six weeks](https://github.com/googleforgames/agones/actions/runs/19414349475/job/55540354553#step:4:95)
An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE/golang_version_upgrade.md!

Validation Failed: {"message":"assignees 0xaravindh cannot be assigned to this issue","value":["0xaravindh"],"resource":"Issue","field":"assignees","code":"invalid"}
```

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:

This means that assignees will need to be manually added, or the issue manually picked up by someone with the power to build and push images with the dependency changes. This is preferable IMO to the action simply failing to create an issue in the first place.

