### PR TITLE
docs: fix alert shortcode syntax to process Markdown content

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -128,11 +128,11 @@ The `agones.dev/last-allocated` annotation will be set on the GameServer to an R
 
 Note that if using `SDK.Allocate()` in combination with [GameServerAllocation]({{< ref "/docs/Reference/gameserverallocation.md" >}})s, it's possible for the `agones.dev/last-allocated` timestamp to move backwards if clocks are not synchronized between the Agones controller and the GameServer pod.
 
-{{< alert title="Note" color="info">}}
+{{% alert title="Note" color="info"%}}
 Using a [GameServerAllocation]({{< ref "/docs/Reference/gameserverallocation.md" >}}) is preferred in all other scenarios, 
 as it gives Agones control over how packed `GameServers` are scheduled within a cluster, whereas with `Allocate()` you
 relinquish control to an external service which likely doesn't have as much information as Agones.
-{{< /alert >}}
+{{% /alert %}}
 
 #### Shutdown()
 This tells Agones to shut down the currently running game server. The GameServer state will be set `Shutdown` and the 

--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -114,11 +114,11 @@ curl -d '{"seconds": "5"}' -H "Content-Type: application/json" -X POST http://lo
 With some matchmakers and game matching strategies, it can be important for game servers to mark themselves as `Allocated`.
 For those scenarios, this SDK functionality exists.
 
-{{< alert title="Note" color="info">}}
+{{% alert title="Note" color="info"%}}
 Using a [GameServerAllocation]({{< ref "/docs/Reference/gameserverallocation.md" >}}) is preferred in all other scenarios,
 as it gives Agones control over how packed `GameServers` are scheduled within a cluster, whereas with `Allocate()` you
 relinquish control to an external service which likely doesn't have as much information as Agones.
-{{< /alert >}}
+{{% /alert %}}
 
 ##### Example
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Change alert shortcodes from {{< >}} to {{% %}} syntax in Client SDK documentation. The {{% %}} syntax allows Markdown content inside the shortcode to be properly rendered.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Must have worked with the earlier versions of hugo+docsy, but not anymore!