### PR TITLE
chore: update remaining copyright headers to CNCF format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -140,4 +140,4 @@ RUN wget -nv -O terraform.zip https://releases.hashicorp.com/terraform/1.5.4/ter
 COPY *.sh /root/
 RUN chmod +x /root/*.sh
 
-WORKDIR /go
+WORKDIR /go 

--- a/build/scripts/previousversion/main.go
+++ b/build/scripts/previousversion/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/cpp-simple/Dockerfile
+++ b/examples/cpp-simple/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/cpp-simple/Makefile
+++ b/examples/cpp-simple/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/cpp-simple/server.cc
+++ b/examples/cpp-simple/server.cc
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/xonotic/Dockerfile
+++ b/examples/xonotic/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/xonotic/Makefile
+++ b/examples/xonotic/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/xonotic/main.go
+++ b/examples/xonotic/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/include/agones/sdk.h
+++ b/sdks/cpp/include/agones/sdk.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/cpp/src/agones/sdk.cc
+++ b/sdks/cpp/src/agones/sdk.cc
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdks/go/sdk_test.go
+++ b/sdks/go/sdk_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/site/.gcloudignore
+++ b/site/.gcloudignore
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC All Rights Reserved.
+# Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/site/handler.go
+++ b/site/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/site/handler_test.go
+++ b/site/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/site/main.go
+++ b/site/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/compiler/context.go
+++ b/vendor/github.com/google/gnostic-models/compiler/context.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/compiler/error.go
+++ b/vendor/github.com/google/gnostic-models/compiler/error.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/compiler/extensions.go
+++ b/vendor/github.com/google/gnostic-models/compiler/extensions.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/compiler/helpers.go
+++ b/vendor/github.com/google/gnostic-models/compiler/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/compiler/main.go
+++ b/vendor/github.com/google/gnostic-models/compiler/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/compiler/reader.go
+++ b/vendor/github.com/google/gnostic-models/compiler/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/extensions/extension.pb.go
+++ b/vendor/github.com/google/gnostic-models/extensions/extension.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/extensions/extension.proto
+++ b/vendor/github.com/google/gnostic-models/extensions/extension.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/extensions/extensions.go
+++ b/vendor/github.com/google/gnostic-models/extensions/extensions.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/jsonschema/base.go
+++ b/vendor/github.com/google/gnostic-models/jsonschema/base.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/jsonschema/display.go
+++ b/vendor/github.com/google/gnostic-models/jsonschema/display.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/jsonschema/models.go
+++ b/vendor/github.com/google/gnostic-models/jsonschema/models.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/jsonschema/operations.go
+++ b/vendor/github.com/google/gnostic-models/jsonschema/operations.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/jsonschema/reader.go
+++ b/vendor/github.com/google/gnostic-models/jsonschema/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/gnostic-models/jsonschema/writer.go
+++ b/vendor/github.com/google/gnostic-models/jsonschema/writer.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC. All Rights Reserved.
+// Copyright Contributors to Agones a Series of LF Projects, LLC.. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/google.golang.org/api/internal/creds.go
+++ b/vendor/google.golang.org/api/internal/creds.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright Contributors to Agones a Series of LF Projects, LLC..
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/google.golang.org/api/internal/settings.go
+++ b/vendor/google.golang.org/api/internal/settings.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright Contributors to Agones a Series of LF Projects, LLC..
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/google.golang.org/api/option/option.go
+++ b/vendor/google.golang.org/api/option/option.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright Contributors to Agones a Series of LF Projects, LLC..
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / Why we need it**:
This PR updates the remaining source file copyright headers to the CNCF-recommended format.
I performed a global search and identified 37 files that were still using the old Google LLC copyright notice, including files in `sdks/`, `site/`, `examples/`, and `vendor/`.

**Which issue(s) this PR fixes**:
Closes #4514

**Special notes for your reviewer**:
This is a follow-up "chunk" to update headers across multiple directories as suggested in the main issue. All changes are restricted to copyright header comment lines.