### PR TITLE
 build: pin actions/github-script to commit SHA in pull_request_target workflow

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |-
             const keywords = {


### PR DESCRIPTION

  Pin `actions/github-script` to full commit SHA instead of mutable `v6` tag
  in the `label-pr.yml` workflow.

  This workflow uses `pull_request_target` trigger which runs with write
  permissions on every PR from forks. Pinning to SHA ensures immutability
  and prevents supply chain attacks via tag manipulation.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions