### PR TITLE
chore: upgrade website to Docsy 0.15.0

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -97,7 +97,7 @@ RUN go install github.com/extism/cli/extism@v1.6.3
 #     \_/\_/ \___|_.__/|___/_|\__\___|
 #
 
-ENV HUGO_VER=0.152.2
+ENV HUGO_VER=0.157.0
 RUN ARCH=$(dpkg --print-architecture) && \
     mkdir /tmp/hugo && \
     wget -q -O /tmp/hugo/hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_extended_${HUGO_VER}_linux-${ARCH}.tar.gz && \

--- a/site/go.mod
+++ b/site/go.mod
@@ -3,8 +3,3 @@ module github.com/agones/agones/site
 go 1.26
 
 require gopkg.in/yaml.v2 v2.4.0
-
-require (
-	github.com/google/docsy v0.14.3 // indirect
-	github.com/google/docsy/dependencies v0.7.2 // indirect
-)

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,11 +1,3 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.14.3 h1:4uFgPWTPj4NT79IboVkXGi49LLQadLVfU4WNOfD/s74=
-github.com/google/docsy v0.14.3/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
-github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
-github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
-github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
-github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Closes #4586

## Summary
Upgrades the Agones website from Docsy v0.14.3 to v0.15.0.

### Changes
- **site/go.mod**: Bump `github.com/google/docsy` from `v0.14.3` to `v0.15.0`
- **site/go.sum**: Regenerated via `go mod tidy`
- **build/build-image/Dockerfile**: Bump `HUGO_VER` from `0.152.2` to `0.157.0`

### New Features in Docsy 0.15.0
- Agent support (experimental): generates llms.txt and Markdown page output
- Doc-rooted sites (experimental)
- Enhanced version menu with headings, separators, per-entry styling

### Notes
- go.sum was regenerated cleanly via `go mod tidy`
- The version menu markup has breaking changes in Docsy 0.15.0 — verify custom CSS/layout overrides