### PR TITLE
Fixes post_cloudbuild release by explicitly passing variables as Makefile arguments

### DIFF
--- a/build/release/post_cloudbuild.yaml
+++ b/build/release/post_cloudbuild.yaml
@@ -55,7 +55,7 @@ steps:
       - VERSION=${_VERSION}
       - REGISTRY=${_REGISTRY}/release
       - FULL_BUILD=1
-    args: [-j, '1', build]
+    args: [-j, '1', build, "VERSION=${_VERSION}", "FULL_BUILD=1"]
 
   #
   # push all the images
@@ -64,8 +64,12 @@ steps:
     id: push-images
     waitFor: [build-images]
     dir: build
-    env: ['VERSION=${_VERSION}', 'REGISTRY=${_REGISTRY}/release']
-    args: [-j, '1', push]
+    env:
+      - VERSION=${_VERSION}
+      - REGISTRY=${_REGISTRY}/release
+      - FULL_BUILD=1
+    # Pass as arguments to force-override the Makefile's git-describe logic for VERSION
+    args: [-j, '1', push, "VERSION=${_VERSION}", "FULL_BUILD=1"]
 
   #
   # Creating cloud storage bucket
@@ -102,7 +106,10 @@ steps:
     id: push-chart
     waitFor: [build-images, push-images]
     dir: build
-    env: ['VERSION=${_VERSION}', DOCKER_RUN_ARGS=--network=cloudbuild]
+    env:
+      - VERSION=${_VERSION}
+      - DOCKER_RUN_ARGS=--network=cloudbuild
+      - FULL_BUILD=1
     args: [push-chart]
 options:
   machineType: E2_HIGHCPU_32


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

This PR updates the `post_cloudbuild.yaml` script to ensure that release build and push uses the correct version string and skips the development suffix.

Specifically, it changes how `VERSION` and `FULL_BUILD` are passed to the make-docker steps. By moving these from environment variables to explicit command-line arguments, we force the `Makefile` to use the provided release version (e.g., 1.55.0).

Previously, the Makefile was defaulting to a development version string (e.g., 1.55.0-dev-1b1c538) during the push-images step. The Cloud Build would fail, because the push-images step looked for development tags that did not match the release image tags correctly created in the previous build step.

[Cloud Build push-images log](https://pantheon.corp.google.com/cloud-build/builds;region=global/63c5cd11-0e7d-4277-b682-6dd6d47d9c58;step=5?e=13803378&mods=prod_coliseum&project=agones-images):

```
Step #5 - "push-images": docker buildx use arm64-builder || docker buildx create --name arm64-builder --use
Step #5 - "push-images": docker buildx build --platform linux/arm64 --builder arm64-builder --build-arg ARCH=arm64 /workspace/cmd/controller/ --tag=us-docker.pkg.dev/agones-images/release/agones-controller:1.55.0-dev-1b1c538-arm64 --push
...
Step #5 - "push-images": docker buildx imagetools create --tag us-docker.pkg.dev/agones-images/release/agones-controller:1.55.0 us-docker.pkg.dev/agones-images/release/agones-controller:1.55.0-amd64 us-docker.pkg.dev/agones-images/release/agones-controller:1.55.0-arm64
Step #5 - "push-images": ERROR: us-docker.pkg.dev/agones-images/release/agones-controller:1.55.0-arm64: not found
```

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:

Even though the `push-images` step was the failing step, I updated for all `build-images`, `push-images`, and `push-chart` steps for consistency. 

