### PR TITLE
fix: Fix flapping with list-based FleetAutoscaler

### DIFF
--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -694,17 +694,23 @@ func isScheduleActive(s *autoscalingv1.SchedulePolicy, currentTime time.Time) bo
 	return false
 }
 
-// getSortedGameServers returns the list of Game Servers for the Fleet in the order in which the
+// getSortedDeletableGameServers returns the list of Game Servers for the Fleet in the order in which the
 // Game Servers would be deleted.
-func getSortedGameServers(f *agonesv1.Fleet, gameServerNamespacedLister listeragonesv1.GameServerNamespaceLister,
+func getSortedDeletableGameServers(f *agonesv1.Fleet, gameServerNamespacedLister listeragonesv1.GameServerNamespaceLister,
 	nodeCounts map[string]gameservers.NodeCount) ([]*agonesv1.GameServer, error) {
 	gsList, err := fleets.ListGameServersByFleetOwner(gameServerNamespacedLister, f)
 	if err != nil {
 		return nil, err
 	}
 
-	gameServers := gssets.SortGameServersByStrategy(f.Spec.Scheduling, gsList, nodeCounts, f.Spec.Priorities)
-	return gameServers, nil
+	deletable := make([]*agonesv1.GameServer, 0, len(gsList))
+	for _, gs := range gsList {
+		if gs.IsDeletable() {
+			deletable = append(deletable, gs)
+		}
+	}
+
+	return gssets.SortGameServersByStrategy(f.Spec.Scheduling, deletable, nodeCounts, f.Spec.Priorities), nil
 }
 
 // isLimited indicates that the calculated scale would be above or below the range defined by
@@ -738,7 +744,7 @@ func scaleDownLimited(f *agonesv1.Fleet, gameServerNamespacedLister listeragones
 	nodeCounts map[string]gameservers.NodeCount, key string, isCounter bool, replicas int32,
 	aggCapacity, maxCapacity int64) (int32, bool, error) {
 	// Game Servers in order of deletion on scale down
-	gameServers, err := getSortedGameServers(f, gameServerNamespacedLister, nodeCounts)
+	gameServers, err := getSortedDeletableGameServers(f, gameServerNamespacedLister, nodeCounts)
 	if err != nil {
 		return 0, false, err
 	}
@@ -809,14 +815,14 @@ func scaleUp(replicas int32, capacity, count, aggCapacity, availableCapacity, ma
 func scaleDown(f *agonesv1.Fleet, gameServerNamespacedLister listeragonesv1.GameServerNamespaceLister,
 	nodeCounts map[string]gameservers.NodeCount, key string, isCounter bool, replicas int32,
 	aggCount, aggCapacity, minCapacity, buffer int64) (int32, bool, error) {
-	// Exit early if we're already at MinCapacity to avoid calling getSortedGameServers if unnecessary
+	// Exit early if we're already at MinCapacity to avoid calling getSortedDeletableGameServers if unnecessary
 	if aggCapacity == minCapacity {
 		return replicas, true, nil
 	}
 
 	// We first need to get the individual game servers in order of deletion on scale down, as any
 	// game server may have a unique value for counts and / or capacity.
-	gameServers, err := getSortedGameServers(f, gameServerNamespacedLister, nodeCounts)
+	gameServers, err := getSortedDeletableGameServers(f, gameServerNamespacedLister, nodeCounts)
 	if err != nil {
 		return 0, false, err
 	}

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -2464,6 +2464,157 @@ func TestApplyListPolicy(t *testing.T) {
 	}
 }
 
+// TestApplyListPolicyFlapping covers a List based FleetAutoscaler flapping bug where scale down
+// logic counted un-deletable (Allocated) game servers toward a reduction, along with scaling up
+// and down against the Min/MaxCapacity limiter.
+func TestApplyListPolicyFlapping(t *testing.T) {
+	utilruntime.FeatureTestMutex.Lock()
+	defer utilruntime.FeatureTestMutex.Unlock()
+
+	require.NoError(t, utilruntime.ParseFeatures(string(utilruntime.FeatureCountsAndLists)+"=true"))
+
+	// One replica provides 60 capacity; the buffer wants 120 available.
+	lp := &autoscalingv1.ListPolicy{
+		Key:         "players",
+		MaxCapacity: 300,
+		MinCapacity: 120,
+		BufferSize:  intstr.FromInt(120),
+	}
+
+	nc := map[string]gameservers.NodeCount{
+		"n1": {Ready: 2},
+		"n2": {Allocated: 1},
+	}
+
+	players := make([]string, 55)
+	for i := range players {
+		players[i] = fmt.Sprintf("player-%d", i)
+	}
+
+	newFleet := func(mutate func(*agonesv1.Fleet)) *agonesv1.Fleet {
+		_, f := defaultFixtures()
+		f.Spec.Template.Spec.Lists = map[string]agonesv1.ListStatus{
+			"players": {Values: []string{}, Capacity: 60},
+		}
+		mutate(f)
+		return f
+	}
+
+	// Full, Allocated (un-deletable) game server.
+	allocatedGS := func(name string) agonesv1.GameServer {
+		return agonesv1.GameServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    map[string]string{"agones.dev/fleet": "fleet-1"}},
+			Status: agonesv1.GameServerStatus{
+				State:    agonesv1.GameServerStateAllocated,
+				NodeName: "n2",
+				Lists: map[string]agonesv1.ListStatus{
+					"players": {Values: players, Capacity: 60},
+				}}}
+	}
+
+	// Empty, Ready (deletable) game server.
+	readyGS := func(name string) agonesv1.GameServer {
+		return agonesv1.GameServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    map[string]string{"agones.dev/fleet": "fleet-1"}},
+			Status: agonesv1.GameServerStatus{
+				State:    agonesv1.GameServerStateReady,
+				NodeName: "n1",
+				Lists: map[string]agonesv1.ListStatus{
+					"players": {Values: []string{}, Capacity: 60},
+				}}}
+	}
+
+	type expected struct {
+		replicas int32
+		limited  bool
+	}
+
+	testCases := map[string]struct {
+		fleet  *agonesv1.Fleet
+		gsList []agonesv1.GameServer
+		want   expected
+	}{
+		"scale up to satisfy buffer": {
+			fleet: newFleet(func(f *agonesv1.Fleet) {
+				f.Status.Replicas = 2
+				f.Status.ReadyReplicas = 1
+				f.Status.AllocatedReplicas = 1
+				f.Status.Lists = map[string]agonesv1.AggregatedListStatus{
+					"players": {Count: 55, Capacity: 120, AllocatedCount: 55, AllocatedCapacity: 60},
+				}
+			}),
+			gsList: []agonesv1.GameServer{allocatedGS("hub-allocated"), readyGS("hub-empty-1"), readyGS("hub-empty-2")},
+			want:   expected{replicas: 3, limited: false},
+		},
+		// At 3 replicas the fleet is stable
+		"stable at buffer, no flap down": {
+			fleet: newFleet(func(f *agonesv1.Fleet) {
+				f.Status.Replicas = 3
+				f.Status.ReadyReplicas = 2
+				f.Status.AllocatedReplicas = 1
+				f.Status.Lists = map[string]agonesv1.AggregatedListStatus{
+					"players": {Count: 55, Capacity: 180, AllocatedCount: 55, AllocatedCapacity: 60},
+				}
+			}),
+			gsList: []agonesv1.GameServer{allocatedGS("hub-allocated"), readyGS("hub-empty-1"), readyGS("hub-empty-2")},
+			want:   expected{replicas: 3, limited: false},
+		},
+		// Below MinCapacity, so scale up to the minimum
+		"limited up to MinCapacity": {
+			fleet: newFleet(func(f *agonesv1.Fleet) {
+				f.Status.Replicas = 1
+				f.Status.ReadyReplicas = 0
+				f.Status.AllocatedReplicas = 1
+				f.Status.Lists = map[string]agonesv1.AggregatedListStatus{
+					"players": {Count: 55, Capacity: 60, AllocatedCount: 55, AllocatedCapacity: 60},
+				}
+			}),
+			gsList: []agonesv1.GameServer{allocatedGS("hub-allocated")},
+			want:   expected{replicas: 2, limited: true},
+		},
+		// Above MaxCapacity, but every server is Allocated and so nothing happens (intended)
+		"limited down blocked by allocated servers": {
+			fleet: newFleet(func(f *agonesv1.Fleet) {
+				f.Status.Replicas = 6
+				f.Status.ReadyReplicas = 0
+				f.Status.AllocatedReplicas = 6
+				f.Status.Lists = map[string]agonesv1.AggregatedListStatus{
+					"players": {Count: 330, Capacity: 360, AllocatedCount: 330, AllocatedCapacity: 360},
+				}
+			}),
+			gsList: []agonesv1.GameServer{
+				allocatedGS("hub-1"), allocatedGS("hub-2"), allocatedGS("hub-3"),
+				allocatedGS("hub-4"), allocatedGS("hub-5"), allocatedGS("hub-6"),
+			},
+			want: expected{replicas: 6, limited: true},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			m := agtesting.NewMocks()
+			m.AgonesClient.AddReactor("list", "gameservers", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &agonesv1.GameServerList{Items: tc.gsList}, nil
+			})
+			informer := m.AgonesInformerFactory.Agones().V1()
+			_, cancel := agtesting.StartInformers(m, informer.GameServers().Informer().HasSynced)
+			defer cancel()
+			lister := informer.GameServers().Lister().GameServers("default")
+
+			replicas, limited, err := applyCounterOrListPolicy(nil, lp, tc.fleet, lister, nc)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want.limited, limited)
+			assert.Equal(t, tc.want.replicas, replicas)
+		})
+	}
+}
+
 // nolint:dupl  // Linter errors on lines are duplicate of TestApplySchedulePolicy
 // NOTE: Does not test for the validity of a fleet autoscaler policy (ValidateSchedulePolicy)
 func TestApplySchedulePolicy(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

### **What type of PR is this?**

/kind bug

### **What this PR does / Why we need it**:

There is an issue caused by inconsistencies in FleetAutoscaler upscale logic and downscale logic, resulting in flapping when using a List based policy. This was reported [here](https://agones.slack.com/archives/C9DGM5DS8/p1779029384013789) on Slack.

---

The root cause of the problem is due to the way that downscale decisions are made. The downscale logic:
1. Gets the list of current GameServers
2. Simulates a deletion
3. Checks whether doing such would cause a server to need to be added again according to the list policy
 
The first two steps were implemented in a way that does not match how Fleets will actually choose to delete a server, as it doesn't exclude GameServers that would normally be considered undeletable. This inconsistency between the simulated deletion and actual deletion logic is what leads to constant upscaling and downscaling (flapping).

---

The first commit on this PR implements a test to reproduce the issue described, and to help check for regressions in the future.

The second commit on the PR implements the logic in FleetAutoscaler to correctly check which servers would be deleted on a downscale.

### **Which issue(s) this PR fixes**:

Addresses the issue raised on Slack [here](https://agones.slack.com/archives/C9DGM5DS8/p1779029384013789).

### **Did you use AI tools in preparing this PR?**:

No

### **Special notes for your reviewer:**

A build of this code was tested by the user that originally reported the issue on Slack. They are able to confirm that it fixes the original issue.