### PR TITLE
chore: promote PortPolicyNone feature gate from Beta to Stable

### DIFF
--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -46,7 +46,6 @@ spec:
       # port is available. When static is the policy specified, `hostPort` is required to be populated
       # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
       #      This will mean that users will need to lookup what port has been opened through the server side SDK.
-      # [Stage:Beta]
       # [FeatureFlag:PortPolicyNone]
       # - "None" means the `hostPort` is ignored and if defined, the `containerPort` (optional) is used to set the port on the GameServer instance.
       portPolicy: Dynamic
@@ -85,7 +84,6 @@ spec:
     # conflict with other TCP connections.
     grpcPort: 9357
     httpPort: 9358
-  # [Stage:Beta]
   # [FeatureFlag:CountsAndLists]
   # Counts and Lists provides the configuration for generic (player, room, session, etc.) tracking features.
   # Now in Beta, and enabled by default

--- a/examples/gameserver.yaml
+++ b/examples/gameserver.yaml
@@ -46,7 +46,6 @@ spec:
       # port is available. When static is the policy specified, `hostPort` is required to be populated
       # - "Passthrough" dynamically sets the `containerPort` to the same value as the dynamically selected hostPort.
       #      This will mean that users will need to lookup what port has been opened through the server side SDK.
-      # [FeatureFlag:PortPolicyNone]
       # - "None" means the `hostPort` is ignored and if defined, the `containerPort` (optional) is used to set the port on the GameServer instance.
       portPolicy: Dynamic
       # The name of the container to open the port on. Defaults to the game server container if omitted or empty.
@@ -84,6 +83,7 @@ spec:
     # conflict with other TCP connections.
     grpcPort: 9357
     httpPort: 9358
+  # [Stage:Beta]
   # [FeatureFlag:CountsAndLists]
   # Counts and Lists provides the configuration for generic (player, room, session, etc.) tracking features.
   # Now in Beta, and enabled by default

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -36,6 +36,8 @@ const (
 
 	// FeatureAutopilotPassthroughPort is a feature flag that enables/disables Passthrough Port Policy.
 	FeatureAutopilotPassthroughPort Feature = "AutopilotPassthroughPort"
+		// FeaturePortPolicyNone is a feature flag to allow setting Port Policy to None.
+		FeaturePortPolicyNone Feature = "PortPolicyNone"
 
 	// FeaturePortRanges is a feature flag to enable/disable specific port ranges.
 	FeaturePortRanges Feature = "PortRanges"
@@ -152,6 +154,7 @@ var (
 		// previous version with the feature flag do not fail on parsing an unknown flag.
 		FeatureDisableResyncOnSDKServer: true,
 		FeatureAutopilotPassthroughPort: true,
+			FeaturePortPolicyNone:           true,
 		FeaturePortRanges:               true,
 		FeatureRollingUpdateFix:         true,
 

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -56,9 +56,6 @@ const (
 	// when Agones is running on Autopilot. Available on 1.28+ only.
 	FeatureGKEAutopilotExtendedDurationPods = "GKEAutopilotExtendedDurationPods"
 
-	// FeaturePortPolicyNone is a feature flag to allow setting Port Policy to None.
-	FeaturePortPolicyNone Feature = "PortPolicyNone"
-
 	// FeatureScheduledAutoscaler is a feature flag to enable/disable scheduled fleet autoscaling.
 	FeatureScheduledAutoscaler Feature = "ScheduledAutoscaler"
 
@@ -154,14 +151,13 @@ var (
 		// previous version with the feature flag do not fail on parsing an unknown flag.
 		FeatureDisableResyncOnSDKServer: true,
 		FeatureAutopilotPassthroughPort: true,
-				FeaturePortPolicyNone:                   true,
+		FeaturePortPolicyNone:           true,
 		FeaturePortRanges:               true,
 		FeatureRollingUpdateFix:         true,
 
 		// Beta features
 		FeatureCountsAndLists:                   true,
 		FeatureGKEAutopilotExtendedDurationPods: true,
-				FeaturePortPolicyNone:                   true,
 		FeatureScheduledAutoscaler:              true,
 		FeatureFleetAutoscaleRequestMetaData:    true,
 		FeatureSidecarContainers:                true,

--- a/pkg/util/runtime/features.go
+++ b/pkg/util/runtime/features.go
@@ -36,8 +36,8 @@ const (
 
 	// FeatureAutopilotPassthroughPort is a feature flag that enables/disables Passthrough Port Policy.
 	FeatureAutopilotPassthroughPort Feature = "AutopilotPassthroughPort"
-		// FeaturePortPolicyNone is a feature flag to allow setting Port Policy to None.
-		FeaturePortPolicyNone Feature = "PortPolicyNone"
+	// FeaturePortPolicyNone is a feature flag to allow setting Port Policy to None.
+	FeaturePortPolicyNone Feature = "PortPolicyNone"
 
 	// FeaturePortRanges is a feature flag to enable/disable specific port ranges.
 	FeaturePortRanges Feature = "PortRanges"
@@ -154,14 +154,14 @@ var (
 		// previous version with the feature flag do not fail on parsing an unknown flag.
 		FeatureDisableResyncOnSDKServer: true,
 		FeatureAutopilotPassthroughPort: true,
-			FeaturePortPolicyNone:           true,
+				FeaturePortPolicyNone:                   true,
 		FeaturePortRanges:               true,
 		FeatureRollingUpdateFix:         true,
 
 		// Beta features
 		FeatureCountsAndLists:                   true,
 		FeatureGKEAutopilotExtendedDurationPods: true,
-		FeaturePortPolicyNone:                   true,
+				FeaturePortPolicyNone:                   true,
 		FeatureScheduledAutoscaler:              true,
 		FeatureFleetAutoscaleRequestMetaData:    true,
 		FeatureSidecarContainers:                true,

--- a/site/content/en/docs/Guides/feature-stages.md
+++ b/site/content/en/docs/Guides/feature-stages.md
@@ -40,7 +40,7 @@ The current set of `alpha`, `beta` and `stable` feature gates include:
 |------------------------------------------------------------------------------------------------------------------------|------------------------------------|---------|--------|--------|
 | [CountsAndLists](https://github.com/agones-dev/agones/issues/2716)                                                     | `CountsAndLists`                   | Enabled | `Beta` | 1.41.0 |
 | [Support for Extended Duration Pods on GKE Autopilot (*1.28+ only*)](https://github.com/agones-dev/agones/issues/3386) | `GKEAutopilotExtendedDurationPods` | Enabled | `Beta` | 1.44.0 |
-| [Port Policy None](https://github.com/agones-dev/agones/issues/3804)                                                   | `PortPolicyNone`                   | Enabled | `Beta` | 1.49.0 |
+| [Port Policy None](https://github.com/agones-dev/agones/issues/3804)                                                   | `PortPolicyNone`                   | Enabled | `Stable` | 1.59.0 |
 | [Scheduled Fleet Autoscaling](https://github.com/agones-dev/agones/issues/3008)                                        | `ScheduledAutoscaler`              | Enabled | `Beta` | 1.51.0 |
 | [Extend Webhook autoscaler to send fleet metadata with the request](https://github.com/agones-dev/agones/issues/3951)  | `FleetAutoscaleRequestMetaData`    | Enabled | `Beta` | 1.54.0 |
 | [Sidecar Containers](https://github.com/agones-dev/agones/issues/3642)                                                 | `SidecarContainers`                | Enabled | `Beta` | 1.56.0 |


### PR DESCRIPTION
Closes #4587

Promotes the PortPolicyNone feature gate from Beta to Stable.
Changes:
pkg/util/runtime/features.go: Move FeaturePortPolicyNone from Beta to Stable section
pkg/apis/agones/v1/gameserver.go: Remove FeaturePortPolicyNone guards; fold logic unconditionally
pkg/cloudproduct/gke/gke.go:  Remove FeaturePortPolicyNone check
pkg/apis/agones/v1/gameserver_test.go : Remove feature-gate-disabled test case and ParseFeatures call
pkg/cloudproduct/gke/gke_test.go : Remove portPolicyNoneFlag field, disabled test case and feature gate block
pkg/gameservers/gameservers_test.go : Remove ParseFeatures call
test/e2e/gameserver_test.go : Remove t.SkipNow guard from TestGameServerPortPolicyNone
install/helm/agones/defaultfeaturegates.yaml : Move PortPolicyNone to Stable section
build/Makefile : Remove PortPolicyNone from BETA_FEATURE_GATES
cloudbuild.yaml : Remove PortPolicyNone=false from inverted e2e config
site/content/en/docs/Guides/feature-stages.md : Move row to Stable table
test/upgrade/versionMap.yaml : Add stableGates entry for 1.59.0

