### PR TITLE
Docs: add allocator, ping, and topology spread HA details

### DIFF
--- a/site/content/en/docs/Advanced/high-availability-agones.md
+++ b/site/content/en/docs/Advanced/high-availability-agones.md
@@ -3,7 +3,7 @@ title: "High Availability Agones"
 date: 2023-02-10
 weight: 20
 description: >
-  Learn how to configure your Agones services for high availability and resiliancy to disruptions.
+  Learn how to configure your Agones services for high availability and resiliency to disruptions.
 publishDate: 2023-02-28
 ---
 
@@ -11,15 +11,15 @@ publishDate: 2023-02-28
 ## High Availability for Agones Controller
 
 
-The `agones-controller` responsibility is split up into `agones-controller`, which enacts the Agones control loop, and `agones-extensions`, which acts as a service endpoint for webhooks and the allocation extension API. Splitting these responsibilities allows the `agones-extensions` pod to be **horizontally scaled**, making the Agones control plane **highly available** and more **resiliant to disruption**.
+The `agones-controller` responsibility is split up into `agones-controller`, which enacts the Agones control loop, and `agones-extensions`, which acts as a service endpoint for webhooks and the allocation extension API. Splitting these responsibilities allows the `agones-extensions` pod to be **horizontally scaled**, making the Agones control plane **highly available** and more **resilient to disruption**.
 
 Multiple `agones-controller` pods enabled, with a primary controller selected via leader election. Having multiple `agones-controller` minimizes downtime of the service from pod disruptions such as deployment updates, autoscaler evictions, and crashes.
 
-## Extension Pod Configrations 
+## Extension Pod Configurations 
 
 The `agones-extensions` binary has a similar `helm` configuration to `agones-controller`, see [here]({{< relref "/docs/Installation/Install Agones/helm.md" >}}). If you previously overrode `agones.controller.*` settings, you may need to override the same `agones.extensions.*` setting.
 
-To change `controller.numWorkers` to 200 from 100 values and through the use of `helm --set`, add the follow to the `helm` command:
+To change `controller.numWorkers` to 200 from 100 values and through the use of `helm --set`, add the following to the `helm` command:
 
 {{% alert color="warning" %}} Important: This will not have any effect on any `extensions` values! {{% /alert %}}
 ```
@@ -51,6 +51,20 @@ agones-ping-5b9647874-rksgg          1/1     Running   0          27h
 ```
 
 The number of replicas for `agones-extensions` can be set using helm variable [`agones.extensions.replicas`]({{< relref "/docs/Installation/Install Agones/helm.md#configuration" >}}), but the default is `2`. 
+
+## High Availability for Supporting Services
+
+The `agones-allocator` service is also deployed with multiple replicas by default. This makes allocation requests resilient to pod failures, rolling updates, and node shutdowns, since other allocator pods can continue serving traffic.
+
+Similarly, the `agones-ping` service runs multiple replicas, allowing health checks and ping responses to remain available even if an individual pod or node becomes unavailable.
+
+The example deployment above shows three `agones-allocator` pods and two `agones-ping` pods running simultaneously to provide redundancy.
+
+## Topology Spread Considerations
+
+For additional resiliency, Agones controller and extension pods can be configured with Kubernetes `topologySpreadConstraints` to distribute replicas across different nodes and zones.
+
+This reduces the risk of multiple replicas being scheduled onto the same node or failure domain, helping ensure that a single node shutdown does not take down all replicas of a service.
 
 We expect the aggregate memory consumption of the pods will be slightly higher than the previous singleton pod, but as the responsibilities are now split across the pods, the aggregate CPU consumption should also be similar.
 


### PR DESCRIPTION
/kind documentation

**What this PR does / Why we need it**:

Updates the High Availability Agones documentation to include additional details about the resiliency of `agones-allocator` and `agones-ping`.

The documentation now explains that these services run multiple replicas by default, helping them remain available during pod failures, rolling updates, and node shutdowns.

This PR also adds guidance about using Kubernetes `topologySpreadConstraints` to distribute controller and extension pods across nodes and zones for improved resiliency.

Additionally, it includes a few minor typo and wording fixes.

**Which issue(s) this PR fixes**:

Closes #3779

**Special notes for your reviewer**:

Added only documentation updates. No code or configuration changes were made.
