### PR TITLE
pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -27,8 +27,8 @@ jobs:
   fossa:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: fossas/fossa-action@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # main
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           team: Agones

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |-
             const keywords = {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@fb469dd4372da087f5f75175cc5ff84fda82b837 # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_max_size: '10'

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Track Obsolete Issues
     steps:
       - name: Track stale issues and check if obsolete
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Automatically update PR
-        uses: adRise/update-pr-branch@v0.6.0
+        uses: adRise/update-pr-branch@af3debe20101b0f5debd9ba9f52f41b3cdcc142d # v0.6.0
         with:
           token: ${{ secrets.AGONES_BOT }}
           base: main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -29,7 +29,7 @@ jobs:
     name: stale issues
     steps:
       - name: Stale issues
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -14,8 +14,8 @@ jobs:
       - name: Run this workflow only every six weeks (fail this step the other five weeks)
         run: |
           if [[ $(("( $(date +%s) - $(date +%s --date=20250310) ) / 86400 % 42")) -eq  0 ]] then exit 0; else exit 1; fi
-      - uses: actions/checkout@v3
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / Why we need it:
Updates the GitHub Action references across the .github/workflows/ directory to use immutable commit SHAs instead of mutable tags (e.g., @v4, @main). Inline comments with the original version tags (like # v4) are preserved for easier future bumps.

Why: To ensure deterministic CI executions and fully align Agones with CNCF software supply chain security standards (specifically the OpenSSF Pin-Dependencies check).

Which issue(s) this PR fixes:
None.

Special notes for your reviewer:
Hi team, my studio is currently using Agones to orchestrate dedicated game servers for our multiplayer titles in production.

While conducting a recent internal software supply chain audit and referencing Agones' CI setups for our own custom SDK server build pipelines, we noticed that a few workflows (such as the fossa scanner, label-pr, and stale issues actions) were still using floating tags.

Since CNCF projects generally enforce strict SHA pinning to prevent tag-hijacking, and we rely heavily on the stability of this framework, I wanted to contribute this patch upstream to help tighten our shared infrastructure. All SHAs were resolved directly via git ls-remote from their upstream remotes. Thanks for the awesome project!