### PR TITLE
build: pin codelytv/pr-size-labeler to commit SHA in pull_request_target workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@56070d7fa4db29f9f14e8002a08ed8e42412d4dd # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_max_size: '10'


### PR DESCRIPTION
/kind cleanup

  **What type of PR is this?**

  /kind cleanup

  **What this PR does / Why we need it**:

  Pins `codelytv/pr-size-labeler` to full commit SHA instead of mutable `v1` tag in the `labeler.yml` workflow.

  This workflow uses `pull_request_target` trigger which runs with write permissions on every PR from forks. Using a mutable tag reference means any compromise of the upstream action repository (tag move,
  account takeover) would execute arbitrary code with write access to this repository.

  Pinning to SHA ensures the action content is immutable and prevents supply chain attacks via tag manipulation.

  **Which issue(s) this PR fixes**:

  N/A — proactive security hardening

  **Special notes for your reviewer**:

  This follows GitHub's security best practice of pinning actions to full SHA in privileged workflows. See:
  https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions