### PR TITLE
Fix/nil pointer dereference updatelist

### DIFF
--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -1161,7 +1161,7 @@ func (s *SDKServer) UpdateList(ctx context.Context, in *beta.UpdateListRequest) 
 	list, err := s.GetList(ctx, &beta.GetListRequest{Name: in.List.Name})
 	if err != nil {
 
-		return nil, errors.Errorf("not found. %s List not found", list.Name)
+		return nil, errors.Errorf("not found. %s List not found", in.List.Name)
 	}
 
 	s.gsUpdateMutex.Lock()
@@ -1604,11 +1604,17 @@ func (s *SDKServer) GsListsMaxItems(ctx context.Context) error {
 	if s.namespace == "default" {
 		labelsName = "fleet-example"
 	} else {
-		gs, _ := s.gameServerGetter.GameServers(s.namespace).Get(
+		gs, err := s.gameServerGetter.GameServers(s.namespace).Get(
 			ctx,
 			s.gameServerName,
 			metav1.GetOptions{},
 		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get GameServer %s", s.gameServerName)
+		}
+		if gs == nil {
+			return errors.Errorf("retrieved nil GameServer %s", s.gameServerName)
+		}
 		labelsName = gs.ObjectMeta.Labels[agonesv1.FleetNameLabel]
 	}
 	selector := labels.Set{

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -1782,6 +1782,20 @@ func TestSDKServerUpdateList(t *testing.T) {
 			updated:                 true,
 			expectedUpdatesQueueLen: 0,
 		},
+		"update list not found (potential panic)": {
+			listName: "nonexistent",
+			request: &beta.UpdateListRequest{
+				List: &beta.List{
+					Name:     "nonexistent",
+					Capacity: int64(100),
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"capacity"}},
+			},
+			want:                    agonesv1.ListStatus{},
+			updateErr:               true,
+			updated:                 false,
+			expectedUpdatesQueueLen: 0,
+		},
 	}
 	// Maximum capacity for the game server list.
 	// of game server items the system can manage at once.
@@ -1838,13 +1852,19 @@ func TestSDKServerUpdateList(t *testing.T) {
 			// check initial value comes through
 			require.Eventually(t, func() bool {
 				list, err := sc.GetList(context.Background(), &beta.GetListRequest{Name: testCase.listName})
-				return cmp.Equal(list.Values, []string{"one", "two", "three", "four"}) && list.Capacity == 100 && err == nil
+				if testCase.listName == "nonexistent" {
+					return list == nil && err != nil
+				}
+				return list != nil && cmp.Equal(list.Values, []string{"one", "two", "three", "four"}) && list.Capacity == 100 && err == nil
 			}, 10*time.Second, time.Second)
 
 			// Update the List
 			_, err = sc.UpdateList(context.Background(), testCase.request)
 			if testCase.updateErr {
 				assert.Error(t, err)
+				cancel()
+				wg.Wait()
+				return
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -1865,9 +1865,8 @@ func TestSDKServerUpdateList(t *testing.T) {
 				cancel()
 				wg.Wait()
 				return
-			} else {
-				assert.NoError(t, err)
 			}
+			assert.NoError(t, err)
 
 			got, err := sc.GetList(context.Background(), &beta.GetListRequest{Name: testCase.listName})
 			assert.NoError(t, err)


### PR DESCRIPTION
/kind bug

**What this PR does / Why we need it:**
Fixes two nil pointer dereference issues in `UpdateList` and `GsListsMaxItems`:

1. In `UpdateList`: when `GetList` returns an error, `list` is nil : the original code referenced `list.Name` which would panic. Fixed to use `in.List.Name` instead.
2. In `GsListsMaxItems`: the error from `GameServers.Get()` was being silently ignored (`gs, _`). Fixed to properly handle the error and guard against a nil `gs`.

**Which issue(s) this PR fixes:**
Originally reported via GitHub Security Advisory (GHSA-f535-v67w-233h).

**Special notes for your reviewer:**
This is the public version of the advisory PR : moved here since the merge status was unavailable in the private advisory repo. Regression test included to prevent future regressions.