### PR TITLE
build: improve test-gen-api-docs failure message

### DIFF
--- a/build/includes/website.mk
+++ b/build/includes/website.mk
@@ -111,7 +111,8 @@ test-gen-api-docs: ensure-build-image
 	sort /tmp/generated.html > /tmp/generated.html.sorted
 	$(GEN_API_DOCS)
 	sort $(expected_docs) > /tmp/result.sorted
-	diff -bB /tmp/result.sorted /tmp/generated.html.sorted
+	diff -bB /tmp/result.sorted /tmp/generated.html.sorted || \
+		(echo "Error: API docs are out of date. Please run 'make gen-api-docs' to regenerate them since the CRD information in /pkg/apis has changed." && exit 1)
 
 # Remove feature expiry/publish version shortcodes update in site/content/en/docs
 feature-shortcode-update: ensure-build-image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

When the API docs diff fails, print a clear error message telling the user to run 'make gen-api-docs' since the CRD information in /pkg/apis has changed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Just making it easier for people to know why this test fails.