### PR TITLE
build: pin GHA to commit SHAs, add workflow permissions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,26 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# This workflow utilizes https://github.com/fossas/fossa-action in GitHub Actions to run FOSSA scans on the codebase
-#
-name: FOSSA
 
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-
-permissions: {}
-jobs:
-  fossa:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          team: Agones
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build"
+    labels:
+      - kind/cleanup

--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84  # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -23,13 +23,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 1 1,15 * *
+permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -30,8 +30,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3  # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           team: Agones

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6
         with:
           script: |-
             const keywords = {

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -17,6 +17,7 @@
 #
 name: Label PR
 on: [pull_request_target]
+permissions: {}
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -25,7 +26,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |-
             const keywords = {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
+      - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9  # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_max_size: '10'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,6 +17,7 @@
 name: labeler
 on:
   - pull_request_target
+permissions: {}
 jobs:
   labeler:
     runs-on: ubuntu-latest
@@ -25,7 +26,7 @@ jobs:
       pull-requests: write
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_max_size: '10'

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Track Obsolete Issues
     steps:
       - name: Track stale issues and check if obsolete
-        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84  # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -21,6 +21,7 @@ on:
   schedule:
     - cron: 0 2 1,15 * *
   workflow_dispatch:
+permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -29,7 +30,7 @@ jobs:
     name: Track Obsolete Issues
     steps:
       - name: Track stale issues and check if obsolete
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -21,6 +21,7 @@ name: PR update
 on:
   push:
     branches: [main]
+permissions: {}
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
@@ -29,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Automatically update PR
-        uses: adRise/update-pr-branch@v0.6.0
+        uses: adRise/update-pr-branch@437fab6e0ac7d2a668f2c479f64225edd7f303fd # v0.6.0
         with:
           token: ${{ secrets.AGONES_BOT }}
           base: main

--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Automatically update PR
-        uses: adRise/update-pr-branch@437fab6e0ac7d2a668f2c479f64225edd7f303fd # v0.6.0
+        uses: adRise/update-pr-branch@437fab6e0ac7d2a668f2c479f64225edd7f303fd  # v0.6.0
         with:
           token: ${{ secrets.AGONES_BOT }}
           base: main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -30,7 +30,7 @@ jobs:
     name: stale issues
     steps:
       - name: Stale issues
-        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84  # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -21,6 +21,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 10 1,15 * *
+permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -29,7 +30,7 @@ jobs:
     name: stale issues
     steps:
       - name: Stale issues
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -15,8 +15,8 @@ jobs:
       - name: Run this workflow only every six weeks (fail this step the other five weeks)
         run: |
           if [[ $(("( $(date +%s) - $(date +%s --date=20250310) ) / 86400 % 42")) -eq  0 ]] then exit 0; else exit 1; fi
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -3,6 +3,7 @@ name: Update Dependencies
 on:
   schedule:
     - cron: 0 0 * * 1
+permissions: {}
 jobs:
   create_issue:
     name: Create update dependency issue once every six weeks
@@ -14,8 +15,8 @@ jobs:
       - name: Run this workflow only every six weeks (fail this step the other five weeks)
         run: |
           if [[ $(("( $(date +%s) - $(date +%s --date=20250310) ) / 86400 % 42")) -eq  0 ]] then exit 0; else exit 1; fi
-      - uses: actions/checkout@v3
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Pin all GitHub Actions references to immutable commit SHAs with inline version comments. Upgrade fossas/fossa-action from @main to v1.9.0. Add top-level permissions: {} to all workflow files and a missing contents: read block to fossa.yml (fixes code scanning alert #23). Add .github/dependabot.yml to enable weekly version update PRs for GitHub Actions.

This was done (a) because it's a good idea, and (b) because we kept getting malicious PRs trying to get us to point GitHub Actions to invalid SHA targets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions recommends this.