### PR TITLE
feat: refactored to use SumGameServerSets

### DIFF
--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -250,8 +250,6 @@ func (f *Fleet) LowerBoundReplicas(i int32) int32 {
 
 // SumGameServerSets calculates a total from the value returned from the passed in function.
 // Useful for calculating totals based on status value(s), such as gsSet.Status.Replicas
-// This should eventually replace the variety of `Sum*` and `GetReadyReplicaCountForGameServerSets` functions as this is
-// a higher and more flexible abstraction.
 func SumGameServerSets(list []*GameServerSet, f func(gsSet *GameServerSet) int32) int32 {
 	var total int32
 	for _, gsSet := range list {
@@ -261,51 +259,4 @@ func SumGameServerSets(list []*GameServerSet, f func(gsSet *GameServerSet) int32
 	}
 
 	return total
-}
-
-// SumStatusAllocatedReplicas returns the total number of
-// Status.AllocatedReplicas in the list of GameServerSets
-func SumStatusAllocatedReplicas(list []*GameServerSet) int32 {
-	total := int32(0)
-	for _, gsSet := range list {
-		total += gsSet.Status.AllocatedReplicas
-	}
-
-	return total
-}
-
-// SumStatusReplicas returns the total number of
-// Status.Replicas in the list of GameServerSets
-func SumStatusReplicas(list []*GameServerSet) int32 {
-	total := int32(0)
-	for _, gsSet := range list {
-		total += gsSet.Status.Replicas
-	}
-
-	return total
-}
-
-// SumSpecReplicas returns the total number of
-// Spec.Replicas in the list of GameServerSets
-func SumSpecReplicas(list []*GameServerSet) int32 {
-	total := int32(0)
-	for _, gsSet := range list {
-		if gsSet != nil {
-			total += gsSet.Spec.Replicas
-		}
-	}
-
-	return total
-}
-
-// GetReadyReplicaCountForGameServerSets returns the total number of
-// Status.ReadyReplicas in the list of GameServerSets
-func GetReadyReplicaCountForGameServerSets(gss []*GameServerSet) int32 {
-	totalReadyReplicas := int32(0)
-	for _, gss := range gss {
-		if gss != nil {
-			totalReadyReplicas += gss.Status.ReadyReplicas
-		}
-	}
-	return totalReadyReplicas
 }

--- a/pkg/apis/agones/v1/fleet_test.go
+++ b/pkg/apis/agones/v1/fleet_test.go
@@ -145,7 +145,9 @@ func TestSumStatusAllocatedReplicas(t *testing.T) {
 	gsSet2 := f.GameServerSet()
 	gsSet2.Status.AllocatedReplicas = 3
 
-	assert.Equal(t, int32(5), SumStatusAllocatedReplicas([]*GameServerSet{gsSet1, gsSet2}))
+	assert.Equal(t, int32(5), SumGameServerSets([]*GameServerSet{gsSet1, gsSet2}, func(gsSet *GameServerSet) int32 {
+		return gsSet.Status.AllocatedReplicas
+	}))
 }
 
 func TestFleetGameserverSpec(t *testing.T) {
@@ -267,7 +269,9 @@ func TestSumStatusReplicas(t *testing.T) {
 		{Status: GameServerSetStatus{Replicas: 5}},
 	}
 
-	assert.Equal(t, int32(30), SumStatusReplicas(fixture))
+	assert.Equal(t, int32(30), SumGameServerSets(fixture, func(gsSet *GameServerSet) int32 {
+		return gsSet.Status.Replicas
+	}))
 }
 
 func TestSumSpecReplicas(t *testing.T) {
@@ -278,7 +282,9 @@ func TestSumSpecReplicas(t *testing.T) {
 		nil,
 	}
 
-	assert.Equal(t, int32(125), SumSpecReplicas(fixture))
+	assert.Equal(t, int32(125), SumGameServerSets(fixture, func(gsSet *GameServerSet) int32 {
+		return gsSet.Spec.Replicas
+	}))
 }
 
 func TestGetReadyReplicaCountForGameServerSets(t *testing.T) {
@@ -289,7 +295,9 @@ func TestGetReadyReplicaCountForGameServerSets(t *testing.T) {
 		nil,
 	}
 
-	assert.Equal(t, int32(1020), GetReadyReplicaCountForGameServerSets(fixture))
+	assert.Equal(t, int32(1020), SumGameServerSets(fixture, func(gsSet *GameServerSet) int32 {
+		return gsSet.Status.ReadyReplicas
+	}))
 }
 
 func TestSumGameServerSets(t *testing.T) {

--- a/pkg/fleets/controller_rollingupdatefix.go
+++ b/pkg/fleets/controller_rollingupdatefix.go
@@ -76,7 +76,9 @@ func (c *Controller) rollingUpdateRestFixedOnReadyRollingUpdateFix(ctx context.C
 	// Check if we can scale down.
 	allGSS := rest
 	allGSS = append(allGSS, active)
-	readyReplicasCount := agonesv1.GetReadyReplicaCountForGameServerSets(allGSS)
+	readyReplicasCount := agonesv1.SumGameServerSets(allGSS, func(gsSet *agonesv1.GameServerSet) int32 {
+		return gsSet.Status.ReadyReplicas
+	})
 	minAvailable := fleet.Status.ReadyReplicas - unavailable
 	if minAvailable > fleet.Spec.Replicas {
 		minAvailable = fleet.Spec.Replicas


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
Refactors the replica counting logic by replacing the legacy `Sum*` and `GetReadyReplicaCountForGameServerSets` functions with the higher-level abstraction. This cleanup addresses the technical debt highlighted in the code comments, unifies the counting mechanism, and removes redundant code.



