### PR TITLE
Upgrade deprecated Grafana Helm chart to grafana-community/grafana

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -916,10 +916,10 @@ setup-grafana: PVC ?= true
 setup-grafana: PV_SIZE ?= 64Gi
 setup-grafana: PASSWORD ?= admin
 setup-grafana:
-	$(DOCKER_RUN) helm repo add grafana https://grafana.github.io/helm-charts
+	$(DOCKER_RUN) helm repo add grafana-community https://grafana-community.github.io/helm-charts
 	$(DOCKER_RUN) helm repo update
 	$(DOCKER_RUN) kubectl apply -f $(mount_path)/build/grafana/
-	$(DOCKER_RUN) helm upgrade grafana grafana/grafana --install --wait \
+	$(DOCKER_RUN) helm upgrade grafana grafana-community/grafana --install --wait \
 		--namespace metrics --create-namespace \
 		--set persistence.enabled=$(PVC),server.persistentVolume.size=$(PV_SIZE) \
 		--set adminPassword=$(PASSWORD) $(HELM_ARGS) -f $(mount_path)/build/grafana.yaml

--- a/build/docs/make-reference.md
+++ b/build/docs/make-reference.md
@@ -193,7 +193,7 @@ Run helm repo update to get the mose recent charts.
 
 #### `make setup-grafana`
 
-Install Grafana server using [grafana community](https://grafana.github.io/helm-charts) chart into
+Install Grafana server using [grafana community](https://grafana-community.github.io/helm-charts) chart into
 the current cluster and setup [Agones dashboards with Prometheus datasource](./grafana/).
 
 You can set your own password using the `PASSWORD` environment variable.

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -191,14 +191,14 @@ kubectl apply -f ./build/grafana/
 ```
 
 Now we can install the
-[Grafana Community Kubernetes Helm Charts](https://grafana.github.io/helm-charts/) from
+[Grafana Community Kubernetes Helm Charts](https://grafana-community.github.io/helm-charts/) from
 their repository. (Replace `<your-admin-password>` with the admin password of your choice)
 
 ```bash
-helm repo add grafana https://grafana.github.io/helm-charts
+helm repo add grafana-community https://grafana-community.github.io/helm-charts
 helm repo update
 
-helm upgrade --install --wait grafana grafana/grafana --namespace metrics \
+helm upgrade --install --wait grafana grafana-community/grafana --namespace metrics \
   --set adminPassword=<your-admin-password> -f ./build/grafana.yaml
 ```
 


### PR DESCRIPTION
## Summary
The `grafana/grafana` Helm chart from `https://grafana.github.io/helm-charts` was deprecated on January 30, 2026. This PR migrates to the new `grafana-community/grafana` chart.

### Changes
- **build/Makefile**: Update `helm repo add` URL from `grafana.github.io/helm-charts` to `grafana-community.github.io/helm-charts`, and chart reference from `grafana/grafana` to `grafana-community/grafana`
- **site/content/en/docs/Guides/metrics.md**: Update Grafana installation docs with new repo URL and chart name
- **build/docs/make-reference.md**: Update chart link to new URL

### Not changed
- `build/grafana.yaml` and `build/grafana-frontend.yaml`: Our current values (service port, tolerations, affinity, sidecar dashboards, plugins, datasources) should be compatible with the new chart. The `uninstall-grafana` target also does not need changes since it references the release name, not the chart.

Closes #4447

## Test plan
- [ ] `make setup-grafana` installs Grafana without the deprecation warning
- [ ] Dashboards load correctly in the Grafana UI
- [ ] `make uninstall-grafana` still works as expected