### PR TITLE
fix: simple-game-server ports are bound before calling SDK Ready()

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -66,7 +66,7 @@ KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
-GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+GS_TEST_IMAGE ?= us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
 
 # Enable all beta feature gates. Keep in sync with `true` (beta) entries in pkg/util/runtime/features.go:featureDefaults
 BETA_FEATURE_GATES ?= "CountsAndLists=true&GKEAutopilotExtendedDurationPods=true&PortPolicyNone=true&PortRanges=true&RollingUpdateFix=true&ScheduledAutoscaler=true&SidecarContainers=true&FleetAutoscaleRequestMetaData=true"

--- a/examples/crd-client/create-gs.yaml
+++ b/examples/crd-client/create-gs.yaml
@@ -38,5 +38,5 @@ spec:
           imagePullPolicy: Always
           env:
             - name: GAMESERVER_IMAGE
-              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              value: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
       restartPolicy: Never

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -110,4 +110,4 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
           imagePullPolicy: Always
           # nodeSelector is a label that can be used to tell Kubernetes which host
           # OS to use. For Windows game servers uncomment the nodeSelector

--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -39,7 +39,7 @@ WITH_ARM64 ?= 1
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-VERSION ?= 0.42
+VERSION ?= 0.43
 ifeq ($(REPOSITORY),)
 	server_tag := simple-game-server:$(VERSION)
 else

--- a/examples/simple-game-server/dev-gameserver.yaml
+++ b/examples/simple-game-server/dev-gameserver.yaml
@@ -31,4 +31,4 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43

--- a/examples/simple-game-server/fleet-distributed.yaml
+++ b/examples/simple-game-server/fleet-distributed.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
               resources:
                 requests:
                   memory: 64Mi

--- a/examples/simple-game-server/fleet-tcp.yaml
+++ b/examples/simple-game-server/fleet-tcp.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
               env:
                 # Disables the UDP listener (Enabled by default)
                 - name: UDP

--- a/examples/simple-game-server/fleet.yaml
+++ b/examples/simple-game-server/fleet.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
               resources:
                 requests:
                   memory: 64Mi

--- a/examples/simple-game-server/gameserver-none.yaml
+++ b/examples/simple-game-server/gameserver-none.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
           resources:
             requests:
               memory: 64Mi

--- a/examples/simple-game-server/gameserver-passthrough.yaml
+++ b/examples/simple-game-server/gameserver-passthrough.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
           env:
             - name: PASSTHROUGH
               value: 'TRUE'

--- a/examples/simple-game-server/gameserver-windows.yaml
+++ b/examples/simple-game-server/gameserver-windows.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
           resources:
             requests:
               memory: 64Mi

--- a/examples/simple-game-server/gameserver.yaml
+++ b/examples/simple-game-server/gameserver.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
           resources:
             requests:
               memory: 64Mi

--- a/examples/simple-game-server/main.go
+++ b/examples/simple-game-server/main.go
@@ -97,12 +97,16 @@ func main() {
 		port = &p
 	}
 
+	var listenersReady sync.WaitGroup
+
 	if *tcp {
-		go tcpListener(port, s, cancel)
+		listenersReady.Add(1)
+		go tcpListener(port, s, cancel, &listenersReady)
 	}
 
 	if *udp {
-		go udpListener(port, s, cancel)
+		listenersReady.Add(1)
+		go udpListener(port, s, cancel, &listenersReady)
 	}
 
 	if *shutdownDelaySec > 0 {
@@ -112,6 +116,7 @@ func main() {
 	}
 
 	if *readyOnStart {
+		listenersReady.Wait()
 		if *readyDelaySec > 0 {
 			log.Printf("Waiting %d seconds before moving to ready", *readyDelaySec)
 			time.Sleep(time.Duration(*readyDelaySec) * time.Second)
@@ -188,12 +193,13 @@ func shutdownAfterNAllocations(s *sdk.SDK, readyIterations, shutdownDelaySec int
 	}
 }
 
-func udpListener(port *string, s *sdk.SDK, cancel context.CancelFunc) {
+func udpListener(port *string, s *sdk.SDK, cancel context.CancelFunc, ready *sync.WaitGroup) {
 	log.Printf("Starting UDP server, listening on port %s", *port)
 	conn, err := net.ListenPacket("udp", ":"+*port)
 	if err != nil {
 		log.Fatalf("Could not start UDP server: %v", err)
 	}
+	ready.Done()
 	defer conn.Close() // nolint: errcheck
 	udpReadWriteLoop(conn, cancel, s)
 }
@@ -227,12 +233,13 @@ func udpRespond(conn net.PacketConn, sender net.Addr, txt string) {
 	}
 }
 
-func tcpListener(port *string, s *sdk.SDK, cancel context.CancelFunc) {
+func tcpListener(port *string, s *sdk.SDK, cancel context.CancelFunc, ready *sync.WaitGroup) {
 	log.Printf("Starting TCP server, listening on port %s", *port)
 	ln, err := net.Listen("tcp", ":"+*port)
 	if err != nil {
 		log.Fatalf("Could not start TCP server: %v", err)
 	}
+	ready.Done()
 	defer ln.Close() // nolint: errcheck
 
 	for {

--- a/install/helm/agones/templates/tests/test-runner.yaml
+++ b/install/helm/agones/templates/tests/test-runner.yaml
@@ -29,7 +29,7 @@ spec:
     imagePullPolicy: Always
     env:
     - name: GAMESERVER_IMAGE
-      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42"
+      value: "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43"
     - name: IS_HELM_TEST
       value: "true"
     - name: GAMESERVERS_NAMESPACE

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -164,7 +164,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 							"template": {
 								"spec": {
 									"containers": [{
-										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42",
+										"image": "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43",
 										"name": false
 									}]
 								}

--- a/site/config.toml
+++ b/site/config.toml
@@ -100,7 +100,7 @@ dev_eks_example_cluster_version = "1.35"
 dev_minikube_example_cluster_version = "1.34.6"
 
 # example tag
-example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42"
+example_image_tag = "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43"
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = true

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -151,7 +151,7 @@ func NewFromFlags() (*Framework, error) {
 	}
 
 	viper.SetDefault(kubeconfigFlag, filepath.Join(usr.HomeDir, ".kube", "config"))
-	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42")
+	viper.SetDefault(gsimageFlag, "us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43")
 	viper.SetDefault(pullSecretFlag, "")
 	viper.SetDefault(stressTestLevelFlag, 0)
 	viper.SetDefault(perfOutputDirFlag, "")

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -1309,7 +1309,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution: ERROR
       containers:
         - name: simple-game-server
-          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
 `
 	err := os.WriteFile("/tmp/invalid.yaml", []byte(gsYaml), 0o644)
 	require.NoError(t, err)

--- a/test/load/allocation/fleet.yaml
+++ b/test/load/allocation/fleet.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - args: [-automaticShutdownDelaySec=600]
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
               name: simple-game-server
               resources:
                 limits:

--- a/test/load/allocation/performance-test-fleet-template.yaml
+++ b/test/load/allocation/performance-test-fleet-template.yaml
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - args: [-automaticShutdownDelaySec=AUTOMATIC_SHUTDOWN_DELAY_SEC_REPLACEMENT]
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
               name: simple-game-server
               resources:
                 limits:

--- a/test/load/allocation/scenario-fleet.yaml
+++ b/test/load/allocation/scenario-fleet.yaml
@@ -38,7 +38,7 @@ spec:
               value: 'true'
           containers:
             - name: simple-game-server
-              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.42
+              image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
               args: [-automaticShutdownDelaySec=60, -readyIterations=10]
               resources:
                 limits:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Previously, tcpListener and udpListener were launched as goroutines and s.Ready() was called immediately after, with no guarantee that either goroutine had reached its net.Listen/net.ListenPacket call. On fast nodes (e.g. GKE Autopilot with a warm NAP node and cached image), the game server could become Ready in ~3 seconds, allowing the e2e test to attempt a TCP connection before the listener goroutine had been scheduled and bound its port — resulting in a flaky "connection refused" failure in TestGameServerTcpProtocol.

Fix this by using a sync.WaitGroup: each listener goroutine calls ready.Done() immediately after net.Listen/net.ListenPacket succeeds (the moment the OS has the port open and will buffer incoming connections/datagrams), and main() calls listenersReady.Wait() before invoking s.Ready(), guaranteeing the ports are bound before the GameServer is ever marked Ready.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A