### PR TITLE
test: fix allocator e2e tests hanging on unresponsive gRPC server

### DIFF
--- a/test/e2e/allocator_test.go
+++ b/test/e2e/allocator_test.go
@@ -86,35 +86,29 @@ func TestAllocatorWithDeprecatedRequired(t *testing.T) {
 
 	var response *pb.AllocationResponse
 	// wait for the allocation system to come online
-	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// create the grpc client each time, as we may end up looking at an old cert
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 		dialOpts, err := helper.CreateRemoteClusterDialOptions(ctx, allocatorClientSecretNamespace, allocatorClientSecretName, tlsCA, framework)
-		if err != nil {
-			return false, err
-		}
+		require.NoError(c, err)
 
 		conn, err := grpc.NewClient(requestURL, dialOpts...)
-		if err != nil {
-			logrus.WithError(err).Info("failing grpc.NewClient")
-			return false, nil
-		}
+		require.NoError(c, err, "failing grpc.NewClient")
 		defer conn.Close() // nolint: errcheck
 
 		grpcClient := pb.NewAllocationServiceClient(conn)
-		response, err = grpcClient.Allocate(context.Background(), request)
-		if err != nil {
-			logrus.WithError(err).Info("failing Allocate request")
-			return false, nil
-		}
+		response, err = grpcClient.Allocate(ctx, request)
+		require.NoError(c, err, "failing Allocate request")
 		helper.ValidateAllocatorResponse(t, response)
 
 		// let's do a re-allocation
 		if runtime.FeatureEnabled(runtime.FeaturePlayerAllocationFilter) {
 			// nolint:staticcheck
 			request.PreferredGameServerSelectors[0].GameServerState = pb.GameServerSelector_ALLOCATED
-			allocatedResponse, err := grpcClient.Allocate(context.Background(), request)
-			require.NoError(t, err)
-			require.Equal(t, response.GameServerName, allocatedResponse.GameServerName)
+			allocatedResponse, err := grpcClient.Allocate(ctx, request)
+			require.NoError(c, err)
+			require.Equal(c, response.GameServerName, allocatedResponse.GetGameServerName())
 			helper.ValidateAllocatorResponse(t, allocatedResponse)
 
 			// do a capacity based allocation
@@ -124,9 +118,9 @@ func TestAllocatorWithDeprecatedRequired(t *testing.T) {
 				MinAvailable: 5,
 				MaxAvailable: 10,
 			}
-			allocatedResponse, err = grpcClient.Allocate(context.Background(), request)
-			require.NoError(t, err)
-			require.Equal(t, response.GameServerName, allocatedResponse.GameServerName)
+			allocatedResponse, err = grpcClient.Allocate(ctx, request)
+			require.NoError(c, err)
+			require.Equal(c, response.GameServerName, allocatedResponse.GetGameServerName())
 			helper.ValidateAllocatorResponse(t, allocatedResponse)
 
 			// do a capacity based allocation that should fail
@@ -137,17 +131,13 @@ func TestAllocatorWithDeprecatedRequired(t *testing.T) {
 			// nolint:staticcheck
 			request.RequiredGameServerSelector.Players = &pb.PlayerSelector{MinAvailable: 99, MaxAvailable: 200}
 
-			allocatedResponse, err = grpcClient.Allocate(context.Background(), request)
-			assert.Nil(t, allocatedResponse)
+			allocatedResponse, err = grpcClient.Allocate(ctx, request)
+			require.Nil(c, allocatedResponse)
 			status, ok := status.FromError(err)
-			require.True(t, ok)
-			assert.Equal(t, codes.ResourceExhausted, status.Code())
+			require.True(c, ok)
+			require.Equal(c, codes.ResourceExhausted, status.Code())
 		}
-
-		return true, nil
-	})
-
-	require.NoError(t, err)
+	}, 5*time.Minute, 2*time.Second)
 }
 
 func TestAllocatorWithSelectors(t *testing.T) {
@@ -181,36 +171,30 @@ func TestAllocatorWithSelectors(t *testing.T) {
 
 	var response *pb.AllocationResponse
 	// wait for the allocation system to come online
-	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// create the grpc client each time, as we may end up looking at an old cert
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		dialOpts, err := helper.CreateRemoteClusterDialOptions(ctx, allocatorClientSecretNamespace, allocatorClientSecretName, tlsCA, framework)
-		if err != nil {
-			return false, err
-		}
+		require.NoError(c, err)
 
 		conn, err := grpc.NewClient(requestURL, dialOpts...)
-		if err != nil {
-			logrus.WithError(err).Info("failing grpc.NewClient")
-			return false, nil
-		}
+		require.NoError(c, err, "failing grpc.NewClient")
 		defer conn.Close() // nolint: errcheck
 
 		grpcClient := pb.NewAllocationServiceClient(conn)
-		response, err = grpcClient.Allocate(context.Background(), request)
-		if err != nil {
-			logrus.WithError(err).Info("failing Allocate request")
-			return false, nil
-		}
+		response, err = grpcClient.Allocate(ctx, request)
+		require.NoError(c, err, "failing Allocate request")
 		helper.ValidateAllocatorResponse(t, response)
 
 		// let's do a re-allocation
 		if runtime.FeatureEnabled(runtime.FeaturePlayerAllocationFilter) {
 			request.GameServerSelectors[0].GameServerState = pb.GameServerSelector_ALLOCATED
-			allocatedResponse, err := grpcClient.Allocate(context.Background(), request)
-			require.NoError(t, err)
-			require.Equal(t, response.GameServerName, allocatedResponse.GameServerName)
+			allocatedResponse, err := grpcClient.Allocate(ctx, request)
+			assert.NoError(c, err)
+			assert.Equal(c, response.GameServerName, allocatedResponse.GetGameServerName())
 			helper.ValidateAllocatorResponse(t, allocatedResponse)
-			assert.Equal(t, flt.ObjectMeta.Name, allocatedResponse.Metadata.Labels[agonesv1.FleetNameLabel])
+			assert.Equal(c, flt.ObjectMeta.Name, allocatedResponse.GetMetadata().GetLabels()[agonesv1.FleetNameLabel])
 
 			// do a capacity based allocation
 			logrus.Info("testing capacity allocation filter")
@@ -218,26 +202,22 @@ func TestAllocatorWithSelectors(t *testing.T) {
 				MinAvailable: 5,
 				MaxAvailable: 10,
 			}
-			allocatedResponse, err = grpcClient.Allocate(context.Background(), request)
-			require.NoError(t, err)
-			require.Equal(t, response.GameServerName, allocatedResponse.GameServerName)
+			allocatedResponse, err = grpcClient.Allocate(ctx, request)
+			assert.NoError(c, err)
+			assert.Equal(c, response.GameServerName, allocatedResponse.GetGameServerName())
 			helper.ValidateAllocatorResponse(t, allocatedResponse)
 
 			// do a capacity based allocation that should fail
 			request.GameServerSelectors[0].GameServerState = pb.GameServerSelector_ALLOCATED
 			request.GameServerSelectors[0].Players = &pb.PlayerSelector{MinAvailable: 99, MaxAvailable: 200}
 
-			allocatedResponse, err = grpcClient.Allocate(context.Background(), request)
-			assert.Nil(t, allocatedResponse)
+			allocatedResponse, err = grpcClient.Allocate(ctx, request)
+			assert.Nil(c, allocatedResponse)
 			status, ok := status.FromError(err)
-			require.True(t, ok)
-			assert.Equal(t, codes.ResourceExhausted, status.Code())
+			assert.True(c, ok)
+			assert.Equal(c, codes.ResourceExhausted, status.Code())
 		}
-
-		return true, nil
-	})
-
-	assert.NoError(t, err)
+	}, 5*time.Minute, 2*time.Second)
 }
 
 func TestRestAllocatorWithDeprecatedRequired(t *testing.T) {
@@ -363,33 +343,26 @@ func TestAllocatorWithCountersAndLists(t *testing.T) {
 			},
 		},
 	}
-	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		dialOpts, err := helper.CreateRemoteClusterDialOptions(ctx, allocatorClientSecretNamespace, allocatorClientSecretName, tlsCA, framework)
-		if err != nil {
-			return false, err
-		}
+		require.NoError(c, err)
 		conn, err := grpc.NewClient(requestURL, dialOpts...)
-		if err != nil {
-			logrus.WithError(err).Info("failing grpc.NewClient")
-			return false, nil
-		}
+		require.NoError(c, err, "failing grpc.NewClient")
 		defer conn.Close() // nolint: errcheck
 
 		grpcClient := pb.NewAllocationServiceClient(conn)
-		response, err := grpcClient.Allocate(context.Background(), request)
-		if err != nil {
-			return false, nil
-		}
-		assert.Contains(t, response.GetCounters(), "players")
-		assert.Equal(t, int64(10), response.GetCounters()["players"].Capacity.GetValue())
-		assert.Equal(t, int64(1), response.GetCounters()["players"].Count.GetValue())
-		assert.Contains(t, response.GetLists(), "rooms")
-		assert.Equal(t, int64(10), response.GetLists()["rooms"].Capacity.GetValue())
-		assert.EqualValues(t, request.Lists["rooms"].AddValues, response.GetLists()["rooms"].Values)
-		assert.NotEqualValues(t, request.Lists["rooms"].DeleteValues, response.GetLists()["rooms"].Values)
-		return true, nil
-	})
-	require.NoError(t, err)
+		response, err := grpcClient.Allocate(ctx, request)
+		require.NoError(c, err)
+		assert.Contains(c, response.GetCounters(), "players")
+		assert.Equal(c, int64(10), response.GetCounters()["players"].Capacity.GetValue())
+		assert.Equal(c, int64(1), response.GetCounters()["players"].Count.GetValue())
+		assert.Contains(c, response.GetLists(), "rooms")
+		assert.Equal(c, int64(10), response.GetLists()["rooms"].Capacity.GetValue())
+		assert.EqualValues(c, request.Lists["rooms"].AddValues, response.GetLists()["rooms"].Values)
+		assert.NotEqualValues(c, request.Lists["rooms"].DeleteValues, response.GetLists()["rooms"].Values)
+	}, 5*time.Minute, 2*time.Second)
 }
 
 func TestRestAllocatorWithCountersAndLists(t *testing.T) {
@@ -626,29 +599,20 @@ func TestAllocatorCrossNamespace(t *testing.T) {
 	}
 
 	// wait for the allocation system to come online
-	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// create the grpc client each time, as we may end up looking at an old cert
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		dialOpts, err := helper.CreateRemoteClusterDialOptions(ctx, namespaceA, allocatorClientSecretName, tlsCA, framework)
-		if err != nil {
-			return false, err
-		}
+		require.NoError(c, err)
 
 		conn, err := grpc.NewClient(requestURL, dialOpts...)
-		if err != nil {
-			logrus.WithError(err).Info("failing grpc.NewClient")
-			return false, nil
-		}
+		require.NoError(c, err, "failing grpc.NewClient")
 		defer conn.Close() // nolint: errcheck
 
 		grpcClient := pb.NewAllocationServiceClient(conn)
-		response, err := grpcClient.Allocate(context.Background(), request)
-		if err != nil {
-			logrus.WithError(err).Info("failing Allocate request")
-			return false, nil
-		}
+		response, err := grpcClient.Allocate(ctx, request)
+		require.NoError(c, err, "failing Allocate request")
 		helper.ValidateAllocatorResponse(t, response)
-		return true, nil
-	})
-
-	assert.NoError(t, err)
+	}, 5*time.Minute, 2*time.Second)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Replace wait.PollUntilContextTimeout with require.EventuallyWithT in the four gRPC allocator tests for better error reporting. Add a 10-second context.WithTimeout to every grpcClient.Allocate call so a hung allocator server can no longer block a goroutine indefinitely.

Fixes the 45-minute hang seen in TestAllocatorCrossNamespace where grpcClient.Allocate was called with context.Background() inside a PollUntilContextTimeout loop, making it impossible to cancel when the poll deadline expired.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
N/A

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

Saw this first here: https://console.cloud.google.com/cloud-build/builds/a24dc4fa-ca00-4097-9b54-1cc9a04a48db;step=1?project=agones-images
