### PR TITLE
test: fix flaky allocation metrics test server startup

### DIFF
--- a/pkg/gameserverallocations/metrics_test.go
+++ b/pkg/gameserverallocations/metrics_test.go
@@ -237,17 +237,14 @@ func TestStartMetricsServer(t *testing.T) {
 
 	metricsURL := startMetricsServerForTest(t, server)
 
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(_ context.Context) (bool, error) {
+	require.EventuallyWithT(t, func(e *assert.CollectT) {
 		resp, err := http.Get(metricsURL)
-		if err != nil {
-			return false, nil
-		}
+		require.NoError(e, err)
 		defer func() {
-			assert.NoError(t, resp.Body.Close())
+			assert.NoError(e, resp.Body.Close())
 		}()
-		return resp.StatusCode == http.StatusOK, nil
-	})
-	require.NoError(t, err)
+		assert.Equal(e, http.StatusOK, resp.StatusCode)
+	}, time.Second, 10*time.Millisecond)
 }
 
 func startMetricsServerForTest(t *testing.T, handler http.Handler) string {


### PR DESCRIPTION
**Title**
  test: fix flaky TestAllocationMetrics port conflict and startup race
  
  Changes:
  - Removed hardcoded metrics port (`3001`) from the test path.
  - Added dynamic test server bootstrap using a pre-bound ephemeral listener (`127.0.0.1:0`).
  - Replaced fixed `time.Sleep(300ms)` with readiness polling against the metrics endpoint.
  - Added `TestStartMetricsServer` to validate server bootstrap helper behavior.
  
  Fix #4444