### PR TITLE
build: improve gen-install and gen-api-docs failure messages

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -430,7 +430,8 @@ test-install-yaml:
 	sort /tmp/agones-install/install.yaml > /tmp/agones-install/install.yaml.sorted
 	$(MAKE) gen-install
 	sort $(agones_path)/install/yaml/install.yaml > /tmp/agones-install/install.current.yaml.sorted
-	diff /tmp/agones-install/install.yaml.sorted /tmp/agones-install/install.current.yaml.sorted
+	@diff /tmp/agones-install/install.yaml.sorted /tmp/agones-install/install.current.yaml.sorted || \
+		(echo "\n\n>>> Error: install.yaml is out of date. Please run 'make gen-install' to regenerate it, since the Helm template has changed.\n\n" && exit 1)
 
 # Push all the images up to $(REGISTRY)
 push: push-controller-image push-extensions-image push-agones-sdk-image push-ping-image push-allocator-image push-processor-image

--- a/build/includes/website.mk
+++ b/build/includes/website.mk
@@ -111,8 +111,8 @@ test-gen-api-docs: ensure-build-image
 	sort /tmp/generated.html > /tmp/generated.html.sorted
 	$(GEN_API_DOCS)
 	sort $(expected_docs) > /tmp/result.sorted
-	diff -bB /tmp/result.sorted /tmp/generated.html.sorted || \
-		(echo "Error: API docs are out of date. Please run 'make gen-api-docs' to regenerate them since the CRD information in /pkg/apis has changed." && exit 1)
+	@diff -bB /tmp/result.sorted /tmp/generated.html.sorted || \
+		(echo "\n\n>>> Error: API docs are out of date. Please run 'make gen-api-docs' to regenerate them since the CRD information in /pkg/apis has changed.\n\n" && exit 1)
 
 # Remove feature expiry/publish version shortcodes update in site/content/en/docs
 feature-shortcode-update: ensure-build-image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

- Enhance error messages for `make gen-install` and `make gen-api-docs` to clearly instruct users on resolving out-of-date files caused by changes in Helm templates and CRD information.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A - just noticed it in #4511 and the submitter had no idea what was wrong, because the test doesn't say! 🤦🏻 

**Special notes for your reviewer**:

output on failure now looks like this:

```shell
❯ make test-gen-api-docs
mkdir -p ~/.kube/
mkdir -p /home/mark/workspace/agones/build//.gocache
mkdir -p /home/mark/workspace/agones/build//.config/gcloud
mkdir -p ~/.config/helm
mkdir -p ~/.cache/helm
make ensure-image IMAGE_TAG=agones-build:a36e3501e7 BUILD_TARGET=build-build-image
make[1]: Entering directory '/home/mark/workspace/agones/build'
make[1]: Leaving directory '/home/mark/workspace/agones/build'
cp /home/mark/workspace/agones/site/content/en/docs/Reference/agones_crd_api_reference.html /tmp/generated.html
sort /tmp/generated.html > /tmp/generated.html.sorted
....
++ sort /tmp/old_docs.html
3015c3015
< <p>Fleet is the data structure for a Fleet resource</p>
---
> <p>Fleet is the data structure for a Fleet resource OH YEAH</p>
Output to a file /go/src/agones.dev/agones/site/content/en/docs/Reference/agones_crd_api_reference.html
expiry version left unchanged
+ echo 'Output to a file /go/src/agones.dev/agones/site/content/en/docs/Reference/agones_crd_api_reference.html'
+ '[' '{{% feature publishVersion="1.58.0" %}}' '!=' '{{% feature publishVersion="1.58.0" %}}' ']'
+ echo 'expiry version left unchanged'
+ cat /tmp/expiry.html
+ cat /tmp/title.html
+ echo -e '{{% feature publishVersion="1.58.0" %}}'
+ cat /tmp/agones_crd_api_reference.html
+ echo -e '{{% /feature %}}\n'
sort /home/mark/workspace/agones/site/content/en/docs/Reference/agones_crd_api_reference.html > /tmp/result.sorted
4480c4480
< <p>Fleet is the data structure for a Fleet resource</p>
---
> <p>Fleet is the data structure for a Fleet resource OH YEAH</p>


>>> Error: API docs are out of date. Please run 'make gen-api-docs' to regenerate them since the CRD information in /pkg/apis has changed.


make: *** [includes/website.mk:114: test-gen-api-docs] Error 1
```

and


```shell
❯ make test-install-yaml
mkdir -p /tmp/agones-install
cp /home/mark/workspace/agones/install/yaml/install.yaml /tmp/agones-install/install.yaml
sort /tmp/agones-install/install.yaml > /tmp/agones-install/install.yaml.sorted
make gen-install
make[1]: Entering directory '/home/mark/workspace/agones/build'
mkdir -p ~/.kube/
mkdir -p /home/mark/workspace/agones/build//.gocache
mkdir -p /home/mark/workspace/agones/build//.config/gcloud
mkdir -p ~/.config/helm
mkdir -p ~/.cache/helm
make ensure-image IMAGE_TAG=agones-build:a36e3501e7 BUILD_TARGET=build-build-image
make[2]: Entering directory '/home/mark/workspace/agones/build'
make[2]: Leaving directory '/home/mark/workspace/agones/build'
docker run --rm -v /home/mark/workspace/agones/build//.config/gcloud:/root/.config/gcloud -v ~/.kube/:/root/.kube -v ~/.config/helm:/root/.config/helm -v ~/.cache/helm:/root/.cache/helm -v /home/mark/workspace/agones:/go/src/agones.dev/agones -v /home/mark/workspace/agones/build//.gomod:/go/pkg/mod -v /home/mark/workspace/agones/build//.gocache:/root/.cache/go-build  agones-build:a36e3501e7 bash -c \
	'helm template agones-manual --namespace agones-system /go/src/agones.dev/agones/install/helm/agones \
	--set agones.controller.generateTLS=false \
	--set agones.allocator.generateTLS=false \
	--set agones.allocator.generateClientTLS=false \
	--set agones.crds.cleanupOnDelete=false \
	> /go/src/agones.dev/agones/install/yaml/install.yaml'
make[1]: Leaving directory '/home/mark/workspace/agones/build'
sort /home/mark/workspace/agones/install/yaml/install.yaml > /tmp/agones-install/install.current.yaml.sorted
9540a9541
>   name: agones-controller
9543d9543
<   name: agones-controller-foo


>>> Error: install.yaml is out of date. Please run 'make gen-install' to regenerate it, since the Helm template has changed.


make: *** [Makefile:433: test-install-yaml] Error 1
```