### PR TITLE
build: replace MetalLB with minikube tunnel for LoadBalancer support

### DIFF
--- a/build/includes/minikube.mk
+++ b/build/includes/minikube.mk
@@ -38,21 +38,7 @@ minikube_cert_mount := ~/.minikube:$(HOME)/.minikube
 minikube-test-cluster: DOCKER_RUN_ARGS+=--network=host -v $(minikube_cert_mount)
 minikube-test-cluster: $(ensure-build-image)
 	$(MINIKUBE) start --kubernetes-version v1.34.6 -p $(MINIKUBE_PROFILE) --driver $(MINIKUBE_DRIVER) --nodes $(MINIKUBE_NODES)
-	$(MAKE) minikube-metallb-helm-install
-	$(MAKE) minikube-metallb-configure
-
-# minikube-metallb-helm-install installs metallb via helm
-minikube-metallb-helm-install:
-	helm repo add metallb https://metallb.github.io/metallb
-	helm repo update
-	helm upgrade metallb metallb/metallb --install --namespace metallb-system --create-namespace --version 0.15.2 --wait --timeout 5m
-
-# minikube-metallb-configure configures metallb with an ip address range based on the minikube ip
-minikube-metallb-configure:
-	MINIKUBE_IP=$$($(MINIKUBE) ip -p $(MINIKUBE_PROFILE)); \
-	NETWORK_PREFIX=$$(echo "$$MINIKUBE_IP" | cut -d '.' -f 1-3); \
-	METALLB_IP_RANGE="$$NETWORK_PREFIX.50-$$NETWORK_PREFIX.250"; \
-	sed "s|__RANGE__|$${METALLB_IP_RANGE}|g" $(build_path)/metallb-config.yaml.tpl | kubectl apply -f -
+	$(MINIKUBE) tunnel -p $(MINIKUBE_PROFILE)
 
 # Connecting to minikube requires so enhanced permissions, so use this target
 # instead of `make shell` to start an interactive shell for development on minikube.

--- a/site/content/en/docs/Installation/Creating Cluster/minikube.md
+++ b/site/content/en/docs/Installation/Creating Cluster/minikube.md
@@ -71,53 +71,24 @@ possible to connect directly to a `GameServer` hosted on Agones as you would on 
 
 If you are unable to do so, the following workarounds are available, and may work on your platform:
 
-## Setting up LoadBalancer Support with MetalLB
+## Setting up LoadBalancer Support with `minikube tunnel`
 
-By default, Minikube doesn't provide LoadBalancer's that are exteranally available without some form of tunneling such as `minikube tunnel`, which means services of type `LoadBalancer` will remain in a "Pending" state. For Agones, LoadBalancer services are often used for the allocator and ping services to provide external access. If you want an external IP for those services without a need to tunnel, you need to install MetalLB.
+By default, Minikube doesn't provide LoadBalancer services that are externally available without some form of tunneling,
+which means services of type `LoadBalancer` will remain in a "Pending" state. For Agones, LoadBalancer services are used
+for the allocator and ping services to provide external access.
 
-### Installing MetalLB
+[`minikube tunnel`](https://minikube.sigs.k8s.io/docs/handbook/accessing/) creates a network route on the host to the
+service CIDR of the cluster, which enables LoadBalancer services to receive external IP addresses and be accessible
+from your host machine.
 
-First, add the MetalLB Helm repository and install it:
-
-```bash
-helm repo add metallb https://metallb.github.io/metallb
-helm repo update
-helm install metallb metallb/metallb --namespace metallb-system --create-namespace
-```
-
-### Configuring MetalLB
-
-After installation, you need to configure MetalLB with an IP address range. Create a configuration file:
+Run it in a terminal after starting Minikube:
 
 ```bash
-# Get the minikube IP to determine the network range
-MINIKUBE_IP=$(minikube ip -p agones)
-NETWORK_PREFIX=$(echo "$MINIKUBE_IP" | cut -d '.' -f 1-3)
-METALLB_IP_RANGE="$NETWORK_PREFIX.50-$NETWORK_PREFIX.250"
-
-# Create MetalLB configuration
-cat <<EOF | kubectl apply -f -
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  name: default-pool
-  namespace: metallb-system
-spec:
-  addresses:
-  - ${METALLB_IP_RANGE}
----
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: default
-  namespace: metallb-system
-spec:
-  ipAddressPools:
-  - default-pool
-EOF
+minikube tunnel -p agones
 ```
 
-Once MetalLB is installed and configured, LoadBalancer services will receive external IP addresses from the configured range, allowing external access to Agones services.
+You may be prompted for your password, as it requires root privileges to add network routes. Keep this terminal window
+open for as long as you need access to the LoadBalancer services.
 
 ### minikube ip
 
@@ -183,8 +154,8 @@ value to point to the new `GameServer` instance and/or the `${GAMESERVER_CONTAIN
 
 {{% alert title="Warning" color="warning" %}}
 `minikube tunnel` ([docs](https://minikube.sigs.k8s.io/docs/handbook/accessing/))
-does not support UDP ([Github Issue](https://github.com/kubernetes/minikube/issues/12362)) on some combination of
-operating system, platforms and drivers, but is required when using the `Service` workaround.
+does not support UDP ([Github Issue](https://github.com/kubernetes/minikube/issues/12362)) on some combinations of
+operating system, platforms and drivers, which means `GameServer` UDP connectivity may not work through the tunnel.
 {{% /alert %}}
 
 ### Use a different driver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Switches minikube cluster setup to use `minikube tunnel` instead of MetalLB for providing external IPs to LoadBalancer services, and updates the Minikube installation docs accordingly.

This is to solve the issue we were having where you couldn't connect to Agones Services through MetalLB on minikube.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
N/A

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

I don't know when this ability came to Minikube, but it's neat that it does it natively!
