### PR TITLE
build: fix ci - pin python grpc-tools

### DIFF
--- a/build/build-sdk-images/python/gen.sh
+++ b/build/build-sdk-images/python/gen.sh
@@ -17,5 +17,5 @@
 set -ex
 cd /go/src/agones.dev/agones/sdks/python
 python3 -m venv .venv
-.venv/bin/pip install grpcio-tools
+.venv/bin/pip install grpcio-tools==1.80.0
 PATH="$(pwd)/.venv/bin:$PATH" bash generate.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

They released a new grpc-tools, and it broke ci.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Noticed this in https://github.com/agones-dev/agones/pull/4601

**Special notes for your reviewer**:

Unblock CI.


