### PR TITLE
Flaky: TestGameServerPodCompletedAfterCleanExit

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -157,7 +157,10 @@ func NewController(
 		healthController:         NewHealthController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory, controllerHooks.WaitOnFreePorts()),
 		migrationController:      NewMigrationController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory, controllerHooks.SyncPodPortsToGameServer),
 		missingPodController:     NewMissingPodController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
-		succeededController:      NewSucceededController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
+	}
+
+	if runtime.FeatureEnabled(runtime.FeatureSidecarContainers) {
+		c.succeededController = NewSucceededController(health, kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory)
 	}
 
 	c.baseLogger = runtime.NewLoggerWithType(c)

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -524,6 +524,7 @@ func TestGameServerPodCompletedAfterCleanExit(t *testing.T) {
 		for {
 			select {
 			case <-ctx.Done():
+				log.Info("Stopping udp CRASH sender")
 				return
 			default:
 				mtx.Lock()
@@ -531,8 +532,7 @@ func TestGameServerPodCompletedAfterCleanExit(t *testing.T) {
 				_, err := conn.Write([]byte("CRASH 0"))
 				mtx.Unlock()
 				if err != nil {
-					log.WithError(err).Warn("error sending udp packet. Stopping.")
-					return
+					log.WithError(err).Warn("error sending udp packet.")
 				}
 			}
 			time.Sleep(5 * time.Second)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Making an attempt to solve this flakiness. Let's see if we keep sending the packet, it eventually gets through.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Also added a small cleanup for when sidecar is not en enabled feature.
