### PR TITLE
Add selectable fields to gameserver crd

### DIFF
--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -37,9 +37,12 @@ spec:
     - name: v1
       served: true
       storage: true
+      {{- with .Values.gameservers.selectableFields }}
       selectableFields:
-        - jsonPath: .status.state
-        - jsonPath: .status.nodeName
+      {{- range . }}
+        - jsonPath: {{ . }}
+      {{- end }}
+      {{- end }}
       additionalPrinterColumns:
         - jsonPath: .status.state
           name: State

--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -37,6 +37,9 @@ spec:
     - name: v1
       served: true
       storage: true
+      selectableFields:
+        - jsonPath: .status.state
+        - jsonPath: .status.nodeName
       additionalPrinterColumns:
         - jsonPath: .status.state
           name: State

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -362,6 +362,9 @@ gameservers:
     # requires feature gate PortRanges to be enabled
     # game: [9000, 10000]
   podPreserveUnknownFields: false
+  selectableFields:
+    - .status.state
+    - .status.nodeName
   lists:
     maxItems: 1000
 

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -7397,6 +7397,9 @@ spec:
     - name: v1
       served: true
       storage: true
+      selectableFields:
+        - jsonPath: .status.state
+        - jsonPath: .status.nodeName
       additionalPrinterColumns:
         - jsonPath: .status.state
           name: State

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -390,6 +390,17 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 ### GameServers
 
+{{% feature expiryVersion="1.58.0" %}}
+| Parameter                              | Description                                                                                                                             | Default       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `gameservers.namespaces`               | a list of namespaces you are planning to use to deploy game servers                                                                     | `["default"]` |
+| `gameservers.minPort`                  | Minimum port to use for dynamic port allocation                                                                                         | `7000`        |
+| `gameservers.maxPort`                  | Maximum port to use for dynamic port allocation                                                                                         | `8000`        |
+| `gameservers.additionalPortRanges`     | Port ranges from which to do named dynamic port allocation. Example: <br /> additionalPortRanges: <br />&nbsp;&nbsp;game: [9000, 10000] | `{}`          |
+| `gameservers.podPreserveUnknownFields` | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition                    | `false`       |
+| `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list.                                                                           | `1000`        |
+{{% /feature %}}
+{{% feature publishVersion="1.58.0" %}}
 | Parameter                              | Description                                                                                                                             | Default                                |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------|
 | `gameservers.namespaces`               | a list of namespaces you are planning to use to deploy game servers                                                                     | `["default"]`                          |
@@ -397,11 +408,9 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `gameservers.maxPort`                  | Maximum port to use for dynamic port allocation                                                                                         | `8000`                                 |
 | `gameservers.additionalPortRanges`     | Port ranges from which to do named dynamic port allocation. Example: <br /> additionalPortRanges: <br />&nbsp;&nbsp;game: [9000, 10000] | `{}`                                   |
 | `gameservers.podPreserveUnknownFields` | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition                    | `false`                                |
-{{% feature publishVersion="1.58.0" %}}
 | `gameservers.selectableFields`         | spec fields available for querying [GameServer][gameserver] resources.                                                                  | `[".status.state", "status.nodeName"]` |
-{{% /feature %}}
 | `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list.                                                                           | `1000`                                 |
-
+{{% /feature %}}
 
 ### Helm Installation
 

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -398,7 +398,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `gameservers.additionalPortRanges`     | Port ranges from which to do named dynamic port allocation. Example: <br /> additionalPortRanges: <br />&nbsp;&nbsp;game: [9000, 10000] | `{}`                                   |
 | `gameservers.podPreserveUnknownFields` | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition                    | `false`                                |
 {{% feature publishVersion="1.58.0" %}}
-| `gameservers.selectableFields`         | spec fields available or querying [GameServer][gameserver] resources based                                                              | `[".status.state", "status.nodeName"]` |
+| `gameservers.selectableFields`         | spec fields available for querying [GameServer][gameserver] resources.                                                                  | `[".status.state", "status.nodeName"]` |
 {{% /feature %}}
 | `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list.                                                                           | `1000`                                 |
 

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -390,14 +390,17 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 ### GameServers
 
-| Parameter                              | Description                                                                                                                             | Default       |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `gameservers.namespaces`               | a list of namespaces you are planning to use to deploy game servers                                                                     | `["default"]` |
-| `gameservers.minPort`                  | Minimum port to use for dynamic port allocation                                                                                         | `7000`        |
-| `gameservers.maxPort`                  | Maximum port to use for dynamic port allocation                                                                                         | `8000`        |
-| `gameservers.additionalPortRanges`     | Port ranges from which to do named dynamic port allocation. Example: <br /> additionalPortRanges: <br />&nbsp;&nbsp;game: [9000, 10000] | `{}`          |
-| `gameservers.podPreserveUnknownFields` | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition                    | `false`       |
-| `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list.                                                                           | `1000`        |
+| Parameter                              | Description                                                                                                                             | Default                                |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------|
+| `gameservers.namespaces`               | a list of namespaces you are planning to use to deploy game servers                                                                     | `["default"]`                          |
+| `gameservers.minPort`                  | Minimum port to use for dynamic port allocation                                                                                         | `7000`                                 |
+| `gameservers.maxPort`                  | Maximum port to use for dynamic port allocation                                                                                         | `8000`                                 |
+| `gameservers.additionalPortRanges`     | Port ranges from which to do named dynamic port allocation. Example: <br /> additionalPortRanges: <br />&nbsp;&nbsp;game: [9000, 10000] | `{}`                                   |
+| `gameservers.podPreserveUnknownFields` | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition                    | `false`                                |
+{{% feature publishVersion="1.58.0" %}}
+| `gameservers.selectableFields`         | spec fields available or querying [GameServer][gameserver] resources based                                                              | `[".status.state", "status.nodeName"]` |
+{{% /feature %}}
+| `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list.                                                                           | `1000`                                 |
 
 
 ### Helm Installation

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -163,7 +163,7 @@ The GameServer resource does not support updates. If you need to make regular up
 
 Agones supports [selectable fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/) for querying `GameServer` resources based on spec field values. This feature enables efficient server-side filtering of `GameServer` resources.
 
-The following spec fields are available for field selectors in `GameServer` resources:
+By default, the following spec fields are available for field selectors in `GameServer` resources:
 - status.state - The lifecycle of the `GameServer` (See **GameServer State Diagram**)
 - status.nodeName - The node which the `GameServer` is running on
 

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -164,9 +164,10 @@ The GameServer resource does not support updates. If you need to make regular up
 Agones supports [selectable fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/) for querying `GameServer` resources based on spec field values. This feature enables efficient server-side filtering of `GameServer` resources.
 
 By default, the following spec fields are available for field selectors in `GameServer` resources:
-- status.state - The lifecycle of the `GameServer` (See **GameServer State Diagram**)
+- status.state - The lifecycle of the `GameServer` (See [GameServer State Diagram]({{< ref "/docs/Reference/gameserver.md#gameserver-state-diagram" >}}))
 - status.nodeName - The node which the `GameServer` is running on
 
+If you want to configure which fields are selectable, you can configure this through [Helm GameServer configuration variables]({{< ref "docs/installation/install-agones/helm.md#gameservers" >}}).
 {{% /feature %}}
 
 ## Sidecar Containers

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -164,7 +164,7 @@ The GameServer resource does not support updates. If you need to make regular up
 Agones supports [selectable fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/) for querying `GameServer` resources based on spec field values. This feature enables efficient server-side filtering of `GameServer` resources.
 
 By default, the following spec fields are available for field selectors in `GameServer` resources:
-- status.state - The lifecycle of the `GameServer` (See [GameServer State Diagram]({{< ref "/docs/Reference/gameserver.md#gameserver-state-diagram" >}}))
+- status.state - The lifecycle of the `GameServer` (See [GameServer State Diagram]({{< relref "#gameserver-state-diagram" >}}))
 - status.nodeName - The node which the `GameServer` is running on
 
 If you want to configure which fields are selectable, you can configure this through [Helm GameServer configuration variables]({{< ref "docs/installation/install-agones/helm.md#gameservers" >}}).

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -161,7 +161,7 @@ The GameServer resource does not support updates. If you need to make regular up
 {{% feature publishVersion="1.58.0" %}}
 ## Selectable fields
 
-Agones supports selectable fields for querying `GameServer` resources based on spec field values. This feature enables efficient server-side filtering of `GameServer` resources.
+Agones supports [selectable fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/) for querying `GameServer` resources based on spec field values. This feature enables efficient server-side filtering of `GameServer` resources.
 
 The following spec fields are available for field selectors in `GameServer` resources:
 - status.state - The lifecycle of the `GameServer` (See **GameServer State Diagram**)

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -158,6 +158,17 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 The GameServer resource does not support updates. If you need to make regular updates to the GameServer spec, consider using a [Fleet]({{< ref "/docs/Reference/fleet.md" >}}).
 {{% /alert %}}
 
+{{% feature publishVersion="1.58.0" %}}
+## Selectable fields
+
+Agones supports selectable fields for querying `GameServer` resources based on spec field values. This feature enables efficient server-side filtering of `GameServer` resources.
+
+The following spec fields are available for field selectors in `GameServer` resources:
+- status.state - The lifecycle of the `GameServer` (See **GameServer State Diagram**)
+- status.nodeName - The node which the `GameServer` is running on
+
+{{% /feature %}}
+
 ## Sidecar Containers
 
 Agones supports the use of [Sidecar Containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) with exposed ports.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix
> /kind release

**What this PR does / Why we need it**:
We have observers to make sure that our servers are being in the right state. Since we are running with multi servers it is hard to find specific servers with fields like `status` and `nodeName`. So, to facilitate the filtering we wanted to add those fields as selectable.

**Special notes for your reviewer**:
This is a nice to have feature, to be able to filter based on fields like state and node name.