### PR TITLE
Adds the build environment image to the pre_cloudbuild pipeline

### DIFF
--- a/build/release/pre_cloudbuild.yaml
+++ b/build/release/pre_cloudbuild.yaml
@@ -33,7 +33,8 @@ steps:
       - .
 
   #
-  # Creates the initial make + docker build platform
+  # Creates the initial make + docker build platform.
+  # This image is used to run subsequent 'make' commands.
   #
   - name: ubuntu
     args:
@@ -46,7 +47,29 @@ steps:
     args: [build, -f, Dockerfile.build, -t, make-docker, .]
 
   #
-  # Ensure example images exists
+  # Pull the build environment image if it exists.
+  # This image contains all the tools needed to run the build and test commands.
+  #
+  - name: make-docker
+    id: pull-build-image
+    dir: build
+    env: ['REGISTRY=us-docker.pkg.dev/${PROJECT_ID}/ci']
+    args: [pull-build-image]
+    waitFor:
+      - build-make-docker
+
+  #
+  # Build the build environment image if we were unable to pull it.
+  #
+  - name: "make-docker"
+    id: "ensure-build-image"
+    dir: "build"
+    args: ["ensure-build-image"]
+    waitFor:
+      - pull-build-image
+
+  #
+  # Ensure example images exists. Requires build image to exist in Cloudbuild environment.
   #
   - name: make-docker
     id: test-examples-on-gar
@@ -55,9 +78,11 @@ steps:
       - REGISTRY=us-docker.pkg.dev/${PROJECT_ID}
       - DOCKER_RUN_ARGS=--network=cloudbuild
     args: [test-examples-on-gar]
+    waitFor:
+      - ensure-build-image
 
   #
-  # Deploys the site by taking in the base version and deploying the previous version
+  # Deploys the site by taking in the base version and deploying the previous version.
   #
   - name: make-docker
     id: release-deploy-site
@@ -65,4 +90,6 @@ steps:
     env:
       - VERSION=${_VERSION}
     args: [release-deploy-site]
+    waitFor:
+      - test-examples-on-gar
 timeout: 5400s


### PR DESCRIPTION
**What type of PR is this?**

/kind hotfix

**What this PR does / Why we need it**:

When running `make pre-build-release VERSION=1.54.0` the Cloudbuild run gives the error:

```
Starting Step #4 - "test-examples-on-gar"
Step #4 - "test-examples-on-gar": Already have image: make-docker
Step #4 - "test-examples-on-gar": docker run --rm -v /workspace/build//.config/gcloud:/root/.config/gcloud -v ~/.kube/:/root/.kube -v ~/.config/helm:/root/.config/helm -v ~/.cache/helm:/root/.cache/helm -v /workspace:/go/src/agones.dev/agones -v /workspace/build//.gomod:/go/pkg/mod -v /workspace/build//.gocache:/root/.cache/go-build -e "KUBECONFIG=/root/.kube/config" -e "GO111MODULE=on" -w /go/src/agones.dev/agones --network=cloudbuild agones-build:a8d1f85932 bash -c "cd examples/allocation-endpoint && make gar-check"
Step #4 - "test-examples-on-gar": Unable to find image 'agones-build:a8d1f85932' locally
Step #4 - "test-examples-on-gar": docker: Error response from daemon: pull access denied for agones-build, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
Step #4 - "test-examples-on-gar": See 'docker run --help'.
Step #4 - "test-examples-on-gar": make: *** [includes/examples.mk:51: example-image-test.allocation-endpoint] Error 125
Finished Step #4 - "test-examples-on-gar"
ERROR
ERROR: build step 4 "make-docker" failed: step exited with non-zero status: 2
```

Looks like this is due to the `make test-examples-on-gar` being dependent on having the build environment image available in the Cloudbuild environment. We fix this by adding back the `pull-build-image` that had been removed in a previous PR. We also add in the `ensure-build-image` as the `pull-build-image` will fail silently if it cannot pull the image.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:


