### PR TITLE
feat: track allocations per fleet

### DIFF
--- a/install/helm/agones/templates/crds/fleet.yaml
+++ b/install/helm/agones/templates/crds/fleet.yaml
@@ -157,6 +157,9 @@ spec:
                 allocatedReplicas:
                   type: integer
                   minimum: 0
+                allocations:
+                  type: integer
+                  minimum: 0
                 players:
                   type: object
                   nullable: true

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -6583,6 +6583,9 @@ spec:
                 allocatedReplicas:
                   type: integer
                   minimum: 0
+                allocations:
+                  type: integer
+                  minimum: 0
                 players:
                   type: object
                   nullable: true

--- a/pkg/apis/agones/v1/fleet.go
+++ b/pkg/apis/agones/v1/fleet.go
@@ -96,6 +96,8 @@ type FleetStatus struct {
 	ReservedReplicas int32 `json:"reservedReplicas"`
 	// AllocatedReplicas are the number of Allocated GameServer replicas
 	AllocatedReplicas int32 `json:"allocatedReplicas"`
+	// Allocations is a counter of the number of allocations observed.
+	Allocations int64 `json:"allocations"`
 	// [Stage:Alpha]
 	// [FeatureFlag:PlayerTracking]
 	// Players are the current total player capacity and count for this Fleet

--- a/pkg/client/applyconfiguration/agones/v1/fleetstatus.go
+++ b/pkg/client/applyconfiguration/agones/v1/fleetstatus.go
@@ -25,6 +25,7 @@ type FleetStatusApplyConfiguration struct {
 	ReadyReplicas     *int32                                               `json:"readyReplicas,omitempty"`
 	ReservedReplicas  *int32                                               `json:"reservedReplicas,omitempty"`
 	AllocatedReplicas *int32                                               `json:"allocatedReplicas,omitempty"`
+	Allocations       *int64                                               `json:"allocations,omitempty"`
 	Players           *AggregatedPlayerStatusApplyConfiguration            `json:"players,omitempty"`
 	Counters          map[string]AggregatedCounterStatusApplyConfiguration `json:"counters,omitempty"`
 	Lists             map[string]AggregatedListStatusApplyConfiguration    `json:"lists,omitempty"`
@@ -65,6 +66,14 @@ func (b *FleetStatusApplyConfiguration) WithReservedReplicas(value int32) *Fleet
 // If called multiple times, the AllocatedReplicas field is set to the value of the last call.
 func (b *FleetStatusApplyConfiguration) WithAllocatedReplicas(value int32) *FleetStatusApplyConfiguration {
 	b.AllocatedReplicas = &value
+	return b
+}
+
+// WithAllocations sets the Allocations field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Allocations field is set to the value of the last call.
+func (b *FleetStatusApplyConfiguration) WithAllocations(value int64) *FleetStatusApplyConfiguration {
+	b.Allocations = &value
 	return b
 }
 

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -72,9 +72,9 @@ type Controller struct {
 	fleetLister         listerv1.FleetLister
 	fleetSynced         cache.InformerSynced
 	workerqueue         *workerqueue.WorkerQueue
-	allocsMu            sync.Mutex
-	allocs              map[string]int64
 	recorder            record.EventRecorder
+	allocs              map[string]int64
+	allocsMu            sync.Mutex
 }
 
 // NewController returns a new fleets crd controller

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"agones.dev/agones/pkg/apis/agones"
@@ -71,10 +73,9 @@ type Controller struct {
 	fleetGetter         getterv1.FleetsGetter
 	fleetLister         listerv1.FleetLister
 	fleetSynced         cache.InformerSynced
+	allocs              *allocTracker
 	workerqueue         *workerqueue.WorkerQueue
 	recorder            record.EventRecorder
-	allocs              map[string]int64
-	allocsMu            sync.Mutex
 }
 
 // NewController returns a new fleets crd controller
@@ -102,7 +103,7 @@ func NewController(
 		fleetGetter:         agonesClient.AgonesV1(),
 		fleetLister:         fleets.Lister(),
 		fleetSynced:         fInformer.HasSynced,
-		allocs:              map[string]int64{},
+		allocs:              newAllocTracker(),
 	}
 
 	c.baseLogger = runtime.NewLoggerWithType(c)
@@ -122,7 +123,7 @@ func NewController(
 		DeleteFunc: func(obj interface{}) {
 			fleet := obj.(*agonesv1.Fleet)
 
-			c.removeAllocations(fleet.ObjectMeta.Namespace, fleet.ObjectMeta.Name)
+			c.allocs.remove(fleet.ObjectMeta.Namespace, fleet.ObjectMeta.Name)
 		},
 	})
 
@@ -152,7 +153,7 @@ func NewController(
 				return
 			}
 
-			c.incAllocations(newGs.Namespace, fleet)
+			c.allocs.inc(newGs.Namespace, fleet, 1)
 		},
 	})
 
@@ -756,10 +757,18 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 		}
 	}
 
-	fCopy.Status.Allocations += c.getAllocations(fleet.ObjectMeta.Namespace, fCopy.ObjectMeta.Name)
+	allocs := c.allocs.get(fleet.ObjectMeta.Namespace, fleet.ObjectMeta.Name)
+	fCopy.Status.Allocations += allocs
 
 	_, err = c.fleetGetter.Fleets(fCopy.ObjectMeta.Namespace).UpdateStatus(ctx, fCopy, metav1.UpdateOptions{})
-	return errors.Wrapf(err, "error updating status of fleet %s", fCopy.ObjectMeta.Name)
+	if err != nil {
+		return errors.Wrapf(err, "error updating status of fleet %s", fCopy.ObjectMeta.Name)
+	}
+
+	// The update was successful, the allocation count must be decremented to reflect this.
+	c.allocs.dec(fleet.ObjectMeta.Namespace, fleet.ObjectMeta.Name, allocs)
+
+	return nil
 }
 
 // filterGameServerSetByActive returns the active GameServerSet (or nil if it
@@ -795,60 +804,104 @@ func (c *Controller) filterGameServerSetByActive(fleet *agonesv1.Fleet, list []*
 	return active, rest
 }
 
-func (c *Controller) getAllocations(ns, fleetName string) (allocs int64) {
-	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
-
-	c.allocsMu.Lock()
-	defer c.allocsMu.Unlock()
-
-	allocs, c.allocs[key] = c.allocs[key], 0
-	return allocs
-}
-
-func (c *Controller) incAllocations(ns, fleetName string) {
-	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
-
-	c.allocsMu.Lock()
-	defer c.allocsMu.Unlock()
-
-	count, ok := c.allocs[key]
-	if !ok {
-		c.allocs[key] = 1
-		return
-	}
-	c.allocs[key] = count + 1
-}
-
-func (c *Controller) removeAllocations(ns, fleetName string) {
-	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
-
-	c.allocsMu.Lock()
-	defer c.allocsMu.Unlock()
-
-	delete(c.allocs, key)
-}
-
 func (c *Controller) flushAllocations() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	c.allocsMu.Lock()
-	defer c.allocsMu.Unlock()
-
-	for fleet, allocs := range c.allocs {
-		if allocs == 0 {
-			continue
-		}
-
-		ns, name, _ := cache.SplitMetaNamespaceKey(fleet)
-		fCopy, err := c.fleetGetter.Fleets(ns).Get(ctx, name, metav1.GetOptions{})
+	c.allocs.forEach(func(ns, fleetName string, count int64) {
+		fCopy, err := c.fleetGetter.Fleets(ns).Get(ctx, fleetName, metav1.GetOptions{})
 		if err != nil {
-			continue
+			return
 		}
 
-		fCopy.Status.Allocations += allocs
+		fCopy.Status.Allocations += count
 
 		_, _ = c.fleetGetter.Fleets(ns).UpdateStatus(ctx, fCopy, metav1.UpdateOptions{})
+	})
+}
+
+type allocTracker struct {
+	counts map[string]*atomic.Int64
+	mu     sync.RWMutex
+}
+
+func newAllocTracker() *allocTracker {
+	return &allocTracker{counts: map[string]*atomic.Int64{}}
+}
+
+func (t *allocTracker) get(ns, fleetName string) int64 {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	counts, ok := t.counts[key]
+	if !ok {
+		return 0
+	}
+	return counts.Load()
+}
+
+func (t *allocTracker) inc(ns, fleetName string, v int64) {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+
+	t.mu.RLock()
+	count, ok := t.counts[key]
+	if ok {
+		count.Add(v)
+		t.mu.RUnlock()
+		return
+	}
+	t.mu.RUnlock()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	count, ok = t.counts[key]
+	if !ok {
+		count = &atomic.Int64{}
+		t.counts[key] = count
+	}
+	count.Add(v)
+}
+
+func (t *allocTracker) dec(ns, fleetName string, v int64) {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+	v = -1 * v
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	// We do not decrement something that does not exist. This would
+	// lead to some fairly confusing results.
+	count, ok := t.counts[key]
+	if ok {
+		count.Add(v)
+	}
+}
+
+func (t *allocTracker) remove(ns, fleetName string) {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.counts, key)
+}
+
+func (t *allocTracker) forEach(fn func(ns, fleetName string, count int64)) {
+	t.mu.Lock()
+	counts := make(map[string]*atomic.Int64, len(t.counts))
+	maps.Copy(counts, t.counts)
+	t.mu.Unlock()
+
+	for key, count := range counts {
+		if count.Load() == 0 {
+			continue
+		}
+
+		ns, fleetName, _ := cache.SplitMetaNamespaceKey(key)
+		fn(ns, fleetName, count.Load())
 	}
 }
 

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"agones.dev/agones/pkg/apis/agones"
@@ -71,6 +72,8 @@ type Controller struct {
 	fleetLister         listerv1.FleetLister
 	fleetSynced         cache.InformerSynced
 	workerqueue         *workerqueue.WorkerQueue
+	allocsMu            sync.Mutex
+	allocs              map[string]int64
 	recorder            record.EventRecorder
 }
 
@@ -81,6 +84,9 @@ func NewController(
 	extClient extclientset.Interface,
 	agonesClient versioned.Interface,
 	agonesInformerFactory externalversions.SharedInformerFactory) *Controller {
+
+	gameServers := agonesInformerFactory.Agones().V1().GameServers()
+	gsInformer := gameServers.Informer()
 
 	gameServerSets := agonesInformerFactory.Agones().V1().GameServerSets()
 	gsSetInformer := gameServerSets.Informer()
@@ -96,6 +102,7 @@ func NewController(
 		fleetGetter:         agonesClient.AgonesV1(),
 		fleetLister:         fleets.Lister(),
 		fleetSynced:         fInformer.HasSynced,
+		allocs:              map[string]int64{},
 	}
 
 	c.baseLogger = runtime.NewLoggerWithType(c)
@@ -112,6 +119,11 @@ func NewController(
 		UpdateFunc: func(_, newObj interface{}) {
 			c.workerqueue.Enqueue(newObj)
 		},
+		DeleteFunc: func(obj interface{}) {
+			fleet := obj.(*agonesv1.Fleet)
+
+			c.removeAllocations(fleet.ObjectMeta.Namespace, fleet.ObjectMeta.Name)
+		},
 	})
 
 	_, _ = gsSetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -122,6 +134,25 @@ func NewController(
 			if gsSet.ObjectMeta.DeletionTimestamp.IsZero() {
 				c.gameServerSetEventHandler(gsSet)
 			}
+		},
+	})
+
+	_, _ = gsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldGs := oldObj.(*agonesv1.GameServer)
+			newGs := newObj.(*agonesv1.GameServer)
+
+			if oldGs.Status.State == agonesv1.GameServerStateAllocated || newGs.Status.State != agonesv1.GameServerStateAllocated {
+				// Count only the transition of a GameServer into the Allocated state.
+				return
+			}
+			fleet, ok := newGs.Labels[agonesv1.FleetNameLabel]
+			if !ok || fleet == "" {
+				// The game server is not attached to a fleet. Nothing to do.
+				return
+			}
+
+			c.incAllocations(newGs.Namespace, fleet)
 		},
 	})
 
@@ -226,6 +257,8 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	}
 
 	c.workerqueue.Run(ctx, workers)
+
+	c.flushAllocations()
 	return nil
 }
 
@@ -723,6 +756,8 @@ func (c *Controller) updateFleetStatus(ctx context.Context, fleet *agonesv1.Flee
 		}
 	}
 
+	fCopy.Status.Allocations += c.getAllocations(fleet.ObjectMeta.Namespace, fCopy.ObjectMeta.Name)
+
 	_, err = c.fleetGetter.Fleets(fCopy.ObjectMeta.Namespace).UpdateStatus(ctx, fCopy, metav1.UpdateOptions{})
 	return errors.Wrapf(err, "error updating status of fleet %s", fCopy.ObjectMeta.Name)
 }
@@ -758,6 +793,63 @@ func (c *Controller) filterGameServerSetByActive(fleet *agonesv1.Fleet, list []*
 	}
 
 	return active, rest
+}
+
+func (c *Controller) getAllocations(ns, fleetName string) (allocs int64) {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+
+	c.allocsMu.Lock()
+	defer c.allocsMu.Unlock()
+
+	allocs, c.allocs[key] = c.allocs[key], 0
+	return allocs
+}
+
+func (c *Controller) incAllocations(ns, fleetName string) {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+
+	c.allocsMu.Lock()
+	defer c.allocsMu.Unlock()
+
+	count, ok := c.allocs[key]
+	if !ok {
+		c.allocs[key] = 1
+		return
+	}
+	c.allocs[key] = count + 1
+}
+
+func (c *Controller) removeAllocations(ns, fleetName string) {
+	key := cache.ObjectName{Namespace: ns, Name: fleetName}.String()
+
+	c.allocsMu.Lock()
+	defer c.allocsMu.Unlock()
+
+	delete(c.allocs, key)
+}
+
+func (c *Controller) flushAllocations() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	c.allocsMu.Lock()
+	defer c.allocsMu.Unlock()
+
+	for fleet, allocs := range c.allocs {
+		if allocs == 0 {
+			continue
+		}
+
+		ns, name, _ := cache.SplitMetaNamespaceKey(fleet)
+		fCopy, err := c.fleetGetter.Fleets(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			continue
+		}
+
+		fCopy.Status.Allocations += allocs
+
+		_, _ = c.fleetGetter.Fleets(ns).UpdateStatus(ctx, fCopy, metav1.UpdateOptions{})
+	}
 }
 
 // mergeCounters adds the contents of AggregatedCounterStatus c2 into c1.

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -67,6 +67,7 @@ type Extensions struct {
 type Controller struct {
 	baseLogger          *logrus.Entry
 	crdGetter           apiextclientv1.CustomResourceDefinitionInterface
+	gameServerSynced    cache.InformerSynced
 	gameServerSetGetter getterv1.GameServerSetsGetter
 	gameServerSetLister listerv1.GameServerSetLister
 	gameServerSetSynced cache.InformerSynced
@@ -97,6 +98,7 @@ func NewController(
 
 	c := &Controller{
 		crdGetter:           extClient.ApiextensionsV1().CustomResourceDefinitions(),
+		gameServerSynced:    gsInformer.HasSynced,
 		gameServerSetGetter: agonesClient.AgonesV1(),
 		gameServerSetLister: gameServerSets.Lister(),
 		gameServerSetSynced: gsSetInformer.HasSynced,
@@ -253,7 +255,7 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	}
 
 	c.baseLogger.Debug("Wait for cache sync")
-	if !cache.WaitForCacheSync(ctx.Done(), c.gameServerSetSynced, c.fleetSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), c.gameServerSynced, c.gameServerSetSynced, c.fleetSynced) {
 		return errors.New("failed to wait for caches to sync")
 	}
 

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -898,12 +898,13 @@ func (t *allocTracker) forEach(fn func(ns, fleetName string, count int64)) {
 	t.mu.Unlock()
 
 	for key, count := range counts {
-		if count.Load() == 0 {
+		v := count.Load()
+		if v == 0 {
 			continue
 		}
 
 		ns, fleetName, _ := cache.SplitMetaNamespaceKey(key)
-		fn(ns, fleetName, count.Load())
+		fn(ns, fleetName, v)
 	}
 }
 

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -310,6 +310,37 @@ func TestControllerSyncFleet(t *testing.T) {
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
+	t.Run("fleets update allocation counter", func(t *testing.T) {
+		f := defaultFixture()
+		f.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+
+		c, m := newFakeController()
+		gsSet := f.GameServerSet()
+		gsSet.ObjectMeta.Name = "gsSet1"
+		gsSet.ObjectMeta.UID = "4321"
+		gsSet.Spec.Replicas = f.Spec.Replicas
+
+		m.AgonesClient.AddReactor("list", "fleets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &agonesv1.FleetList{Items: []agonesv1.Fleet{*f}}, nil
+		})
+		m.AgonesClient.AddReactor("get", "fleets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, f, nil
+		})
+
+		m.AgonesClient.AddReactor("list", "gameserversets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &agonesv1.GameServerSetList{Items: []agonesv1.GameServerSet{*gsSet}}, nil
+		})
+
+		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.gameServerSetSynced)
+		defer cancel()
+
+		c.incAllocations("default", "fleet-1")
+
+		err := c.syncFleet(ctx, "default/fleet-1")
+		assert.Nil(t, err)
+		assert.Equal(t, int64(1), f.Status.Allocations)
+	})
+
 	t.Run("error on getting fleet", func(t *testing.T) {
 		c, _ := newFakeController()
 		c.fleetLister = &fakeFleetListerWithErr{}

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -334,7 +334,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		ctx, cancel := agtesting.StartInformers(m, c.fleetSynced, c.gameServerSetSynced)
 		defer cancel()
 
-		c.incAllocations("default", "fleet-1")
+		c.allocs.inc("default", "fleet-1", 1)
 
 		err := c.syncFleet(ctx, "default/fleet-1")
 		assert.Nil(t, err)

--- a/pkg/metrics/controller.go
+++ b/pkg/metrics/controller.go
@@ -456,6 +456,9 @@ func (c *Controller) recordGameServerStatusChanges(old, next interface{}) {
 	if newGs.Status.State != oldGs.Status.State {
 		RecordWithTags(context.Background(), []tag.Mutator{tag.Upsert(keyType, string(newGs.Status.State)),
 			tag.Upsert(keyFleetName, fleetName), tag.Upsert(keyNamespace, newGs.GetNamespace())}, gameServerTotalStats.M(1))
+		if newGs.Status.State == agonesv1.GameServerStateAllocated {
+			RecordWithTags(context.Background(), []tag.Mutator{tag.Upsert(keyFleetName, fleetName), tag.Upsert(keyNamespace, newGs.GetNamespace())}, gameServerAllocationsTotalStats.M(1))
+		}
 
 		// Calculate the duration of the current state
 		duration, err := c.calcDuration(oldGs, newGs)

--- a/pkg/metrics/controller_metrics.go
+++ b/pkg/metrics/controller_metrics.go
@@ -33,6 +33,7 @@ const (
 	fleetListsName                          = "fleet_lists"
 	gameServersCountName                    = "gameservers_count"
 	gameServersTotalName                    = "gameservers_total"
+	gameServersAllocationsTotalName         = "gameservers_allocations_total"
 	gameServersPlayerConnectedTotalName     = "gameserver_player_connected_total"
 	gameServersPlayerCapacityTotalName      = "gameserver_player_capacity_total"
 	nodeCountName                           = "nodes_count"
@@ -47,24 +48,25 @@ var (
 	// fleetViews are metric views associated with Fleets
 	fleetViews = append([]string{fleetRolloutPercent, fleetReplicaCountName, gameServersCountName, gameServersTotalName, gameServersPlayerConnectedTotalName, gameServersPlayerCapacityTotalName, gameServerStateDurationName, fleetCountersName, fleetListsName}, fleetAutoscalerViews...)
 
-	stateDurationSeconds           = []float64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384}
-	fleetRolloutPercentStats       = stats.Int64("fleets/rollout_percent", "The current fleet rollout percentage", "1")
-	fleetsReplicasCountStats       = stats.Int64("fleets/replicas_count", "The count of replicas per fleet", "1")
-	fasBufferLimitsCountStats      = stats.Int64("fas/buffer_limits", "The buffer limits of autoscalers", "1")
-	fasBufferSizeStats             = stats.Int64("fas/buffer_size", "The buffer size value of autoscalers", "1")
-	fasCurrentReplicasStats        = stats.Int64("fas/current_replicas_count", "The current replicas cout as seen by autoscalers", "1")
-	fasDesiredReplicasStats        = stats.Int64("fas/desired_replicas_count", "The desired replicas cout as seen by autoscalers", "1")
-	fasAbleToScaleStats            = stats.Int64("fas/able_to_scale", "The fleet autoscaler can access the fleet to scale (0 indicates false, 1 indicates true)", "1")
-	fasLimitedStats                = stats.Int64("fas/limited", "The fleet autoscaler is capped (0 indicates false, 1 indicates true)", "1")
-	fleetCountersStats             = stats.Int64("fleets/counters", "Aggregated Counters counts and capacity across GameServers in the Fleet", "1")
-	fleetListsStats                = stats.Int64("fleets/lists", "Aggregated Lists counts and capacity across GameServers in the Fleet", "1")
-	gameServerCountStats           = stats.Int64("gameservers/count", "The count of gameservers", "1")
-	gameServerTotalStats           = stats.Int64("gameservers/total", "The total of gameservers", "1")
-	gameServerPlayerConnectedTotal = stats.Int64("gameservers/player_connected", "The total number of players connected to gameservers", "1")
-	gameServerPlayerCapacityTotal  = stats.Int64("gameservers/player_capacity", "The available player capacity for gameservers", "1")
-	nodesCountStats                = stats.Int64("nodes/count", "The count of nodes in the cluster", "1")
-	gsPerNodesCountStats           = stats.Int64("gameservers_node/count", "The count of gameservers per node in the cluster", "1")
-	gsStateDurationSec             = stats.Float64("gameservers_state/duration", "The duration of gameservers to be in a particular state", stats.UnitSeconds)
+	stateDurationSeconds            = []float64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384}
+	fleetRolloutPercentStats        = stats.Int64("fleets/rollout_percent", "The current fleet rollout percentage", "1")
+	fleetsReplicasCountStats        = stats.Int64("fleets/replicas_count", "The count of replicas per fleet", "1")
+	fasBufferLimitsCountStats       = stats.Int64("fas/buffer_limits", "The buffer limits of autoscalers", "1")
+	fasBufferSizeStats              = stats.Int64("fas/buffer_size", "The buffer size value of autoscalers", "1")
+	fasCurrentReplicasStats         = stats.Int64("fas/current_replicas_count", "The current replicas cout as seen by autoscalers", "1")
+	fasDesiredReplicasStats         = stats.Int64("fas/desired_replicas_count", "The desired replicas cout as seen by autoscalers", "1")
+	fasAbleToScaleStats             = stats.Int64("fas/able_to_scale", "The fleet autoscaler can access the fleet to scale (0 indicates false, 1 indicates true)", "1")
+	fasLimitedStats                 = stats.Int64("fas/limited", "The fleet autoscaler is capped (0 indicates false, 1 indicates true)", "1")
+	fleetCountersStats              = stats.Int64("fleets/counters", "Aggregated Counters counts and capacity across GameServers in the Fleet", "1")
+	fleetListsStats                 = stats.Int64("fleets/lists", "Aggregated Lists counts and capacity across GameServers in the Fleet", "1")
+	gameServerCountStats            = stats.Int64("gameservers/count", "The count of gameservers", "1")
+	gameServerTotalStats            = stats.Int64("gameservers/total", "The total of gameservers", "1")
+	gameServerAllocationsTotalStats = stats.Int64("gameservers/allocations_total", "The total of gameserver allocations", "1")
+	gameServerPlayerConnectedTotal  = stats.Int64("gameservers/player_connected", "The total number of players connected to gameservers", "1")
+	gameServerPlayerCapacityTotal   = stats.Int64("gameservers/player_capacity", "The available player capacity for gameservers", "1")
+	nodesCountStats                 = stats.Int64("nodes/count", "The count of nodes in the cluster", "1")
+	gsPerNodesCountStats            = stats.Int64("gameservers_node/count", "The count of gameservers per node in the cluster", "1")
+	gsStateDurationSec              = stats.Float64("gameservers_state/duration", "The duration of gameservers to be in a particular state", stats.UnitSeconds)
 
 	stateViews = []*view.View{
 		{
@@ -150,6 +152,13 @@ var (
 			Description: "The total of gameservers",
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{keyType, keyFleetName, keyNamespace},
+		},
+		{
+			Name:        gameServersAllocationsTotalName,
+			Measure:     gameServerAllocationsTotalStats,
+			Description: "The total of gameserver allocations",
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{keyFleetName, keyNamespace},
 		},
 		{
 			Name:        gameServersPlayerConnectedTotalName,

--- a/pkg/metrics/controller_test.go
+++ b/pkg/metrics/controller_test.go
@@ -446,13 +446,10 @@ func TestControllerGameServerAllocationsTotal(t *testing.T) {
 	generateGsEvents(19, agonesv1.GameServerStateAllocated, "", c.gsWatch)
 
 	expected := 34
-	assert.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		list, err := c.gameServerLister.GameServers(gs.ObjectMeta.Namespace).List(labels.Everything())
-		if err != nil || list == nil {
-			return false
-		}
-		require.NoError(t, err)
-		return len(list) == expected
+		require.NoError(ct, err)
+		assert.Len(ct, list, expected)
 	}, 10*time.Second, time.Second)
 	// While these values are tested above, the following test checks will provide a more detailed diff output
 	// in the case where the assert.Eventually(...) case fails, which makes failing tests easier to debug.

--- a/pkg/metrics/controller_test.go
+++ b/pkg/metrics/controller_test.go
@@ -428,6 +428,44 @@ func TestControllerGameServersTotal(t *testing.T) {
 	})
 }
 
+func TestControllerGameServerAllocationsTotal(t *testing.T) {
+	mu.Lock()
+	defer mu.Unlock()
+	resetMetrics()
+	reader := metricexport.NewReader()
+	c := newFakeController()
+	defer c.close()
+	c.run(t)
+
+	// deleted gs should not be counted
+	gs := gameServerWithFleetAndState("deleted", agonesv1.GameServerStateCreating)
+	c.gsWatch.Add(gs)
+	c.gsWatch.Delete(gs)
+
+	generateGsEvents(15, agonesv1.GameServerStateAllocated, "test", c.gsWatch)
+	generateGsEvents(19, agonesv1.GameServerStateAllocated, "", c.gsWatch)
+
+	expected := 34
+	assert.Eventually(t, func() bool {
+		list, err := c.gameServerLister.GameServers(gs.ObjectMeta.Namespace).List(labels.Everything())
+		if err != nil || list == nil {
+			return false
+		}
+		require.NoError(t, err)
+		return len(list) == expected
+	}, 10*time.Second, time.Second)
+	// While these values are tested above, the following test checks will provide a more detailed diff output
+	// in the case where the assert.Eventually(...) case fails, which makes failing tests easier to debug.
+
+	list, err := c.gameServerLister.GameServers(gs.ObjectMeta.Namespace).List(labels.Everything())
+	require.NoError(t, err)
+	require.Len(t, list, expected)
+	assertMetricData(t, c, func() {}, reader, gameServersAllocationsTotalName, []expectedMetricData{
+		{labels: []string{"test", defaultNs}, val: int64(15)},
+		{labels: []string{"none", defaultNs}, val: int64(19)},
+	})
+}
+
 func TestControllerFleetOnDeleting(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -282,13 +282,10 @@ func setupGameServerAllocation(t *testing.T, ctrl *fakeController) {
 	gs.Status.State = agonesv1.GameServerStateAllocated
 	ctrl.gsWatch.Modify(gs)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		gs, err := ctrl.gameServerLister.GameServers(gs.ObjectMeta.Namespace).Get(gs.ObjectMeta.Name)
-		if gs == nil || err != nil {
-			return false
-		}
-		assert.NoError(t, err)
-		return gs.Status.State == agonesv1.GameServerStateAllocated
+		require.NoError(collect, err)
+		assert.Equal(collect, gs.Status.State, agonesv1.GameServerStateAllocated)
 	}, 5*time.Second, time.Second)
 	ctrl.collect()
 }

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -212,6 +212,20 @@ func setupGameServer(t *testing.T, ctrl *fakeController) {
 		return gs.Status.State == agonesv1.GameServerStateCreating
 	}, 5*time.Second, time.Second)
 	ctrl.collect()
+
+	newGs := gs.DeepCopy()
+	newGs.Status.State = agonesv1.GameServerStateAllocated
+	ctrl.gsWatch.Modify(newGs)
+
+	require.Eventually(t, func() bool {
+		gs, err := ctrl.gameServerLister.GameServers(gs.ObjectMeta.Namespace).Get(gs.ObjectMeta.Name)
+		if gs == nil || err != nil {
+			return false
+		}
+		assert.NoError(t, err)
+		return gs.Status.State == agonesv1.GameServerStateAllocated
+	}, 5*time.Second, time.Second)
+	ctrl.collect()
 }
 
 func setupFleet(_ *testing.T, ctrl *fakeController) {

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -100,6 +100,7 @@ func TestMetrics_Endpoint_ExposesAllMetrics(t *testing.T) {
 		setupFleetWithCountersAndLists,
 		setupGameServerPlayerConnect,
 		setupGameServerStateDuration,
+		setupGameServerAllocation,
 	}
 
 	for _, stepFn := range setupSteps {
@@ -212,20 +213,6 @@ func setupGameServer(t *testing.T, ctrl *fakeController) {
 		return gs.Status.State == agonesv1.GameServerStateCreating
 	}, 5*time.Second, time.Second)
 	ctrl.collect()
-
-	newGs := gs.DeepCopy()
-	newGs.Status.State = agonesv1.GameServerStateAllocated
-	ctrl.gsWatch.Modify(newGs)
-
-	require.Eventually(t, func() bool {
-		gs, err := ctrl.gameServerLister.GameServers(gs.ObjectMeta.Namespace).Get(gs.ObjectMeta.Name)
-		if gs == nil || err != nil {
-			return false
-		}
-		assert.NoError(t, err)
-		return gs.Status.State == agonesv1.GameServerStateAllocated
-	}, 5*time.Second, time.Second)
-	ctrl.collect()
 }
 
 func setupFleet(_ *testing.T, ctrl *fakeController) {
@@ -284,6 +271,24 @@ func setupGameServerPlayerConnect(t *testing.T, ctrl *fakeController) {
 		}
 		assert.NoError(t, err)
 		return gs.Status.Players.Count == 1
+	}, 5*time.Second, time.Second)
+	ctrl.collect()
+}
+
+func setupGameServerAllocation(t *testing.T, ctrl *fakeController) {
+	gs := gameServerWithFleetAndState("test-fleet", agonesv1.GameServerStateCreating)
+	ctrl.gsWatch.Add(gs)
+	gs = gs.DeepCopy()
+	gs.Status.State = agonesv1.GameServerStateAllocated
+	ctrl.gsWatch.Modify(gs)
+
+	require.Eventually(t, func() bool {
+		gs, err := ctrl.gameServerLister.GameServers(gs.ObjectMeta.Namespace).Get(gs.ObjectMeta.Name)
+		if gs == nil || err != nil {
+			return false
+		}
+		assert.NoError(t, err)
+		return gs.Status.State == agonesv1.GameServerStateAllocated
 	}, 5*time.Second, time.Second)
 	ctrl.collect()
 }

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -45,6 +45,7 @@ Follow the [Google Cloud Monitoring installation steps](#google-cloud-monitoring
 
 
 
+{{% feature expiryVersion="1.58.0" %}}
 | Name                                                  | Description                                                                                                                                                                                 | Type      |
 |-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | agones_gameservers_count                              | The number of gameservers per fleet and status                                                                                                                                              | gauge     |
@@ -75,7 +76,40 @@ Follow the [Google Cloud Monitoring installation steps](#google-cloud-monitoring
 | agones_k8s_client_workqueue_retries_total             | Total number of items retried to the work queue                                                                                                                                             | counter   |
 | agones_k8s_client_workqueue_longest_running_processor | How long the longest running workqueue processor has been running in microseconds                                                                                                           | gauge     |
 | agones_k8s_client_workqueue_unfinished_work_seconds   | How long unfinished work has been sitting in the workqueue in seconds                                                                                                                       | gauge     |
-
+{{% /feature %}}
+{{% feature publishVersion="1.58.0" %}}
+| Name                                                  | Description                                                                                                                                                                                 | Type      |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| agones_gameservers_count                              | The number of gameservers per fleet and status                                                                                                                                              | gauge     |
+| agones_gameserver_allocations_duration_seconds        | The distribution of gameserver allocation requests latencies                                                                                                                                | histogram |
+| agones_gameserver_allocations_retry_total             | The count of gameserver allocation retry until it succeeds | histogram |
+| agones_gameserver_creation_duration                   | The time gameserver takes to be created in seconds  | histogram | 
+| agones_gameservers_total                              | The total of gameservers per fleet and status                                                                                                                                               | counter   |
+| agones_gameservers_allocations_total                  | The total of gameserver allocations                                                                                                                                                         | counter   |
+| agones_gameserver_player_connected_total              | The total number of players connected to gameservers (Only available when [player tracking]({{< relref "player-tracking.md" >}}) is enabled)                                                | gauge     |
+| agones_gameserver_player_capacity_total               | The available capacity for players on gameservers (Only available when [player tracking]({{< relref "player-tracking.md" >}}) is enabled)                                                   | gauge     |
+| agones_fleets_replicas_count                          | The number of replicas per fleet (total, desired, ready, reserved, allocated)                                                                                                               | gauge     |
+| agones_fleet_counters                                 | Aggregate Metrics for Counters within a Fleet, including total capacity and count values (Only available when [Counters and Lists]({{< relref "counters-and-lists.md" >}})) are enabled)    | gauge     |
+| agones_fleet_lists                                    | Aggregate Metrics for Lists within a Fleet, including total capacity and List lengths (Only available when [Counters and Lists]({{< relref "counters-and-lists.md" >}})) are enabled)       | gauge     |
+| agones_fleet_autoscalers_able_to_scale                | The fleet autoscaler can access the fleet to scale                                                                                                                                          | gauge     |
+| agones_fleet_autoscalers_buffer_limits                | The limits of buffer based fleet autoscalers (min, max)                                                                                                                                     | gauge     |
+| agones_fleet_autoscalers_buffer_size                  | The buffer size of fleet autoscalers (count or percentage)                                                                                                                                  | gauge     |
+| agones_fleet_autoscalers_current_replicas_count       | The current replicas count as seen by autoscalers                                                                                                                                           | gauge     |
+| agones_fleet_autoscalers_desired_replicas_count       | The desired replicas count as seen by autoscalers                                                                                                                                           | gauge     |
+| agones_fleet_autoscalers_limited                      | The fleet autoscaler is outside the limits set by MinReplicas and MaxReplicas.                                                                                                              | gauge     |
+| agones_gameservers_node_count                         | The distribution of gameservers per node                                                                                                                                                    | histogram |
+| agones_nodes_count                                    | The count of nodes empty and with gameservers                                                                                                                                               | gauge     |
+| agones_gameserver_state_duration                      | The distribution of gameserver state duration in seconds. Note: this metric could have some missing samples by design. Do not use the `_total` counter as the real value for state changes. | histogram |
+| agones_k8s_client_http_request_total                  | The total of HTTP requests to the Kubernetes API by status code                                                                                                                             | counter   |
+| agones_k8s_client_http_request_duration_seconds       | The distribution of HTTP requests latencies to the Kubernetes API by status code                                                                                                            | histogram |
+| agones_k8s_client_workqueue_depth                     | Current depth of the work queue                                                                                                                                                             | gauge     |
+| agones_k8s_client_workqueue_latency_seconds           | How long an item stays in the work queue                                                                                                                                                    | histogram |
+| agones_k8s_client_workqueue_items_total               | Total number of items added to the work queue                                                                                                                                               | counter   |
+| agones_k8s_client_workqueue_work_duration_seconds     | How long processing an item from the work queue takes                                                                                                                                       | histogram |
+| agones_k8s_client_workqueue_retries_total             | Total number of items retried to the work queue                                                                                                                                             | counter   |
+| agones_k8s_client_workqueue_longest_running_processor | How long the longest running workqueue processor has been running in microseconds                                                                                                           | gauge     |
+| agones_k8s_client_workqueue_unfinished_work_seconds   | How long unfinished work has been sitting in the workqueue in seconds                                                                                                                       | gauge     |
+{{% /feature %}}
 
 
 ### Dropping Metric Labels

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -45,7 +45,7 @@ Follow the [Google Cloud Monitoring installation steps](#google-cloud-monitoring
 
 
 
-{{% feature expiryVersion="1.58.0" %}}
+{{% feature expiryVersion="1.59.0" %}}
 | Name                                                  | Description                                                                                                                                                                                 | Type      |
 |-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | agones_gameservers_count                              | The number of gameservers per fleet and status                                                                                                                                              | gauge     |
@@ -77,7 +77,7 @@ Follow the [Google Cloud Monitoring installation steps](#google-cloud-monitoring
 | agones_k8s_client_workqueue_longest_running_processor | How long the longest running workqueue processor has been running in microseconds                                                                                                           | gauge     |
 | agones_k8s_client_workqueue_unfinished_work_seconds   | How long unfinished work has been sitting in the workqueue in seconds                                                                                                                       | gauge     |
 {{% /feature %}}
-{{% feature publishVersion="1.58.0" %}}
+{{% feature publishVersion="1.59.0" %}}
 | Name                                                  | Description                                                                                                                                                                                 | Type      |
 |-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | agones_gameservers_count                              | The number of gameservers per fleet and status                                                                                                                                              | gauge     |

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -3,5018 +3,7 @@ title="Agones Kubernetes API"
 description="Detailed list of Agones Custom Resource Definitions available"
 +++
 
-{{% feature expiryVersion="1.57.0" %}}
-<p>Packages:</p>
-<ul>
-<li>
-<a href="#agones.dev%2fv1">agones.dev/v1</a>
-</li>
-<li>
-<a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
-</li>
-<li>
-<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
-</li>
-<li>
-<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
-</li>
-</ul>
-<h2 id="agones.dev/v1">agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#agones.dev/v1.Fleet">Fleet</a>
-</li><li>
-<a href="#agones.dev/v1.GameServer">GameServer</a>
-</li><li>
-<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>
-</li></ul>
-<h3 id="agones.dev/v1.Fleet">Fleet
-</h3>
-<p>
-<p>Fleet is the data structure for a Fleet resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>Fleet</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#agones.dev/v1.FleetSpec">
-FleetSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationOverflow</code><br/>
-<em>
-<a href="#agones.dev/v1.AllocationOverflow">
-AllocationOverflow
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Labels and/or Annotations to apply to overflowing GameServers when the number of Allocated GameServers is more
-than the desired replicas on the underlying <code>GameServerSet</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>strategy</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#deploymentstrategy-v1-apps">
-Kubernetes apps/v1.DeploymentStrategy
-</a>
-</em>
-</td>
-<td>
-<p>Deployment strategy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorities</code><br/>
-<em>
-<a href="#agones.dev/v1.Priority">
-[]Priority
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
-<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
-<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
-infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
-<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
-order of <code>GameServers</code> to delete on scale down.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this Fleet</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#agones.dev/v1.FleetStatus">
-FleetStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServer">GameServer
-</h3>
-<p>
-<p>GameServer is the data structure for a GameServer resource.
-It is worth noting that while there is a <code>GameServerStatus</code> Status entry for the <code>GameServer</code>, it is not
-defined as a subresource - unlike <code>Fleet</code> and other Agones resources.
-This is so that we can retain the ability to change multiple aspects of a <code>GameServer</code> in a single atomic operation,
-which is particularly useful for operations such as allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>GameServer</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerSpec">
-GameServerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Container specifies which Pod container is the game server. Only required if there is more than one
-container defined</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerPort">
-[]GameServerPort
-</a>
-</em>
-</td>
-<td>
-<p>Ports are the array of ports that can be exposed via the game server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>health</code><br/>
-<em>
-<a href="#agones.dev/v1.Health">
-Health
-</a>
-</em>
-</td>
-<td>
-<p>Health configures health checking</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sdkServer</code><br/>
-<em>
-<a href="#agones.dev/v1.SdkServer">
-SdkServer
-</a>
-</em>
-</td>
-<td>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the Pod that will be created for the GameServer</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#agones.dev/v1.PlayersSpec">
-PlayersSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.CounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
-Keys must be declared at GameServer creation time.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.ListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
-Keys must be declared at GameServer creation time.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eviction</code><br/>
-<em>
-<a href="#agones.dev/v1.Eviction">
-Eviction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerStatus">
-GameServerStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSet">GameServerSet
-</h3>
-<p>
-<p>GameServerSet is the data structure for a set of GameServers.
-This matches philosophically with the relationship between
-Deployments and ReplicaSets</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>GameServerSet</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerSetSpec">
-GameServerSetSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationOverflow</code><br/>
-<em>
-<a href="#agones.dev/v1.AllocationOverflow">
-AllocationOverflow
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Labels and Annotations to apply to GameServers when the number of Allocated GameServers drops below
-the desired replicas on the underlying <code>GameServerSet</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorities</code><br/>
-<em>
-<a href="#agones.dev/v1.Priority">
-[]Priority
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
-<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
-<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
-infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
-<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
-order of <code>GameServers</code> to delete on scale down.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this GameServerSet</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerSetStatus">
-GameServerSetStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.AggregatedCounterStatus">AggregatedCounterStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
-<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
-</p>
-<p>
-<p>AggregatedCounterStatus stores total and allocated Counter tracking values</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>allocatedCount</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocatedCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>count</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.AggregatedListStatus">AggregatedListStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
-<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
-</p>
-<p>
-<p>AggregatedListStatus stores total and allocated List tracking values</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>allocatedCount</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocatedCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>count</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.AggregatedPlayerStatus">AggregatedPlayerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
-<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
-</p>
-<p>
-<p>AggregatedPlayerStatus stores total player tracking values</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>count</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.AllocationOverflow">AllocationOverflow
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
-<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
-</p>
-<p>
-<p>AllocationOverflow specifies what labels and/or annotations to apply on Allocated GameServers
-if the desired number of the underlying <code>GameServerSet</code> drops below the number of Allocated GameServers
-attached to it.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>labels</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Labels to be applied to the <code>GameServer</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Annotations to be applied to the <code>GameServer</code></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.CounterStatus">CounterStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
-</p>
-<p>
-<p>CounterStatus stores the current counter values and maximum capacity</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>count</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.Eviction">Eviction
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
-</p>
-<p>
-<p>Eviction specifies the eviction tolerance of the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>safe</code><br/>
-<em>
-<a href="#agones.dev/v1.EvictionSafe">
-EvictionSafe
-</a>
-</em>
-</td>
-<td>
-<p>Game server supports termination via SIGTERM:
-- Always: Allow eviction for both Cluster Autoscaler and node drain for upgrades
-- OnUpgrade: Allow eviction for upgrades alone
-- Never (default): Pod should run to completion</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.EvictionSafe">EvictionSafe
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.Eviction">Eviction</a>)
-</p>
-<p>
-<p>EvictionSafe specified whether the game server supports termination via SIGTERM</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Always&#34;</p></td>
-<td><p>EvictionSafeAlways means the game server supports termination via SIGTERM, and wants eviction signals
-from Cluster Autoscaler scaledown and node upgrades.</p>
-</td>
-</tr><tr><td><p>&#34;Never&#34;</p></td>
-<td><p>EvictionSafeNever means the game server should run to completion and may not understand SIGTERM. Eviction
-from ClusterAutoscaler and upgrades should both be blocked.</p>
-</td>
-</tr><tr><td><p>&#34;OnUpgrade&#34;</p></td>
-<td><p>EvictionSafeOnUpgrade means the game server supports termination via SIGTERM, and wants eviction signals
-from node upgrades, but not Cluster Autoscaler scaledown.</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="agones.dev/v1.FleetSpec">FleetSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.Fleet">Fleet</a>)
-</p>
-<p>
-<p>FleetSpec is the spec for a Fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationOverflow</code><br/>
-<em>
-<a href="#agones.dev/v1.AllocationOverflow">
-AllocationOverflow
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Labels and/or Annotations to apply to overflowing GameServers when the number of Allocated GameServers is more
-than the desired replicas on the underlying <code>GameServerSet</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>strategy</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#deploymentstrategy-v1-apps">
-Kubernetes apps/v1.DeploymentStrategy
-</a>
-</em>
-</td>
-<td>
-<p>Deployment strategy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorities</code><br/>
-<em>
-<a href="#agones.dev/v1.Priority">
-[]Priority
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
-<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
-<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
-infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
-<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
-order of <code>GameServers</code> to delete on scale down.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this Fleet</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.FleetStatus">FleetStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.Fleet">Fleet</a>, 
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
-</p>
-<p>
-<p>FleetStatus is the status of a Fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas the total number of current GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readyReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReadyReplicas are the number of Ready GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reservedReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
-Reserved instances won&rsquo;t be deleted on scale down, but won&rsquo;t cause an autoscaler to scale up.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocatedReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#agones.dev/v1.AggregatedPlayerStatus">
-AggregatedPlayerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerTracking]
-Players are the current total player capacity and count for this Fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.AggregatedCounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedCounterStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Counters provides aggregated Counter capacity and Counter
-count for this Fleet.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.AggregatedListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedListStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Lists provides aggregated List capacityv and List values
-for this Fleet.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerPort">GameServerPort
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>GameServerPort defines a set of Ports that
-are to be exposed via the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the descriptive name of the port</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>range</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PortRanges feature flag) Range is the port range name from which to select a port when using a
-&lsquo;Dynamic&rsquo; or &lsquo;Passthrough&rsquo; port policy.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>portPolicy</code><br/>
-<em>
-<a href="#agones.dev/v1.PortPolicy">
-PortPolicy
-</a>
-</em>
-</td>
-<td>
-<p>PortPolicy defines the policy for how the HostPort is populated.
-Dynamic port will allocate a HostPort within the selected MIN_PORT and MAX_PORT range passed to the controller
-at installation time.
-When <code>Static</code> portPolicy is specified, <code>HostPort</code> is required, to specify the port that game clients will
-connect to
-<code>Passthrough</code> dynamically sets the <code>containerPort</code> to the same value as the dynamically selected hostPort.
-<code>None</code> portPolicy ignores <code>HostPort</code> and the <code>containerPort</code> (optional) is used to set the port on the GameServer instance.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Container is the name of the container or sidecar container on which to open the port. Defaults to the game server container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>containerPort</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ContainerPort is the port that is being opened on the specified container&rsquo;s process</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>hostPort</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>HostPort the port exposed on the host for clients to connect to</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>protocol</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#protocol-v1-core">
-Kubernetes core/v1.Protocol
-</a>
-</em>
-</td>
-<td>
-<p>Protocol is the network protocol being used. Defaults to UDP. TCP and TCPUDP are other options.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSetSpec">GameServerSetSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
-</p>
-<p>
-<p>GameServerSetSpec the specification for GameServerSet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas are the number of GameServers that should be in this set</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationOverflow</code><br/>
-<em>
-<a href="#agones.dev/v1.AllocationOverflow">
-AllocationOverflow
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Labels and Annotations to apply to GameServers when the number of Allocated GameServers drops below
-the desired replicas on the underlying <code>GameServerSet</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorities</code><br/>
-<em>
-<a href="#agones.dev/v1.Priority">
-[]Priority
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
-<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
-<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
-infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
-<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
-order of <code>GameServers</code> to delete on scale down.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerTemplateSpec">
-GameServerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template the GameServer template to apply for this GameServerSet</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSetStatus">GameServerSetStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
-</p>
-<p>
-<p>GameServerSetStatus is the status of a GameServerSet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Replicas is the total number of current GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readyReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReadyReplicas is the number of Ready GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reservedReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ReservedReplicas is the number of Reserved GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocatedReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>AllocatedReplicas is the number of Allocated GameServer replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>shutdownReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ShutdownReplicas is the number of Shutdown GameServers replicas</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#agones.dev/v1.AggregatedPlayerStatus">
-AggregatedPlayerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerTracking]
-Players is the current total player capacity and count for this GameServerSet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.AggregatedCounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedCounterStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Counters provides aggregated Counter capacity and Counter
-count for this GameServerSet.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.AggregatedListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedListStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Lists provides aggregated List capacity and List values
-for this GameServerSet.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerSpec">GameServerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServer">GameServer</a>, 
-<a href="#agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec</a>)
-</p>
-<p>
-<p>GameServerSpec is the spec for a GameServer resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Container specifies which Pod container is the game server. Only required if there is more than one
-container defined</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerPort">
-[]GameServerPort
-</a>
-</em>
-</td>
-<td>
-<p>Ports are the array of ports that can be exposed via the game server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>health</code><br/>
-<em>
-<a href="#agones.dev/v1.Health">
-Health
-</a>
-</em>
-</td>
-<td>
-<p>Health configures health checking</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sdkServer</code><br/>
-<em>
-<a href="#agones.dev/v1.SdkServer">
-SdkServer
-</a>
-</em>
-</td>
-<td>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the Pod that will be created for the GameServer</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#agones.dev/v1.PlayersSpec">
-PlayersSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.CounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
-Keys must be declared at GameServer creation time.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.ListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
-Keys must be declared at GameServer creation time.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eviction</code><br/>
-<em>
-<a href="#agones.dev/v1.Eviction">
-Eviction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerState">GameServerState
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
-<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
-</p>
-<p>
-<p>GameServerState is the state for the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Allocated&#34;</p></td>
-<td><p>GameServerStateAllocated is when the GameServer has been allocated to a session</p>
-</td>
-</tr><tr><td><p>&#34;Creating&#34;</p></td>
-<td><p>GameServerStateCreating is before the Pod for the GameServer is being created</p>
-</td>
-</tr><tr><td><p>&#34;Error&#34;</p></td>
-<td><p>GameServerStateError is when something has gone wrong with the Gameserver and
-it cannot be resolved</p>
-</td>
-</tr><tr><td><p>&#34;PortAllocation&#34;</p></td>
-<td><p>GameServerStatePortAllocation is for when a dynamically allocating GameServer
-is being created, an open port needs to be allocated</p>
-</td>
-</tr><tr><td><p>&#34;Ready&#34;</p></td>
-<td><p>GameServerStateReady is when a GameServer is ready to take connections
-from Game clients</p>
-</td>
-</tr><tr><td><p>&#34;RequestReady&#34;</p></td>
-<td><p>GameServerStateRequestReady is when the GameServer has declared that it is ready</p>
-</td>
-</tr><tr><td><p>&#34;Reserved&#34;</p></td>
-<td><p>GameServerStateReserved is for when a GameServer is reserved and therefore can be allocated but not removed</p>
-</td>
-</tr><tr><td><p>&#34;Scheduled&#34;</p></td>
-<td><p>GameServerStateScheduled is for when we have determined that the Pod has been
-scheduled in the cluster &ndash; basically, we have a NodeName</p>
-</td>
-</tr><tr><td><p>&#34;Shutdown&#34;</p></td>
-<td><p>GameServerStateShutdown is when the GameServer has shutdown and everything needs to be
-deleted from the cluster</p>
-</td>
-</tr><tr><td><p>&#34;Starting&#34;</p></td>
-<td><p>GameServerStateStarting is for when the Pods for the GameServer are being
-created but are not yet Scheduled</p>
-</td>
-</tr><tr><td><p>&#34;Unhealthy&#34;</p></td>
-<td><p>GameServerStateUnhealthy is when the GameServer has failed its health checks</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerStatus">GameServerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServer">GameServer</a>)
-</p>
-<p>
-<p>GameServerStatus is the status for a GameServer resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>state</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerState">
-GameServerState
-</a>
-</em>
-</td>
-<td>
-<p>GameServerState is the current state of a GameServer, e.g. Creating, Starting, Ready, etc</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerStatusPort">
-[]GameServerStatusPort
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>addresses</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#nodeaddress-v1-core">
-[]Kubernetes core/v1.NodeAddress
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Addresses is the array of addresses at which the GameServer can be reached; copy of Node.Status.addresses.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>reservedUntil</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#agones.dev/v1.PlayerStatus">
-PlayerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerTracking]</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.CounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Counters and Lists provides the configuration for generic tracking features.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.ListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>eviction</code><br/>
-<em>
-<a href="#agones.dev/v1.Eviction">
-Eviction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Eviction specifies the eviction tolerance of the GameServer.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerStatusPort">GameServerStatusPort
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
-</p>
-<p>
-<p>GameServerStatusPort shows the port that was allocated to a
-GameServer.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>port</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
-<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
-</p>
-<p>
-<p>GameServerTemplateSpec is a template for GameServers</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerSpec">
-GameServerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Container specifies which Pod container is the game server. Only required if there is more than one
-container defined</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerPort">
-[]GameServerPort
-</a>
-</em>
-</td>
-<td>
-<p>Ports are the array of ports that can be exposed via the game server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>health</code><br/>
-<em>
-<a href="#agones.dev/v1.Health">
-Health
-</a>
-</em>
-</td>
-<td>
-<p>Health configures health checking</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sdkServer</code><br/>
-<em>
-<a href="#agones.dev/v1.SdkServer">
-SdkServer
-</a>
-</em>
-</td>
-<td>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the Pod that will be created for the GameServer</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#agones.dev/v1.PlayersSpec">
-PlayersSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.CounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
-Keys must be declared at GameServer creation time.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.ListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
-Keys must be declared at GameServer creation time.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eviction</code><br/>
-<em>
-<a href="#agones.dev/v1.Eviction">
-Eviction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.Health">Health
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>Health configures health checking on the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>disabled</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Disabled is whether health checking is disabled or not</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>periodSeconds</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>PeriodSeconds is the number of seconds each health ping has to occur in</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>failureThreshold</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>FailureThreshold how many failures in a row constitutes unhealthy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>initialDelaySeconds</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>InitialDelaySeconds initial delay before checking health</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.ListStatus">ListStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
-</p>
-<p>
-<p>ListStatus stores the current list values and maximum capacity</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>values</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.PlayerStatus">PlayerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
-</p>
-<p>
-<p>PlayerStatus stores the current player capacity values</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>count</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>ids</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.PlayersSpec">PlayersSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>PlayersSpec tracks the initial player capacity</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>initialCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.PortPolicy">PortPolicy
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerPort">GameServerPort</a>)
-</p>
-<p>
-<p>PortPolicy is the port policy for the GameServer</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Dynamic&#34;</p></td>
-<td><p>Dynamic PortPolicy means that the system will choose an open
-port for the GameServer in question</p>
-</td>
-</tr><tr><td><p>&#34;None&#34;</p></td>
-<td><p>None means the <code>hostPort</code> is ignored and if defined, the <code>containerPort</code> (optional) is used to set the port on the GameServer instance.</p>
-</td>
-</tr><tr><td><p>&#34;Passthrough&#34;</p></td>
-<td><p>Passthrough dynamically sets the <code>containerPort</code> to the same value as the dynamically selected hostPort.
-This will mean that users will need to lookup what port has been opened through the server side SDK.</p>
-</td>
-</tr><tr><td><p>&#34;Static&#34;</p></td>
-<td><p>Static PortPolicy means that the user defines the hostPort to be used
-in the configuration.</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="agones.dev/v1.Priority">Priority
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
-<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>, 
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>Priority is a sorting option for GameServers with Counters or Lists based on the available capacity,
-i.e. the current Capacity value, minus either the Count value or List length.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Type: Sort by a &ldquo;Counter&rdquo; or a &ldquo;List&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>key</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Key: The name of the Counter or List. If not found on the GameServer, has no impact.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>order</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Order: Sort by &ldquo;Ascending&rdquo; or &ldquo;Descending&rdquo;. &ldquo;Descending&rdquo; a bigger available capacity is preferred.
-&ldquo;Ascending&rdquo; would be smaller available capacity is preferred.
-The default sort order is &ldquo;Ascending&rdquo;</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.SdkServer">SdkServer
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
-</p>
-<p>
-<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>logLevel</code><br/>
-<em>
-<a href="#agones.dev/v1.SdkServerLogLevel">
-SdkServerLogLevel
-</a>
-</em>
-</td>
-<td>
-<p>LogLevel for SDK server (sidecar) logs. Defaults to &ldquo;Info&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>grpcPort</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>GRPCPort is the port on which the SDK Server binds the gRPC server to accept incoming connections</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>httpPort</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>HTTPPort is the port on which the SDK Server binds the HTTP gRPC gateway server to accept incoming connections</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="agones.dev/v1.SdkServerLogLevel">SdkServerLogLevel
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#agones.dev/v1.SdkServer">SdkServer</a>)
-</p>
-<p>
-<p>SdkServerLogLevel is the log level for SDK server (sidecar) logs</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Debug&#34;</p></td>
-<td><p>SdkServerLogLevelDebug will cause the SDK server to output all messages including debug messages.</p>
-</td>
-</tr><tr><td><p>&#34;Error&#34;</p></td>
-<td><p>SdkServerLogLevelError will cause the SDK server to only output error messages.</p>
-</td>
-</tr><tr><td><p>&#34;Info&#34;</p></td>
-<td><p>SdkServerLogLevelInfo will cause the SDK server to output all messages except for debug messages.</p>
-</td>
-</tr><tr><td><p>&#34;Trace&#34;</p></td>
-<td><p>SdkServerLogLevelTrace will cause the SDK server to output all messages, including detailed tracing information.</p>
-</td>
-</tr></tbody>
-</table>
-<hr/>
-<h2 id="allocation.agones.dev/v1">allocation.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>
-</li></ul>
-<h3 id="allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation
-</h3>
-<p>
-<p>GameServerAllocation is the data structure for allocating against a set of
-GameServers, defined <code>selectors</code> selectors</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-allocation.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>GameServerAllocation</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">
-GameServerAllocationSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>multiClusterSetting</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.MultiClusterSetting">
-MultiClusterSetting
-</a>
-</em>
-</td>
-<td>
-<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
-Otherwise, allocation will happen locally.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>required</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">
-GameServerSelector
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
-Required is the GameServer selector from which to choose GameServers from.
-Defaults to all GameServers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>preferred</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">
-[]GameServerSelector
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
-Preferred is an ordered list of preferred GameServer selectors
-that are optional to be fulfilled, but will be searched before the <code>required</code> selector.
-If the first selector is not matched, the selection attempts the second selector, and so on.
-If any of the preferred selectors are matched, the required selector is not considered.
-This is useful for things like smoke testing of new game servers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorities</code><br/>
-<em>
-<a href="#agones.dev/v1.Priority">
-[]Priority
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-<code>Priorities</code> configuration alters the order in which <code>GameServers</code> are searched for matches to the configured <code>selectors</code>.</p>
-<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
-<p>For <code>Packed</code> strategy sorting, this priority list will be the tie-breaker within the least utilised infrastructure, to ensure optimal
-infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
-<p>For <code>Distributed</code> strategy sorting, the entire selection of <code>GameServers</code> will be sorted by this priority list to provide the
-order that <code>GameServers</code> will be allocated by.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selectors</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">
-[]GameServerSelector
-</a>
-</em>
-</td>
-<td>
-<p>Ordered list of GameServer label selectors.
-If the first selector is not matched, the selection attempts the second selector, and so on.
-This is useful for things like smoke testing of new game servers.
-Note: This field can only be set if neither Required or Preferred is set.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.MetaPatch">
-MetaPatch
-</a>
-</em>
-</td>
-<td>
-<p>MetaPatch is optional custom metadata that is added to the game server at allocation
-You can use this to tell the server necessary session data</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.CounterAction">
-map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterAction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-Counter actions to perform during allocation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.ListAction">
-map[string]agones.dev/agones/pkg/apis/allocation/v1.ListAction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-List actions to perform during allocation.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">
-GameServerAllocationStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.CounterAction">CounterAction
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>CounterAction is an optional action that can be performed on a Counter at allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>action</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Action must to either &ldquo;Increment&rdquo; or &ldquo;Decrement&rdquo; the Counter&rsquo;s Count. Must also define the Amount.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>amount</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Amount is the amount to increment or decrement the Count. Must be a positive integer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Capacity is the amount to update the maximum capacity of the Counter to this number. Min 0, Max int64.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.CounterSelector">CounterSelector
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
-</p>
-<p>
-<p>CounterSelector is the filter options for a GameServer based on the count and/or available capacity.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>minCount</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MinCount is the minimum current value. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxCount</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MaxCount is the maximum current value. Defaults to 0, which translates as max(in64).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minAvailable</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MinAvailable specifies the minimum capacity (current capacity - current count) available on a GameServer. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxAvailable</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MaxAvailable specifies the maximum capacity (current capacity - current count) available on a GameServer. Defaults to 0, which translates to max(int64).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
-</p>
-<p>
-<p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>multiClusterSetting</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.MultiClusterSetting">
-MultiClusterSetting
-</a>
-</em>
-</td>
-<td>
-<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
-Otherwise, allocation will happen locally.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>required</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">
-GameServerSelector
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
-Required is the GameServer selector from which to choose GameServers from.
-Defaults to all GameServers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>preferred</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">
-[]GameServerSelector
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
-Preferred is an ordered list of preferred GameServer selectors
-that are optional to be fulfilled, but will be searched before the <code>required</code> selector.
-If the first selector is not matched, the selection attempts the second selector, and so on.
-If any of the preferred selectors are matched, the required selector is not considered.
-This is useful for things like smoke testing of new game servers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorities</code><br/>
-<em>
-<a href="#agones.dev/v1.Priority">
-[]Priority
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-<code>Priorities</code> configuration alters the order in which <code>GameServers</code> are searched for matches to the configured <code>selectors</code>.</p>
-<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
-<p>For <code>Packed</code> strategy sorting, this priority list will be the tie-breaker within the least utilised infrastructure, to ensure optimal
-infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
-<p>For <code>Distributed</code> strategy sorting, the entire selection of <code>GameServers</code> will be sorted by this priority list to provide the
-order that <code>GameServers</code> will be allocated by.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selectors</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">
-[]GameServerSelector
-</a>
-</em>
-</td>
-<td>
-<p>Ordered list of GameServer label selectors.
-If the first selector is not matched, the selection attempts the second selector, and so on.
-This is useful for things like smoke testing of new game servers.
-Note: This field can only be set if neither Required or Preferred is set.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scheduling</code><br/>
-<em>
-agones.dev/agones/pkg/apis.SchedulingStrategy
-</em>
-</td>
-<td>
-<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.MetaPatch">
-MetaPatch
-</a>
-</em>
-</td>
-<td>
-<p>MetaPatch is optional custom metadata that is added to the game server at allocation
-You can use this to tell the server necessary session data</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.CounterAction">
-map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterAction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-Counter actions to perform during allocation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.ListAction">
-map[string]agones.dev/agones/pkg/apis/allocation/v1.ListAction
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-List actions to perform during allocation.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerAllocationState">GameServerAllocationState
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
-</p>
-<p>
-<p>GameServerAllocationState is the Allocation state</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Allocated&#34;</p></td>
-<td><p>GameServerAllocationAllocated is allocation successful</p>
-</td>
-</tr><tr><td><p>&#34;Contention&#34;</p></td>
-<td><p>GameServerAllocationContention when the allocation is unsuccessful
-because of contention</p>
-</td>
-</tr><tr><td><p>&#34;UnAllocated&#34;</p></td>
-<td><p>GameServerAllocationUnAllocated when the allocation is unsuccessful</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
-</p>
-<p>
-<p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>state</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationState">
-GameServerAllocationState
-</a>
-</em>
-</td>
-<td>
-<p>GameServerState is the current state of an GameServerAllocation, e.g. Allocated, or UnAllocated</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>gameServerName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerStatusPort">
-[]GameServerStatusPort
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>addresses</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#nodeaddress-v1-core">
-[]Kubernetes core/v1.NodeAddress
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>nodeName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>If the allocation is from a remote cluster, Source is the endpoint of the remote agones-allocator.
-Otherwise, Source is &ldquo;local&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.GameServerMetadata">
-GameServerMetadata
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#agones.dev/v1.CounterStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#agones.dev/v1.ListStatus">
-map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerMetadata">GameServerMetadata
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
-</p>
-<p>
-<p>GameServerMetadata is the metadata from the allocated game server at allocation time</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>labels</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.GameServerSelector">GameServerSelector
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>GameServerSelector contains all the filter options for selecting
-a GameServer for allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>LabelSelector</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>LabelSelector</code> are embedded into this type.)
-</p>
-<p>See: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>gameServerState</code><br/>
-<em>
-<a href="#agones.dev/v1.GameServerState">
-GameServerState
-</a>
-</em>
-</td>
-<td>
-<p>GameServerState specifies which State is the filter to be used when attempting to retrieve a GameServer
-via Allocation. Defaults to &ldquo;Ready&rdquo;. The only other option is &ldquo;Allocated&rdquo;, which can be used in conjunction with
-label/annotation/player selectors to retrieve an already Allocated GameServer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>players</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.PlayerSelector">
-PlayerSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Alpha]
-[FeatureFlag:PlayerAllocationFilter]
-Players provides a filter on minimum and maximum values for player capacity when retrieving a GameServer
-through Allocation. Defaults to no limits.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counters</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.CounterSelector">
-map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-Counters provides filters on minimum and maximum values
-for a Counter&rsquo;s count and available capacity when retrieving a GameServer through Allocation.
-Defaults to no limits.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lists</code><br/>
-<em>
-<a href="#allocation.agones.dev/v1.ListSelector">
-map[string]agones.dev/agones/pkg/apis/allocation/v1.ListSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage: Beta]
-[FeatureFlag:CountsAndLists]
-Lists provides filters on minimum and maximum values
-for List capacity, and for the existence of a value in a List, when retrieving a GameServer
-through Allocation. Defaults to no limits.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.ListAction">ListAction
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>ListAction is an optional action that can be performed on a List at allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>addValues</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>AddValues appends values to a List&rsquo;s Values array. Any duplicate values will be ignored.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deleteValues</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeleteValues removes values from a List&rsquo;s Values array. Any nonexistant values will be ignored.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>capacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Capacity updates the maximum capacity of the Counter to this number. Min 0, Max 1000.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.ListSelector">ListSelector
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
-</p>
-<p>
-<p>ListSelector is the filter options for a GameServer based on List available capacity and/or the
-existence of a value in a List.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>containsValue</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ContainsValue says to only match GameServers who has this value in the list. Defaults to &ldquo;&rdquo;, which is all.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minAvailable</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MinAvailable specifies the minimum capacity (current capacity - current count) available on a GameServer. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxAvailable</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MaxAvailable specifies the maximum capacity (current capacity - current count) available on a GameServer. Defaults to 0, which is translated as max(int64).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.MetaPatch">MetaPatch
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>labels</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.MultiClusterSetting">MultiClusterSetting
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
-</p>
-<p>
-<p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>enabled</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policySelector</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="allocation.agones.dev/v1.PlayerSelector">PlayerSelector
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
-</p>
-<p>
-<p>PlayerSelector is the filter options for a GameServer based on player counts</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>minAvailable</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxAvailable</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
-</li></ul>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
-</h3>
-<p>
-<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-autoscaling.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>FleetAutoscaler</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
-FleetAutoscalerSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>fleetName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Autoscaling policy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sync</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
-FleetAutoscalerSync
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sync defines when FleetAutoscalers runs autoscaling</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
-FleetAutoscalerStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.ActivePeriod">ActivePeriod
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
-</p>
-<p>
-<p>ActivePeriod defines the time period that the policy is applied.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>timezone</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Timezone to be used for the startCron field. If not set, startCron is defaulted to the UTC timezone.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startCron</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>StartCron defines when the policy should be applied.
-If not set, the policy is always to be applied within the start and end time.
-This field must conform to UNIX cron syntax.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>duration</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Duration is the length of time that the policy is applied.
-If not set, the duration is indefinite.
-A duration string is a possibly signed sequence of decimal numbers,
-(e.g. &ldquo;300ms&rdquo;, &ldquo;-1.5h&rdquo; or &ldquo;2h45m&rdquo;).
-The representation limits the largest representable duration to approximately 290 years.
-Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.Between">Between
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
-</p>
-<p>
-<p>Between defines the time period that the policy is eligible to be applied.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>start</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>Start is the datetime that the policy is eligible to be applied.
-This field must conform to RFC3339 format. If this field not set or is in the past, the policy is eligible to be applied
-as soon as the fleet autoscaler is running.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>end</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>End is the datetime that the policy is no longer eligible to be applied.
-This field must conform to RFC3339 format. If not set, the policy is always eligible to be applied, after the start time above.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>maxReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
-It must be bigger than both MinReplicas and BufferSize</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>MinReplicas is the minimum amount of replicas that the fleet must have
-If zero, it is ignored.
-If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code><br/>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
-Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
-Absolute number is calculated from percentage by rounding up.
-Example: when this is set to 20%, the autoscaler will make sure that 20%
-of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
-the autoscaler will make sure that there are 20 available game servers
-Must be bigger than 0
-Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
-and computation stability in different edge case (fleet just created, not enough
-capacity in the cluster etc)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.ChainEntry">ChainEntry
-</h3>
-<p>
-<p>ChainEntry defines a single entry in the ChainPolicy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>id</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ID is the unique identifier for a ChainEntry. If not set the identifier will be set to the index of chain entry.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>FleetAutoscalerPolicy</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>FleetAutoscalerPolicy</code> are embedded into this type.)
-</p>
-<p>Policy is the name of the policy to be applied. Required field.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.ChainPolicy">ChainPolicy
-(<code>[]agones.dev/agones/pkg/apis/autoscaling/v1.ChainEntry</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>ChainPolicy controls the desired behavior of the Chain autoscaler policy.</p>
-</p>
-<h3 id="autoscaling.agones.dev/v1.CounterPolicy">CounterPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>CounterPolicy controls the desired behavior of the Counter autoscaler policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>key</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Key is the name of the Counter. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MaxCapacity is the maximum aggregate Counter total capacity across the fleet.
-MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MinCapacity is the minimum aggregate Counter total capacity across the fleet.
-If zero, MinCapacity is ignored.
-If non zero, MinCapacity must be smaller than MaxCapacity and bigger than BufferSize.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code><br/>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize is the size of a buffer of counted items that are available in the Fleet (available
-capacity). Value can be an absolute number (ex: 5) or a percentage of desired gs instances
-(ex: 5%). An absolute number is calculated from percentage by rounding up.
-Must be bigger than 0. Required field.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FixedIntervalSync">FixedIntervalSync
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
-</p>
-<p>
-<p>FixedIntervalSync controls the desired behavior of the fixed interval based sync.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>seconds</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>Seconds defines how often we run fleet autoscaling in seconds</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
-</p>
-<p>
-<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code><br/>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
-otherwise identical (parallel requests, requests when earlier requests did not modify etc)
-The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
-It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the Fleet being scaled</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Namespace is the namespace associated with the request (if any).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#agones.dev/v1.FleetStatus">
-FleetStatus
-</a>
-</em>
-</td>
-<td>
-<p>The Fleet&rsquo;s status values</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>labels</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>Standard map labels; More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels</a>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>Standard map annotations; More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations">https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations</a>.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
-</p>
-<p>
-<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code><br/>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<p>UID is an identifier for the individual request/response.
-This should be copied over from the corresponding FleetAutoscaleRequest.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scale</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Set to false if no scaling should occur to the Fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>The targeted replica count</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
-</h3>
-<p>
-<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
-and then returned with a populated Response.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>request</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
-FleetAutoscaleRequest
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>response</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
-FleetAutoscaleResponse
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.ChainEntry">ChainEntry</a>, 
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>, 
-<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
-</p>
-<p>
-<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
-FleetAutoscalerPolicyType
-</a>
-</em>
-</td>
-<td>
-<p>Type of autoscaling policy.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>buffer</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.BufferPolicy">
-BufferPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>webhook</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.URLConfiguration">
-URLConfiguration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>counter</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.CounterPolicy">
-CounterPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Beta]
-[FeatureFlag:CountsAndLists]
-Counter policy config params. Present only if FleetAutoscalerPolicyType = Counter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>list</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.ListPolicy">
-ListPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Beta]
-[FeatureFlag:CountsAndLists]
-List policy config params. Present only if FleetAutoscalerPolicyType = List.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.SchedulePolicy">
-SchedulePolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Beta]
-[FeatureFlag:ScheduledAutoscaler]
-Schedule policy config params. Present only if FleetAutoscalerPolicyType = Schedule.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>chain</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.ChainPolicy">
-ChainPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>[Stage:Beta]
-[FeatureFlag:ScheduledAutoscaler]
-Chain policy config params. Present only if FleetAutoscalerPolicyType = Chain.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>wasm</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.WasmPolicy">
-WasmPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Wasm policy config params. Present only if FleetAutoscalerPolicyType = Wasm.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>, 
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus</a>)
-</p>
-<p>
-<p>FleetAutoscalerPolicyType is the policy for autoscaling
-for a given Fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Buffer&#34;</p></td>
-<td><p>BufferPolicyType FleetAutoscalerPolicyType is a simple buffering strategy for Ready
-GameServers</p>
-</td>
-</tr><tr><td><p>&#34;Chain&#34;</p></td>
-<td><p>[Stage:Beta]
-[FeatureFlag:ScheduledAutoscaler]
-ChainPolicyType is for Chain based fleet autoscaling
-nolint:revive // Linter contains comment doesn&rsquo;t start with ChainPolicyType</p>
-</td>
-</tr><tr><td><p>&#34;Counter&#34;</p></td>
-<td><p>[Stage:Beta]
-[FeatureFlag:CountsAndLists]
-CounterPolicyType is for Counter based fleet autoscaling
-nolint:revive // Linter contains comment doesn&rsquo;t start with CounterPolicyType</p>
-</td>
-</tr><tr><td><p>&#34;List&#34;</p></td>
-<td><p>[Stage:Beta]
-[FeatureFlag:CountsAndLists]
-ListPolicyType is for List based fleet autoscaling
-nolint:revive // Linter contains comment doesn&rsquo;t start with ListPolicyType</p>
-</td>
-</tr><tr><td><p>&#34;Schedule&#34;</p></td>
-<td><p>[Stage:Beta]
-[FeatureFlag:ScheduledAutoscaler]
-SchedulePolicyType is for Schedule based fleet autoscaling
-nolint:revive // Linter contains comment doesn&rsquo;t start with SchedulePolicyType</p>
-</td>
-</tr><tr><td><p>&#34;Wasm&#34;</p></td>
-<td><p>WasmPolicyType is for WebAssembly based fleet autoscaling
-[Stage:Alpha]
-[FeatureFlag:WasmAutoscaler]</p>
-</td>
-</tr><tr><td><p>&#34;Webhook&#34;</p></td>
-<td><p>WebhookPolicyType is a simple webhook strategy used for horizontal fleet scaling
-GameServers</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
-</p>
-<p>
-<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>fleetName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Autoscaling policy</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sync</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
-FleetAutoscalerSync
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sync defines when FleetAutoscalers runs autoscaling</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
-</p>
-<p>
-<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currentReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>CurrentReplicas is the current number of gameserver replicas
-of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>desiredReplicas</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>DesiredReplicas is the desired number of gameserver replicas
-of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lastScaleTime</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ableToScale</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>AbleToScale indicates that we can access the target fleet</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scalingLimited</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>ScalingLimited indicates that the calculated scale would be above or below the range
-defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lastAppliedPolicy</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
-FleetAutoscalerPolicyType
-</a>
-</em>
-</td>
-<td>
-<p>LastAppliedPolicy is the ID of the last applied policy in the ChainPolicy.
-Used to track policy transitions for logging purposes.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
-</p>
-<p>
-<p>FleetAutoscalerSync describes when to sync a fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSyncType">
-FleetAutoscalerSyncType
-</a>
-</em>
-</td>
-<td>
-<p>Type of autoscaling sync.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>fixedInterval</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FixedIntervalSync">
-FixedIntervalSync
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FixedInterval config params. Present only if FleetAutoscalerSyncType = FixedInterval.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSyncType">FleetAutoscalerSyncType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
-</p>
-<p>
-<p>FleetAutoscalerSyncType is the sync strategy for a given Fleet</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;FixedInterval&#34;</p></td>
-<td><p>FixedIntervalSyncType is a simple fixed interval based strategy for trigger autoscaling</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.ListPolicy">ListPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>ListPolicy controls the desired behavior of the List autoscaler policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>key</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Key is the name of the List. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MaxCapacity is the maximum aggregate List total capacity across the fleet.
-MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minCapacity</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>MinCapacity is the minimum aggregate List total capacity across the fleet.
-If zero, it is ignored.
-If non zero, it must be smaller than MaxCapacity and bigger than BufferSize.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bufferSize</code><br/>
-<em>
-k8s.io/apimachinery/pkg/util/intstr.IntOrString
-</em>
-</td>
-<td>
-<p>BufferSize is the size of a buffer based on the List capacity that is available over the
-current aggregate List length in the Fleet (available capacity). It can be specified either
-as an absolute value (i.e. 5) or percentage format (i.e. 5%).
-Must be bigger than 0. Required field.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>SchedulePolicy controls the desired behavior of the Schedule autoscaler policy.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>between</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.Between">
-Between
-</a>
-</em>
-</td>
-<td>
-<p>Between defines the time period that the policy is eligible to be applied.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>activePeriod</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.ActivePeriod">
-ActivePeriod
-</a>
-</em>
-</td>
-<td>
-<p>ActivePeriod defines the time period that the policy is applied.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>policy</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
-FleetAutoscalerPolicy
-</a>
-</em>
-</td>
-<td>
-<p>Policy is the name of the policy to be applied. Required field.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.URLConfiguration">URLConfiguration
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>, 
-<a href="#autoscaling.agones.dev/v1.WasmFrom">WasmFrom</a>)
-</p>
-<p>
-<p>URLConfiguration is a generic configuration for any integration with an external URL or
-cluster provided service. For example, it can be used to configure a webhook or Wasm module</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>url</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>url</code> gives the location of the webhook, in standard URL form
-(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
-must be specified.</p>
-<p>The <code>host</code> should not refer to a service running in the cluster; use
-the <code>service</code> field instead. The host might be resolved via external
-DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
-in-cluster DNS as that would be a layering violation). <code>host</code> may
-also be an IP address.</p>
-<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
-risky unless you take great care to run this webhook on all hosts
-which run an apiserver which might need to make calls to this
-webhook. Such installs are likely to be non-portable, i.e., not easy
-to turn up in a new cluster.</p>
-<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
-<p>A path is optional, and if present may be any string permissible in
-a URL. You may use the path to pass an arbitrary string to the
-webhook, for example, a cluster identifier.</p>
-<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
-allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
-allowed, either.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>service</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#servicereference-v1-admissionregistration">
-Kubernetes admissionregistration/v1.ServiceReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>service</code> is a reference to the service for this webhook. Either
-<code>service</code> or <code>url</code> must be specified.</p>
-<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caBundle</code><br/>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
-If unspecified, system trust roots on the apiserver are used.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.WasmFrom">WasmFrom
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.WasmPolicy">WasmPolicy</a>)
-</p>
-<p>
-<p>WasmFrom defines the source of the Wasm module</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>url</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.URLConfiguration">
-URLConfiguration
-</a>
-</em>
-</td>
-<td>
-<p>URL is the URL of the Wasm module to use for autoscaling.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.agones.dev/v1.WasmPolicy">WasmPolicy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
-</p>
-<p>
-<p>WasmPolicy controls the desired behavior of the Wasm policy.
-It contains the configuration for the WebAssembly module used for autoscaling.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>function</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Function is the exported function to call in the wasm module, defaults to &lsquo;scale&rsquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>config</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Config values to pass to the wasm program on startup</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>from</code><br/>
-<em>
-<a href="#autoscaling.agones.dev/v1.WasmFrom">
-WasmFrom
-</a>
-</em>
-</td>
-<td>
-<p>WasmFrom defines the source of the Wasm module</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>hash</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Hash of the Wasm module, used to verify the integrity of the module</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
-</li></ul>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
-</h3>
-<p>
-<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-multicluster.agones.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>GameServerAllocationPolicy</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-33.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
-GameServerAllocationPolicySpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>priority</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code><br/>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
-</p>
-<p>
-<p>ClusterConnectionInfo defines the connection information for a cluster</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>clusterName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Optional: the name of the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>allocationEndpoints</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>The endpoints for the allocator service in the targeted cluster.
-If the AllocationEndpoints is not set, the allocation happens on local cluster.
-If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>namespace</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The cluster namespace from which to allocate gameservers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serverCa</code><br/>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
-</h3>
-<p>
-<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>currPriority</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<p>currPriority Current priority index from the orderedPriorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>orderedPriorities</code><br/>
-<em>
-[]int32
-</em>
-</td>
-<td>
-<p>orderedPriorities list of ordered priorities</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>priorityToCluster</code><br/>
-<em>
-map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
-</em>
-</td>
-<td>
-<p>priorityToCluster Map of priority to cluster-policies map</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>clusterBlackList</code><br/>
-<em>
-map[string]bool
-</em>
-</td>
-<td>
-<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
-</p>
-<p>
-<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>priority</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>weight</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>connectionInfo</code><br/>
-<em>
-<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
-ClusterConnectionInfo
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<p><em>
-Generated with <code>gen-crd-api-reference-docs</code>.
-</em></p>
-{{% /feature %}}
-{{% feature publishVersion="1.57.0" %}}
+{{% feature expiryVersion="1.58.0" %}}
 <p>Packages:</p>
 <ul>
 <li>
@@ -6035,6 +1024,5028 @@ int32
 </td>
 <td>
 <p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
+AggregatedPlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]
+Players are the current total player capacity and count for this Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedCounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedCounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides aggregated Counter capacity and Counter
+count for this Fleet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides aggregated List capacityv and List values
+for this Fleet.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerPort">GameServerPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>GameServerPort defines a set of Ports that
+are to be exposed via the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the descriptive name of the port</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>range</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PortRanges feature flag) Range is the port range name from which to select a port when using a
+&lsquo;Dynamic&rsquo; or &lsquo;Passthrough&rsquo; port policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>portPolicy</code><br/>
+<em>
+<a href="#agones.dev/v1.PortPolicy">
+PortPolicy
+</a>
+</em>
+</td>
+<td>
+<p>PortPolicy defines the policy for how the HostPort is populated.
+Dynamic port will allocate a HostPort within the selected MIN_PORT and MAX_PORT range passed to the controller
+at installation time.
+When <code>Static</code> portPolicy is specified, <code>HostPort</code> is required, to specify the port that game clients will
+connect to
+<code>Passthrough</code> dynamically sets the <code>containerPort</code> to the same value as the dynamically selected hostPort.
+<code>None</code> portPolicy ignores <code>HostPort</code> and the <code>containerPort</code> (optional) is used to set the port on the GameServer instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Container is the name of the container or sidecar container on which to open the port. Defaults to the game server container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ContainerPort is the port that is being opened on the specified container&rsquo;s process</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HostPort the port exposed on the host for clients to connect to</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#protocol-v1-core">
+Kubernetes core/v1.Protocol
+</a>
+</em>
+</td>
+<td>
+<p>Protocol is the network protocol being used. Defaults to UDP. TCP and TCPUDP are other options.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSetSpec">GameServerSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetSpec the specification for GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and Annotations to apply to GameServers when the number of Allocated GameServers drops below
+the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSetStatus">GameServerSetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetStatus is the status of a GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas is the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas is the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas is the number of Reserved GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas is the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shutdownReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ShutdownReplicas is the number of Shutdown GameServers replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
+AggregatedPlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]
+Players is the current total player capacity and count for this GameServerSet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedCounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedCounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides aggregated Counter capacity and Counter
+count for this GameServerSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides aggregated List capacity and List values
+for this GameServerSet.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSpec">GameServerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServer">GameServer</a>, 
+<a href="#agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec</a>)
+</p>
+<p>
+<p>GameServerSpec is the spec for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code><br/>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerState">GameServerState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>GameServerState is the state for the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Allocated&#34;</p></td>
+<td><p>GameServerStateAllocated is when the GameServer has been allocated to a session</p>
+</td>
+</tr><tr><td><p>&#34;Creating&#34;</p></td>
+<td><p>GameServerStateCreating is before the Pod for the GameServer is being created</p>
+</td>
+</tr><tr><td><p>&#34;Error&#34;</p></td>
+<td><p>GameServerStateError is when something has gone wrong with the Gameserver and
+it cannot be resolved</p>
+</td>
+</tr><tr><td><p>&#34;PortAllocation&#34;</p></td>
+<td><p>GameServerStatePortAllocation is for when a dynamically allocating GameServer
+is being created, an open port needs to be allocated</p>
+</td>
+</tr><tr><td><p>&#34;Ready&#34;</p></td>
+<td><p>GameServerStateReady is when a GameServer is ready to take connections
+from Game clients</p>
+</td>
+</tr><tr><td><p>&#34;RequestReady&#34;</p></td>
+<td><p>GameServerStateRequestReady is when the GameServer has declared that it is ready</p>
+</td>
+</tr><tr><td><p>&#34;Reserved&#34;</p></td>
+<td><p>GameServerStateReserved is for when a GameServer is reserved and therefore can be allocated but not removed</p>
+</td>
+</tr><tr><td><p>&#34;Scheduled&#34;</p></td>
+<td><p>GameServerStateScheduled is for when we have determined that the Pod has been
+scheduled in the cluster &ndash; basically, we have a NodeName</p>
+</td>
+</tr><tr><td><p>&#34;Shutdown&#34;</p></td>
+<td><p>GameServerStateShutdown is when the GameServer has shutdown and everything needs to be
+deleted from the cluster</p>
+</td>
+</tr><tr><td><p>&#34;Starting&#34;</p></td>
+<td><p>GameServerStateStarting is for when the Pods for the GameServer are being
+created but are not yet Scheduled</p>
+</td>
+</tr><tr><td><p>&#34;Unhealthy&#34;</p></td>
+<td><p>GameServerStateUnhealthy is when the GameServer has failed its health checks</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerStatus">GameServerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServer">GameServer</a>)
+</p>
+<p>
+<p>GameServerStatus is the status for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerState">
+GameServerState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of a GameServer, e.g. Creating, Starting, Ready, etc</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>addresses</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#nodeaddress-v1-core">
+[]Kubernetes core/v1.NodeAddress
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Addresses is the array of addresses at which the GameServer can be reached; copy of Node.Status.addresses.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedUntil</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayerStatus">
+PlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters and Lists provides the configuration for generic tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerStatusPort">GameServerStatusPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerStatusPort shows the port that was allocated to a
+GameServer.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
+</p>
+<p>
+<p>GameServerTemplateSpec is a template for GameServers</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code><br/>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.Health">Health
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>Health configures health checking on the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>disabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Disabled is whether health checking is disabled or not</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>periodSeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>PeriodSeconds is the number of seconds each health ping has to occur in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failureThreshold</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>FailureThreshold how many failures in a row constitutes unhealthy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>initialDelaySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>InitialDelaySeconds initial delay before checking health</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.ListStatus">ListStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>ListStatus stores the current list values and maximum capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PlayerStatus">PlayerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>PlayerStatus stores the current player capacity values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ids</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PlayersSpec">PlayersSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>PlayersSpec tracks the initial player capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initialCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PortPolicy">PortPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerPort">GameServerPort</a>)
+</p>
+<p>
+<p>PortPolicy is the port policy for the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Dynamic&#34;</p></td>
+<td><p>Dynamic PortPolicy means that the system will choose an open
+port for the GameServer in question</p>
+</td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td><p>None means the <code>hostPort</code> is ignored and if defined, the <code>containerPort</code> (optional) is used to set the port on the GameServer instance.</p>
+</td>
+</tr><tr><td><p>&#34;Passthrough&#34;</p></td>
+<td><p>Passthrough dynamically sets the <code>containerPort</code> to the same value as the dynamically selected hostPort.
+This will mean that users will need to lookup what port has been opened through the server side SDK.</p>
+</td>
+</tr><tr><td><p>&#34;Static&#34;</p></td>
+<td><p>Static PortPolicy means that the user defines the hostPort to be used
+in the configuration.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="agones.dev/v1.Priority">Priority
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>Priority is a sorting option for GameServers with Counters or Lists based on the available capacity,
+i.e. the current Capacity value, minus either the Count value or List length.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Type: Sort by a &ldquo;Counter&rdquo; or a &ldquo;List&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key: The name of the Counter or List. If not found on the GameServer, has no impact.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>order</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Order: Sort by &ldquo;Ascending&rdquo; or &ldquo;Descending&rdquo;. &ldquo;Descending&rdquo; a bigger available capacity is preferred.
+&ldquo;Ascending&rdquo; would be smaller available capacity is preferred.
+The default sort order is &ldquo;Ascending&rdquo;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.SdkServer">SdkServer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>logLevel</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServerLogLevel">
+SdkServerLogLevel
+</a>
+</em>
+</td>
+<td>
+<p>LogLevel for SDK server (sidecar) logs. Defaults to &ldquo;Info&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>grpcPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>GRPCPort is the port on which the SDK Server binds the gRPC server to accept incoming connections</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HTTPPort is the port on which the SDK Server binds the HTTP gRPC gateway server to accept incoming connections</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.SdkServerLogLevel">SdkServerLogLevel
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.SdkServer">SdkServer</a>)
+</p>
+<p>
+<p>SdkServerLogLevel is the log level for SDK server (sidecar) logs</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Debug&#34;</p></td>
+<td><p>SdkServerLogLevelDebug will cause the SDK server to output all messages including debug messages.</p>
+</td>
+</tr><tr><td><p>&#34;Error&#34;</p></td>
+<td><p>SdkServerLogLevelError will cause the SDK server to only output error messages.</p>
+</td>
+</tr><tr><td><p>&#34;Info&#34;</p></td>
+<td><p>SdkServerLogLevelInfo will cause the SDK server to output all messages except for debug messages.</p>
+</td>
+</tr><tr><td><p>&#34;Trace&#34;</p></td>
+<td><p>SdkServerLogLevelTrace will cause the SDK server to output all messages, including detailed tracing information.</p>
+</td>
+</tr></tbody>
+</table>
+<hr/>
+<h2 id="allocation.agones.dev/v1">allocation.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>
+</li></ul>
+<h3 id="allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation
+</h3>
+<p>
+<p>GameServerAllocation is the data structure for allocating against a set of
+GameServers, defined <code>selectors</code> selectors</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+allocation.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServerAllocation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">
+GameServerAllocationSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>multiClusterSetting</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Required is the GameServer selector from which to choose GameServers from.
+Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Preferred is an ordered list of preferred GameServer selectors
+that are optional to be fulfilled, but will be searched before the <code>required</code> selector.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+If any of the preferred selectors are matched, the required selector is not considered.
+This is useful for things like smoke testing of new game servers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters the order in which <code>GameServers</code> are searched for matches to the configured <code>selectors</code>.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy sorting, this priority list will be the tie-breaker within the least utilised infrastructure, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy sorting, the entire selection of <code>GameServers</code> will be sorted by this priority list to provide the
+order that <code>GameServers</code> will be allocated by.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selectors</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Ordered list of GameServer label selectors.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+This is useful for things like smoke testing of new game servers.
+Note: This field can only be set if neither Required or Preferred is set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.CounterAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Counter actions to perform during allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.ListAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.ListAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+List actions to perform during allocation.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">
+GameServerAllocationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.CounterAction">CounterAction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>CounterAction is an optional action that can be performed on a Counter at allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>action</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Action must to either &ldquo;Increment&rdquo; or &ldquo;Decrement&rdquo; the Counter&rsquo;s Count. Must also define the Amount.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>amount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Amount is the amount to increment or decrement the Count. Must be a positive integer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Capacity is the amount to update the maximum capacity of the Counter to this number. Min 0, Max int64.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.CounterSelector">CounterSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>CounterSelector is the filter options for a GameServer based on the count and/or available capacity.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinCount is the minimum current value. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxCount is the maximum current value. Defaults to 0, which translates as max(in64).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinAvailable specifies the minimum capacity (current capacity - current count) available on a GameServer. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxAvailable specifies the maximum capacity (current capacity - current count) available on a GameServer. Defaults to 0, which translates to max(int64).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>multiClusterSetting</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Required is the GameServer selector from which to choose GameServers from.
+Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Preferred is an ordered list of preferred GameServer selectors
+that are optional to be fulfilled, but will be searched before the <code>required</code> selector.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+If any of the preferred selectors are matched, the required selector is not considered.
+This is useful for things like smoke testing of new game servers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters the order in which <code>GameServers</code> are searched for matches to the configured <code>selectors</code>.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy sorting, this priority list will be the tie-breaker within the least utilised infrastructure, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy sorting, the entire selection of <code>GameServers</code> will be sorted by this priority list to provide the
+order that <code>GameServers</code> will be allocated by.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selectors</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Ordered list of GameServer label selectors.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+This is useful for things like smoke testing of new game servers.
+Note: This field can only be set if neither Required or Preferred is set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.CounterAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Counter actions to perform during allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.ListAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.ListAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+List actions to perform during allocation.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationState">GameServerAllocationState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerAllocationState is the Allocation state</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Allocated&#34;</p></td>
+<td><p>GameServerAllocationAllocated is allocation successful</p>
+</td>
+</tr><tr><td><p>&#34;Contention&#34;</p></td>
+<td><p>GameServerAllocationContention when the allocation is unsuccessful
+because of contention</p>
+</td>
+</tr><tr><td><p>&#34;UnAllocated&#34;</p></td>
+<td><p>GameServerAllocationUnAllocated when the allocation is unsuccessful</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationState">
+GameServerAllocationState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of an GameServerAllocation, e.g. Allocated, or UnAllocated</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gameServerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>addresses</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#nodeaddress-v1-core">
+[]Kubernetes core/v1.NodeAddress
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>If the allocation is from a remote cluster, Source is the endpoint of the remote agones-allocator.
+Otherwise, Source is &ldquo;local&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerMetadata">
+GameServerMetadata
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerMetadata">GameServerMetadata
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerMetadata is the metadata from the allocated game server at allocation time</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerSelector">GameServerSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>GameServerSelector contains all the filter options for selecting
+a GameServer for allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>LabelSelector</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>LabelSelector</code> are embedded into this type.)
+</p>
+<p>See: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gameServerState</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerState">
+GameServerState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState specifies which State is the filter to be used when attempting to retrieve a GameServer
+via Allocation. Defaults to &ldquo;Ready&rdquo;. The only other option is &ldquo;Allocated&rdquo;, which can be used in conjunction with
+label/annotation/player selectors to retrieve an already Allocated GameServer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.PlayerSelector">
+PlayerSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerAllocationFilter]
+Players provides a filter on minimum and maximum values for player capacity when retrieving a GameServer
+through Allocation. Defaults to no limits.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.CounterSelector">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Counters provides filters on minimum and maximum values
+for a Counter&rsquo;s count and available capacity when retrieving a GameServer through Allocation.
+Defaults to no limits.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.ListSelector">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.ListSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Lists provides filters on minimum and maximum values
+for List capacity, and for the existence of a value in a List, when retrieving a GameServer
+through Allocation. Defaults to no limits.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.ListAction">ListAction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>ListAction is an optional action that can be performed on a List at allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>addValues</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AddValues appends values to a List&rsquo;s Values array. Any duplicate values will be ignored.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deleteValues</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeleteValues removes values from a List&rsquo;s Values array. Any nonexistant values will be ignored.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Capacity updates the maximum capacity of the Counter to this number. Min 0, Max 1000.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.ListSelector">ListSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>ListSelector is the filter options for a GameServer based on List available capacity and/or the
+existence of a value in a List.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containsValue</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainsValue says to only match GameServers who has this value in the list. Defaults to &ldquo;&rdquo;, which is all.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinAvailable specifies the minimum capacity (current capacity - current count) available on a GameServer. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxAvailable specifies the maximum capacity (current capacity - current count) available on a GameServer. Defaults to 0, which is translated as max(int64).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.MetaPatch">MetaPatch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.MultiClusterSetting">MultiClusterSetting
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policySelector</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.PlayerSelector">PlayerSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>PlayerSelector is the filter options for a GameServer based on player counts</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
+</li></ul>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
+</h3>
+<p>
+<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+autoscaling.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>FleetAutoscaler</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
+FleetAutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>fleetName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sync</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
+FleetAutoscalerSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sync defines when FleetAutoscalers runs autoscaling</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
+FleetAutoscalerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ActivePeriod">ActivePeriod
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
+</p>
+<p>
+<p>ActivePeriod defines the time period that the policy is applied.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>timezone</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Timezone to be used for the startCron field. If not set, startCron is defaulted to the UTC timezone.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startCron</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>StartCron defines when the policy should be applied.
+If not set, the policy is always to be applied within the start and end time.
+This field must conform to UNIX cron syntax.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>duration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Duration is the length of time that the policy is applied.
+If not set, the duration is indefinite.
+A duration string is a possibly signed sequence of decimal numbers,
+(e.g. &ldquo;300ms&rdquo;, &ldquo;-1.5h&rdquo; or &ldquo;2h45m&rdquo;).
+The representation limits the largest representable duration to approximately 290 years.
+Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.Between">Between
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
+</p>
+<p>
+<p>Between defines the time period that the policy is eligible to be applied.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>start</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Start is the datetime that the policy is eligible to be applied.
+This field must conform to RFC3339 format. If this field not set or is in the past, the policy is eligible to be applied
+as soon as the fleet autoscaler is running.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>end</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>End is the datetime that the policy is no longer eligible to be applied.
+This field must conform to RFC3339 format. If not set, the policy is always eligible to be applied, after the start time above.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
+It must be bigger than both MinReplicas and BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MinReplicas is the minimum amount of replicas that the fleet must have
+If zero, it is ignored.
+If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
+Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
+Absolute number is calculated from percentage by rounding up.
+Example: when this is set to 20%, the autoscaler will make sure that 20%
+of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
+the autoscaler will make sure that there are 20 available game servers
+Must be bigger than 0
+Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
+and computation stability in different edge case (fleet just created, not enough
+capacity in the cluster etc)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ChainEntry">ChainEntry
+</h3>
+<p>
+<p>ChainEntry defines a single entry in the ChainPolicy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for a ChainEntry. If not set the identifier will be set to the index of chain entry.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>FleetAutoscalerPolicy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>FleetAutoscalerPolicy</code> are embedded into this type.)
+</p>
+<p>Policy is the name of the policy to be applied. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ChainPolicy">ChainPolicy
+(<code>[]agones.dev/agones/pkg/apis/autoscaling/v1.ChainEntry</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>ChainPolicy controls the desired behavior of the Chain autoscaler policy.</p>
+</p>
+<h3 id="autoscaling.agones.dev/v1.CounterPolicy">CounterPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>CounterPolicy controls the desired behavior of the Counter autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key is the name of the Counter. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MaxCapacity is the maximum aggregate Counter total capacity across the fleet.
+MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MinCapacity is the minimum aggregate Counter total capacity across the fleet.
+If zero, MinCapacity is ignored.
+If non zero, MinCapacity must be smaller than MaxCapacity and bigger than BufferSize.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize is the size of a buffer of counted items that are available in the Fleet (available
+capacity). Value can be an absolute number (ex: 5) or a percentage of desired gs instances
+(ex: 5%). An absolute number is calculated from percentage by rounding up.
+Must be bigger than 0. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FixedIntervalSync">FixedIntervalSync
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
+</p>
+<p>
+<p>FixedIntervalSync controls the desired behavior of the fixed interval based sync.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>seconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Seconds defines how often we run fleet autoscaling in seconds</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code><br/>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
+It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the Fleet being scaled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace associated with the request (if any).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+<p>The Fleet&rsquo;s status values</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Standard map labels; More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Standard map annotations; More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations">https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations</a>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code><br/>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response.
+This should be copied over from the corresponding FleetAutoscaleRequest.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scale</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Set to false if no scaling should occur to the Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>The targeted replica count</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
+</h3>
+<p>
+<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
+and then returned with a populated Response.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>request</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
+FleetAutoscaleRequest
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>response</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
+FleetAutoscaleResponse
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.ChainEntry">ChainEntry</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>, 
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buffer</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.BufferPolicy">
+BufferPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhook</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.URLConfiguration">
+URLConfiguration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counter</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.CounterPolicy">
+CounterPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+Counter policy config params. Present only if FleetAutoscalerPolicyType = Counter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>list</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.ListPolicy">
+ListPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+List policy config params. Present only if FleetAutoscalerPolicyType = List.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedule</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">
+SchedulePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+Schedule policy config params. Present only if FleetAutoscalerPolicyType = Schedule.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>chain</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.ChainPolicy">
+ChainPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+Chain policy config params. Present only if FleetAutoscalerPolicyType = Chain.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>wasm</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.WasmPolicy">
+WasmPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Wasm policy config params. Present only if FleetAutoscalerPolicyType = Wasm.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicyType is the policy for autoscaling
+for a given Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Buffer&#34;</p></td>
+<td><p>BufferPolicyType FleetAutoscalerPolicyType is a simple buffering strategy for Ready
+GameServers</p>
+</td>
+</tr><tr><td><p>&#34;Chain&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+ChainPolicyType is for Chain based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with ChainPolicyType</p>
+</td>
+</tr><tr><td><p>&#34;Counter&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+CounterPolicyType is for Counter based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with CounterPolicyType</p>
+</td>
+</tr><tr><td><p>&#34;List&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+ListPolicyType is for List based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with ListPolicyType</p>
+</td>
+</tr><tr><td><p>&#34;Schedule&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+SchedulePolicyType is for Schedule based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with SchedulePolicyType</p>
+</td>
+</tr><tr><td><p>&#34;Wasm&#34;</p></td>
+<td><p>WasmPolicyType is for WebAssembly based fleet autoscaling
+[Stage:Alpha]
+[FeatureFlag:WasmAutoscaler]</p>
+</td>
+</tr><tr><td><p>&#34;Webhook&#34;</p></td>
+<td><p>WebhookPolicyType is a simple webhook strategy used for horizontal fleet scaling
+GameServers</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fleetName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sync</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
+FleetAutoscalerSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sync defines when FleetAutoscalers runs autoscaling</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>CurrentReplicas is the current number of gameserver replicas
+of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>desiredReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredReplicas is the desired number of gameserver replicas
+of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScaleTime</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ableToScale</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>AbleToScale indicates that we can access the target fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scalingLimited</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ScalingLimited indicates that the calculated scale would be above or below the range
+defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastAppliedPolicy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>LastAppliedPolicy is the ID of the last applied policy in the ChainPolicy.
+Used to track policy transitions for logging purposes.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+</p>
+<p>
+<p>FleetAutoscalerSync describes when to sync a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSyncType">
+FleetAutoscalerSyncType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling sync.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>fixedInterval</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FixedIntervalSync">
+FixedIntervalSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FixedInterval config params. Present only if FleetAutoscalerSyncType = FixedInterval.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSyncType">FleetAutoscalerSyncType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
+</p>
+<p>
+<p>FleetAutoscalerSyncType is the sync strategy for a given Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;FixedInterval&#34;</p></td>
+<td><p>FixedIntervalSyncType is a simple fixed interval based strategy for trigger autoscaling</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ListPolicy">ListPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>ListPolicy controls the desired behavior of the List autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key is the name of the List. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MaxCapacity is the maximum aggregate List total capacity across the fleet.
+MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MinCapacity is the minimum aggregate List total capacity across the fleet.
+If zero, it is ignored.
+If non zero, it must be smaller than MaxCapacity and bigger than BufferSize.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize is the size of a buffer based on the List capacity that is available over the
+current aggregate List length in the Fleet (available capacity). It can be specified either
+as an absolute value (i.e. 5) or percentage format (i.e. 5%).
+Must be bigger than 0. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>SchedulePolicy controls the desired behavior of the Schedule autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>between</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.Between">
+Between
+</a>
+</em>
+</td>
+<td>
+<p>Between defines the time period that the policy is eligible to be applied.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>activePeriod</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.ActivePeriod">
+ActivePeriod
+</a>
+</em>
+</td>
+<td>
+<p>ActivePeriod defines the time period that the policy is applied.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Policy is the name of the policy to be applied. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.URLConfiguration">URLConfiguration
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>, 
+<a href="#autoscaling.agones.dev/v1.WasmFrom">WasmFrom</a>)
+</p>
+<p>
+<p>URLConfiguration is a generic configuration for any integration with an external URL or
+cluster provided service. For example, it can be used to configure a webhook or Wasm module</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>url</code> gives the location of the webhook, in standard URL form
+(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
+must be specified.</p>
+<p>The <code>host</code> should not refer to a service running in the cluster; use
+the <code>service</code> field instead. The host might be resolved via external
+DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
+in-cluster DNS as that would be a layering violation). <code>host</code> may
+also be an IP address.</p>
+<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
+risky unless you take great care to run this webhook on all hosts
+which run an apiserver which might need to make calls to this
+webhook. Such installs are likely to be non-portable, i.e., not easy
+to turn up in a new cluster.</p>
+<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
+<p>A path is optional, and if present may be any string permissible in
+a URL. You may use the path to pass an arbitrary string to the
+webhook, for example, a cluster identifier.</p>
+<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
+allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
+allowed, either.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>service</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#servicereference-v1-admissionregistration">
+Kubernetes admissionregistration/v1.ServiceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>service</code> is a reference to the service for this webhook. Either
+<code>service</code> or <code>url</code> must be specified.</p>
+<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caBundle</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
+If unspecified, system trust roots on the apiserver are used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.WasmFrom">WasmFrom
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.WasmPolicy">WasmPolicy</a>)
+</p>
+<p>
+<p>WasmFrom defines the source of the Wasm module</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.URLConfiguration">
+URLConfiguration
+</a>
+</em>
+</td>
+<td>
+<p>URL is the URL of the Wasm module to use for autoscaling.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.WasmPolicy">WasmPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>WasmPolicy controls the desired behavior of the Wasm policy.
+It contains the configuration for the WebAssembly module used for autoscaling.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>function</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Function is the exported function to call in the wasm module, defaults to &lsquo;scale&rsquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Config values to pass to the wasm program on startup</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>from</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.WasmFrom">
+WasmFrom
+</a>
+</em>
+</td>
+<td>
+<p>WasmFrom defines the source of the Wasm module</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hash</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Hash of the Wasm module, used to verify the integrity of the module</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
+</li></ul>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
+</h3>
+<p>
+<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+multicluster.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServerAllocationPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
+GameServerAllocationPolicySpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>priority</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code><br/>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
+</p>
+<p>
+<p>ClusterConnectionInfo defines the connection information for a cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clusterName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Optional: the name of the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationEndpoints</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The endpoints for the allocator service in the targeted cluster.
+If the AllocationEndpoints is not set, the allocation happens on local cluster.
+If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The cluster namespace from which to allocate gameservers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverCa</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
+</h3>
+<p>
+<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currPriority</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<p>currPriority Current priority index from the orderedPriorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>orderedPriorities</code><br/>
+<em>
+[]int32
+</em>
+</td>
+<td>
+<p>orderedPriorities list of ordered priorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorityToCluster</code><br/>
+<em>
+map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
+</em>
+</td>
+<td>
+<p>priorityToCluster Map of priority to cluster-policies map</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterBlackList</code><br/>
+<em>
+map[string]bool
+</em>
+</td>
+<td>
+<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
+</p>
+<p>
+<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>priority</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code><br/>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>
+{{% /feature %}}
+{{% feature publishVersion="1.58.0" %}}
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#agones.dev%2fv1">agones.dev/v1</a>
+</li>
+<li>
+<a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
+</li>
+<li>
+<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
+</li>
+<li>
+<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
+</li>
+</ul>
+<h2 id="agones.dev/v1">agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#agones.dev/v1.Fleet">Fleet</a>
+</li><li>
+<a href="#agones.dev/v1.GameServer">GameServer</a>
+</li><li>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>
+</li></ul>
+<h3 id="agones.dev/v1.Fleet">Fleet
+</h3>
+<p>
+<p>Fleet is the data structure for a Fleet resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Fleet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.FleetSpec">
+FleetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and/or Annotations to apply to overflowing GameServers when the number of Allocated GameServers is more
+than the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServer">GameServer
+</h3>
+<p>
+<p>GameServer is the data structure for a GameServer resource.
+It is worth noting that while there is a <code>GameServerStatus</code> Status entry for the <code>GameServer</code>, it is not
+defined as a subresource - unlike <code>Fleet</code> and other Agones resources.
+This is so that we can retain the ability to change multiple aspects of a <code>GameServer</code> in a single atomic operation,
+which is particularly useful for operations such as allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code><br/>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerStatus">
+GameServerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSet">GameServerSet
+</h3>
+<p>
+<p>GameServerSet is the data structure for a set of GameServers.
+This matches philosophically with the relationship between
+Deployments and ReplicaSets</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServerSet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSetSpec">
+GameServerSetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and Annotations to apply to GameServers when the number of Allocated GameServers drops below
+the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSetStatus">
+GameServerSetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedCounterStatus">AggregatedCounterStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedCounterStatus stores total and allocated Counter tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>allocatedCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedListStatus">AggregatedListStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedListStatus stores total and allocated List tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>allocatedCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedPlayerStatus">AggregatedPlayerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedPlayerStatus stores total player tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AllocationOverflow">AllocationOverflow
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
+</p>
+<p>
+<p>AllocationOverflow specifies what labels and/or annotations to apply on Allocated GameServers
+if the desired number of the underlying <code>GameServerSet</code> drops below the number of Allocated GameServers
+attached to it.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels to be applied to the <code>GameServer</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Annotations to be applied to the <code>GameServer</code></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.CounterStatus">CounterStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>CounterStatus stores the current counter values and maximum capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.Eviction">Eviction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>Eviction specifies the eviction tolerance of the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>safe</code><br/>
+<em>
+<a href="#agones.dev/v1.EvictionSafe">
+EvictionSafe
+</a>
+</em>
+</td>
+<td>
+<p>Game server supports termination via SIGTERM:
+- Always: Allow eviction for both Cluster Autoscaler and node drain for upgrades
+- OnUpgrade: Allow eviction for upgrades alone
+- Never (default): Pod should run to completion</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.EvictionSafe">EvictionSafe
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Eviction">Eviction</a>)
+</p>
+<p>
+<p>EvictionSafe specified whether the game server supports termination via SIGTERM</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Always&#34;</p></td>
+<td><p>EvictionSafeAlways means the game server supports termination via SIGTERM, and wants eviction signals
+from Cluster Autoscaler scaledown and node upgrades.</p>
+</td>
+</tr><tr><td><p>&#34;Never&#34;</p></td>
+<td><p>EvictionSafeNever means the game server should run to completion and may not understand SIGTERM. Eviction
+from ClusterAutoscaler and upgrades should both be blocked.</p>
+</td>
+</tr><tr><td><p>&#34;OnUpgrade&#34;</p></td>
+<td><p>EvictionSafeOnUpgrade means the game server supports termination via SIGTERM, and wants eviction signals
+from node upgrades, but not Cluster Autoscaler scaledown.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="agones.dev/v1.FleetSpec">FleetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Fleet">Fleet</a>)
+</p>
+<p>
+<p>FleetSpec is the spec for a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and/or Annotations to apply to overflowing GameServers when the number of Allocated GameServers is more
+than the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code><br/>
+<em>
+<a href="https://v1-34.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.FleetStatus">FleetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Fleet">Fleet</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
+</p>
+<p>
+<p>FleetStatus is the status of a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas are the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+Reserved instances won&rsquo;t be deleted on scale down, but won&rsquo;t cause an autoscaler to scale up.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocations</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>Allocations is a counter of the number of allocations observed.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -203,6 +203,7 @@ When the `FleetAutoscaleRequestMetaData` feature gate is enabled, the Fleet's `l
 `annotations` are included in the `FleetAutoscaleRequest`, allowing webhooks to make scaling decisions based on 
 Fleet-specific metadata.
 
+{{% feature expiryVersion="1.58.0" %}}
 ```go
 // FleetAutoscaleReview is passed to the webhook with a populated Request value,
 // and then returned with a populated Response.
@@ -252,6 +253,60 @@ type FleetStatus struct {
 	AllocatedReplicas int32 `json:"allocatedReplicas"`
 }
 ```
+{{% /feature %}}
+{{% feature publishVersion="1.58.0" %}}
+```go
+// FleetAutoscaleReview is passed to the webhook with a populated Request value,
+// and then returned with a populated Response.
+type FleetAutoscaleReview struct {
+	Request  *FleetAutoscaleRequest  `json:"request"`
+	Response *FleetAutoscaleResponse `json:"response"`
+}
+
+type FleetAutoscaleRequest struct {
+	// UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+	// The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
+	// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+	UID types.UID `json:"uid""`
+	// Name is the name of the Fleet being scaled
+	Name string `json:"name"`
+	// Namespace is the namespace associated with the request (if any).
+	Namespace string `json:"namespace"`
+	// The Fleet's status values
+	Status v1.FleetStatus `json:"status"`
+	// Standard map labels; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels.
+	Labels map[string]string `json:"labels,omitempty"`
+	// Standard map annotations; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type FleetAutoscaleResponse struct {
+	// UID is an identifier for the individual request/response.
+	// This should be copied over from the corresponding FleetAutoscaleRequest.
+	UID types.UID `json:"uid"`
+	// Set to false if no scaling should occur to the Fleet
+	Scale bool `json:"scale"`
+	// The targeted replica count
+	Replicas int32 `json:"replicas"`
+}
+
+// FleetStatus is the status of a Fleet
+type FleetStatus struct {
+	// Replicas the total number of current GameServer replicas
+	Replicas int32 `json:"replicas"`
+	// ReadyReplicas are the number of Ready GameServer replicas
+	ReadyReplicas int32 `json:"readyReplicas"`
+	// ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+	// Reserved instances won't be deleted on scale down, but won't cause an autoscaler to scale up.
+	ReservedReplicas int32 `json:"reservedReplicas"`
+	// AllocatedReplicas are the number of Allocated GameServer replicas
+	AllocatedReplicas int32 `json:"allocatedReplicas"`
+    // Allocations is a counter of the number of allocations observed.
+    Allocations int64 `json:"allocations"`
+}
+```
+{{% /feature %}}
 
 For Webhook Fleetautoscaler Policy either HTTP or HTTPS could be used. Switching between them occurs depending on https presence in `URL` or by the presence of `caBundle`.
 The example of the webhook written in Go could be found {{< ghlink href="examples/autoscaler-webhook/main.go" >}}here{{< /ghlink >}}.
@@ -328,6 +383,58 @@ exact same structure as the [Webhook Autoscaler Specification](#webhook-endpoint
 The `FleetAutoscaleResponse`'s `Replicas` field is used to set the target `Fleet` count with each sync interval, thereby
 providing the autoscaling functionality. The `Scale` field indicates whether scaling should occur.
 
+{{% feature expiryVersion="1.58.0" %}}
+```go
+// FleetAutoscaleReview is passed to the Wasm function with a populated Request value,
+// and then returned with a populated Response.
+type FleetAutoscaleReview struct {
+	Request  *FleetAutoscaleRequest  `json:"request"`
+	Response *FleetAutoscaleResponse `json:"response"`
+}
+
+type FleetAutoscaleRequest struct {
+	// UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+	// The UID is meant to track the round trip (request/response) between the Autoscaler and the Wasm function, not the user request.
+	// It is suitable for correlating log entries between the autoscaler and the Wasm function, for either auditing or debugging.
+	UID string `json:"uid"`
+	// Name is the name of the Fleet being scaled
+	Name string `json:"name"`
+	// Namespace is the namespace associated with the request (if any).
+	Namespace string `json:"namespace"`
+	// The Fleet's status values
+	Status FleetStatus `json:"status"`
+	// Standard map labels; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels.
+	Labels map[string]string `json:"labels,omitempty"`
+	// Standard map annotations; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type FleetAutoscaleResponse struct {
+	// UID is an identifier for the individual request/response.
+	// This should be copied over from the corresponding FleetAutoscaleRequest.
+	UID string `json:"uid"`
+	// Set to false if no scaling should occur to the Fleet
+	Scale bool `json:"scale"`
+	// The targeted replica count
+	Replicas int32 `json:"replicas"`
+}
+
+// FleetStatus is the status of a Fleet
+type FleetStatus struct {
+	// Replicas the total number of current GameServer replicas
+	Replicas int32 `json:"replicas"`
+	// ReadyReplicas are the number of Ready GameServer replicas
+	ReadyReplicas int32 `json:"readyReplicas"`
+	// ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+	// Reserved instances won't be deleted on scale down, but won't cause an autoscaler to scale up.
+	ReservedReplicas int32 `json:"reservedReplicas"`
+	// AllocatedReplicas are the number of Allocated GameServer replicas
+	AllocatedReplicas int32 `json:"allocatedReplicas"`
+}
+```
+{{% /feature %}}
+{{% feature publishVersion="1.58.0" %}}
 ```go
 // FleetAutoscaleReview is passed to the Wasm function with a populated Request value,
 // and then returned with a populated Response.
@@ -379,6 +486,7 @@ type FleetStatus struct {
     Allocations int64 `json:"allocations"`
 }
 ```
+{{% /feature %}}
 
 The example of a Wasm autoscaler written in Go using the Extism PDK can be found {{< ghlink href="examples/autoscaler-wasm/main.go" >}}here{{< /ghlink >}}.
 

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -217,7 +217,7 @@ type FleetAutoscaleRequest struct {
 	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
 	// The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
 	// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
-	UID types.UID `json:"uid""`
+	UID types.UID `json:"uid"`
 	// Name is the name of the Fleet being scaled
 	Name string `json:"name"`
 	// Namespace is the namespace associated with the request (if any).
@@ -268,7 +268,7 @@ type FleetAutoscaleRequest struct {
 	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
 	// The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
 	// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
-	UID types.UID `json:"uid""`
+	UID types.UID `json:"uid"`
 	// Name is the name of the Fleet being scaled
 	Name string `json:"name"`
 	// Namespace is the namespace associated with the request (if any).

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -203,7 +203,7 @@ When the `FleetAutoscaleRequestMetaData` feature gate is enabled, the Fleet's `l
 `annotations` are included in the `FleetAutoscaleRequest`, allowing webhooks to make scaling decisions based on 
 Fleet-specific metadata.
 
-{{% feature expiryVersion="1.58.0" %}}
+{{% feature expiryVersion="1.59.0" %}}
 ```go
 // FleetAutoscaleReview is passed to the webhook with a populated Request value,
 // and then returned with a populated Response.
@@ -254,7 +254,7 @@ type FleetStatus struct {
 }
 ```
 {{% /feature %}}
-{{% feature publishVersion="1.58.0" %}}
+{{% feature publishVersion="1.59.0" %}}
 ```go
 // FleetAutoscaleReview is passed to the webhook with a populated Request value,
 // and then returned with a populated Response.
@@ -383,7 +383,7 @@ exact same structure as the [Webhook Autoscaler Specification](#webhook-endpoint
 The `FleetAutoscaleResponse`'s `Replicas` field is used to set the target `Fleet` count with each sync interval, thereby
 providing the autoscaling functionality. The `Scale` field indicates whether scaling should occur.
 
-{{% feature expiryVersion="1.58.0" %}}
+{{% feature expiryVersion="1.59.0" %}}
 ```go
 // FleetAutoscaleReview is passed to the Wasm function with a populated Request value,
 // and then returned with a populated Response.
@@ -434,7 +434,7 @@ type FleetStatus struct {
 }
 ```
 {{% /feature %}}
-{{% feature publishVersion="1.58.0" %}}
+{{% feature publishVersion="1.59.0" %}}
 ```go
 // FleetAutoscaleReview is passed to the Wasm function with a populated Request value,
 // and then returned with a populated Response.

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -375,6 +375,8 @@ type FleetStatus struct {
 	ReservedReplicas int32 `json:"reservedReplicas"`
 	// AllocatedReplicas are the number of Allocated GameServer replicas
 	AllocatedReplicas int32 `json:"allocatedReplicas"`
+    // Allocations is a counter of the number of allocations observed.
+    Allocations int64 `json:"allocations"`
 }
 ```
 

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -762,6 +762,26 @@ func TestFleetUpdates(t *testing.T) {
 	}
 }
 
+func TestFleetCountsAllocations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	client := framework.AgonesClient.AgonesV1()
+	flt := defaultFleet(framework.Namespace)
+	flt.Spec.Replicas = 5
+	flt, err := client.Fleets(framework.Namespace).Create(ctx, flt, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer client.Fleets(framework.Namespace).Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
+
+	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
+	_ = framework.CreateAndApplyAllocation(t, flt)
+	_ = framework.CreateAndApplyAllocation(t, flt)
+
+	framework.AssertFleetCondition(t, flt, func(_ *logrus.Entry, fleet *agonesv1.Fleet) bool {
+		return fleet.Status.Allocations == 2
+	})
+}
+
 func TestUpdateGameServerConfigurationInFleet(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
/kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

This PR adds allocations tracking on a Fleet level to provide real allocation metrics to the Fleet Autoscaler. This provides better metrics to base custom autoscaling off of while also providing a good metric to the system

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #4452

**Special notes for your reviewer**:

Initially I thought to use a `RWMutex` and `atomic.Int64`, but the locking logic got really verbose and I dont think, even in active clusters, that the contention on a `Mutex` is likely to be a real issue, given how low the actual lock time will be. If this proves to no longer be true, it is simple to change it.

It also occurred to me that queuing the Fleet when an Allocation is observed is likely not needed, as this will always result in either a change in AllocatedReplicas, ReadyReplicas or Replicas on the `GameServerSet` which will itself queue the `Fleet`. I will run some manual tests to prove this.

