### PR TITLE
fix(docs): update external links in out-of-cluster dev server guide

### DIFF
--- a/site/content/en/docs/Advanced/out-of-cluster-dev-server.md
+++ b/site/content/en/docs/Advanced/out-of-cluster-dev-server.md
@@ -79,7 +79,7 @@ Obviously, this document does not know what every developer's specific network c
 The developer will need to figure out which steps are necessary for their specific configuration.
 
 If attempting to connect via the internet, the developer needs to set the `GameServer`'s `metadata:annotations:agones.dev/dev-address` field to their public IP.
-This can be found by going to [whatsmyip.org](https://www.whatsmyip.org/) or [whatismyip.com](https://www.whatismyip.com/) in a web browser.
+This can be found by going to [whatsmyip.org](https://www.whatsmyip.org/) or <a href="https://www.whatismyip.com/" data-proofer-ignore>whatismyip.com</a> in a web browser.
 
 The  `GameServer`'s `spec:ports:hostPort`/`spec:ports:containerPort` should be set to whichever port the game server binary's logic will bind to -- the port used by `simple-game-server` is 7654 (by default).
 The local network's router must also be configured to forward this port to the desired machine; allowing inbound external requests (from the internet) to be directed to the machine on the network that is running the game server.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

- Adjusted `<a>` tags for `whatismyip.com` to bypass link checker because they are returning a 403 when we try and check them.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Unblock CI
