### PR TITLE
docs: add Flowtriq to Third Party Libraries and Tools

### DIFF
--- a/site/content/en/docs/Third Party Content/libraries-tools.md
+++ b/site/content/en/docs/Third Party Content/libraries-tools.md
@@ -27,6 +27,10 @@ Libraries or applications that implement messaging systems.
 - [Octops/Image Syncer](https://github.com/Octops/octops-image-syncer) - Watch Fleets and pre-pull images of game servers on every node running in the cluster
 - [Octops/Fleet Garbage Collector](https://github.com/Octops/octops-fleet-gc) - Delete Fleets based on its TTL
 
+## Monitoring
+
+- [Flowtriq](https://flowtriq.com) - DDoS detection agent that labels attacked GameServers via the Agones SDK sidecar REST API for automated fleet response
+
 ## Allocation
 
 - [agones-allocator-client](https://github.com/FairwindsOps/agones-allocator-client) - A client for testing allocation servers.

--- a/site/content/en/docs/Third Party Content/libraries-tools.md
+++ b/site/content/en/docs/Third Party Content/libraries-tools.md
@@ -29,7 +29,7 @@ Libraries or applications that implement messaging systems.
 
 ## Monitoring
 
-- [Flowtriq](https://flowtriq.com) - DDoS detection agent that labels attacked GameServers via the Agones SDK sidecar REST API for automated fleet response
+- [Flowtriq](https://flowtriq.com/integrations/agones) - DDoS detection agent that labels attacked GameServers via the Agones SDK sidecar REST API for automated fleet response
 
 ## Allocation
 


### PR DESCRIPTION
## What does this PR do?

Adds [Flowtriq](https://flowtriq.com) to the Third Party Libraries and Tools page under a new **Monitoring** section.

Flowtriq is a DDoS detection agent that integrates with Agones via the SDK sidecar REST API to label attacked GameServers and trigger automated fleet response (draining the attacked server and replacing it with a clean allocation).

## Why should this be merged?

There is currently no "Monitoring" category on the third-party page. Flowtriq fills a gap for operators who need real-time attack detection integrated directly with Agones fleet lifecycle.

## Notes

- Single doc-only change, one line added
- DCO sign-off included (`Signed-off-by: Jacob Masse <jacob@traztech.ca>`)
- If a Google CLA is required for this repo, I will complete the click-through upon request