### PR TITLE
Fix SucceededController to handle pods with deletion timestamp

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -157,7 +157,10 @@ func NewController(
 		healthController:         NewHealthController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory, controllerHooks.WaitOnFreePorts()),
 		migrationController:      NewMigrationController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory, controllerHooks.SyncPodPortsToGameServer),
 		missingPodController:     NewMissingPodController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
-		succeededController:      NewSucceededController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
+	}
+
+	if runtime.FeatureEnabled(runtime.FeatureSidecarContainers) {
+		c.succeededController = NewSucceededController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory)
 	}
 
 	c.baseLogger = runtime.NewLoggerWithType(c)

--- a/pkg/gameservers/succeeded.go
+++ b/pkg/gameservers/succeeded.go
@@ -150,8 +150,8 @@ func (c *SucceededController) syncGameServer(ctx context.Context, key string) er
 		return nil
 	}
 
-	// If the pod exists but is not in Succeeded state or is being terminated, we don't need to do anything
-	if !isGameServerPod(pod) || pod.Status.Phase != corev1.PodSucceeded || !pod.ObjectMeta.DeletionTimestamp.IsZero() {
+	// If the pod exists but is not in Succeeded state, we don't need to do anything
+	if !isGameServerPod(pod) || pod.Status.Phase != corev1.PodSucceeded {
 		return nil
 	}
 

--- a/pkg/gameservers/succeeded.go
+++ b/pkg/gameservers/succeeded.go
@@ -150,8 +150,11 @@ func (c *SucceededController) syncGameServer(ctx context.Context, key string) er
 		return nil
 	}
 
-	// If the pod exists but is not in Succeeded state, we don't need to do anything
-	if !isGameServerPod(pod) || pod.Status.Phase != corev1.PodSucceeded {
+	// If the pod exists but is not in Succeeded state, or is not terminating, we don't need to do anything.
+	// HealthController handles PodSucceeded pods that are not terminating.
+	// SucceededController handles the gap: pods that are both PodSucceeded AND terminating (deletion timestamp set),
+	// which HealthController skips (it only enqueues pods where DeletionTimestamp.IsZero()).
+	if !isGameServerPod(pod) || pod.Status.Phase != corev1.PodSucceeded || pod.ObjectMeta.DeletionTimestamp.IsZero() {
 		return nil
 	}
 

--- a/pkg/gameservers/succeeded_test.go
+++ b/pkg/gameservers/succeeded_test.go
@@ -148,7 +148,7 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
 			},
 		},
-		"pod is in terminating state": {
+		"pod is in terminating state but succeeded": {
 			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
 				now := metav1.Now()
 				pod.ObjectMeta.DeletionTimestamp = &now
@@ -156,9 +156,11 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 				return gs, pod
 			},
 			expected: expected{
-				updated:     false,
-				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
-				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
+				},
+				postTests: func(_ *testing.T, _ agtesting.Mocks) {},
 			},
 		},
 	}

--- a/pkg/gameservers/succeeded_test.go
+++ b/pkg/gameservers/succeeded_test.go
@@ -54,6 +54,8 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 		},
 		"pod exists and is in Succeeded state": {
 			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
 				pod.Status.Phase = corev1.PodSucceeded
 				return gs, pod
 			},
@@ -103,6 +105,8 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 		"game server is already in Shutdown state": {
 			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
 				gs.Status.State = agonesv1.GameServerStateShutdown
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
 				pod.Status.Phase = corev1.PodSucceeded
 				return gs, pod
 			},
@@ -115,6 +119,8 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 		"game server is in Error state": {
 			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
 				gs.Status.State = agonesv1.GameServerStateError
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
 				pod.Status.Phase = corev1.PodSucceeded
 				return gs, pod
 			},
@@ -127,6 +133,8 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 		"game server is in Unhealthy state": {
 			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
 				gs.Status.State = agonesv1.GameServerStateUnhealthy
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
 				pod.Status.Phase = corev1.PodSucceeded
 				return gs, pod
 			},
@@ -146,6 +154,50 @@ func TestSucceededControllerSyncGameServer(t *testing.T) {
 				updated:     false,
 				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
 				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"pod succeeded without deletion timestamp is skipped": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				// No deletion timestamp: HealthController handles this, SucceededController skips it
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated:     false,
+				updateTests: func(_ *testing.T, _ *agonesv1.GameServer) {},
+				postTests:   func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"game server is in Ready state, pod terminating and succeeded": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateReady
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
+				},
+				postTests: func(_ *testing.T, _ agtesting.Mocks) {},
+			},
+		},
+		"game server is in Allocated state, pod terminating and succeeded": {
+			setup: func(gs *agonesv1.GameServer, pod *corev1.Pod) (*agonesv1.GameServer, *corev1.Pod) {
+				gs.Status.State = agonesv1.GameServerStateAllocated
+				now := metav1.Now()
+				pod.ObjectMeta.DeletionTimestamp = &now
+				pod.Status.Phase = corev1.PodSucceeded
+				return gs, pod
+			},
+			expected: expected{
+				updated: true,
+				updateTests: func(t *testing.T, gs *agonesv1.GameServer) {
+					assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
+				},
+				postTests: func(_ *testing.T, _ agtesting.Mocks) {},
 			},
 		},
 		"pod is in terminating state but succeeded": {
@@ -223,6 +275,8 @@ func TestSucceededControllerRun(t *testing.T) {
 
 	pod, err := gs.Pod(agtesting.FakeAPIHooks{})
 	require.NoError(t, err)
+	now := metav1.Now()
+	pod.ObjectMeta.DeletionTimestamp = &now
 	pod.Status.Phase = corev1.PodSucceeded
 
 	m.AgonesClient.AddReactor("list", "gameservers", func(_ k8stesting.Action) (bool, runtime.Object, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

When Kubernetes sets a deletion timestamp on a pod simultaneously with it reaching PodSucceeded phase, the SucceededController was skipping the GameServer transition to Shutdown. Remove the DeletionTimestamp guard so a pod in PodSucceeded phase always triggers GameServer→Shutdown.

Update the test case 'pod is in terminating state' to reflect the corrected behaviour: expect updated=true and GameServerStateShutdown.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:


Should fix TestGameServerPodCompletedAfterCleanExit flake!
