### PR TITLE
fix(rust-simple): upgrade rust toolchain to 1.92 to fix build failure

### DIFF
--- a/examples/rust-simple/Dockerfile
+++ b/examples/rust-simple/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.71.0 as builder
+FROM rust:1.92.0 as builder
 RUN useradd -m build
 RUN apt update && apt install -y protobuf-compiler
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

 /kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:

Closes #4413

**Special notes for your reviewer**:


