### PR TITLE
build: add minikube image load support for simple-game-server

### DIFF
--- a/build/docs/building-testing.md
+++ b/build/docs/building-testing.md
@@ -49,6 +49,28 @@ version to your cluster.
 Another would be to run `make lint test-go` to run the golang linter against the Go code, and then run all the unit
 tests.
 
+## Testing changes to the `simple-game-server` example image
+
+The [`simple-game-server`](../../examples/simple-game-server) example is used throughout Agones' own examples,
+fleets and end-to-end tests. If you make changes to it and want to
+test them on Minikube without publishing an image, you can build it and push it straight into your Minikube
+cluster, tagged as if it were the production image, so that the existing yaml files (`fleet.yaml`,
+`gameserver.yaml`, etc.) pick up your changes without any edits.
+
+From the [`examples/simple-game-server`](../../examples/simple-game-server) directory (this has its own `Makefile`,
+separate from the one in `build/`), run:
+
+```bash
+make build-linux-image-$(dpkg --print-architecture) && make minikube-push
+```
+
+This builds the image for your host machine's architecture, loads it into the `agones` Minikube profile (the same
+one created by `make minikube-test-cluster`), and re-tags it to match the production image reference
+(e.g. `us-docker.pkg.dev/agones-images/examples/simple-game-server:<version>`).
+
+This can also be useful if the `simple-game-server` was recently edited, and has yet to be published to the production
+registry.
+
 ## Set Local Make Targets and Variables with `local-includes`
 
 If you want to permanently set `Makefile` variables or add targets to your local setup, all `local-includes/*.mk`

--- a/examples/simple-game-server/Makefile
+++ b/examples/simple-game-server/Makefile
@@ -25,6 +25,8 @@
 
 REPOSITORY ?=
 PROD_REPO ?= us-docker.pkg.dev/agones-images/examples
+MINIKUBE ?= minikube
+MINIKUBE_PROFILE ?= agones
 BUILDX_WINDOWS_BUILDER = windows-builder
 # Versions of Windows Server to support, default is Windows Server 2019.
 # For the full list of tags see https://hub.docker.com/_/microsoft-windows-servercore.
@@ -53,6 +55,11 @@ else
 server_tag_linux_amd64 = $(server_tag)-amd64
 server_tag_linux_arm64 = $(server_tag)-arm64
 endif
+
+# Host machine architecture (amd64/arm64), to match the image tag suffixes
+# above, so we know which arch specific image to load into minikube.
+HOST_ARCH := $(shell dpkg --print-architecture)
+server_tag_linux_host = $(server_tag_linux_$(HOST_ARCH))
 
 push_server_manifest = $(server_tag_linux_amd64)
 root_path = $(realpath $(project_path)/../..)
@@ -98,6 +105,14 @@ push-linux-image-amd64: build
 	docker push $(server_tag_linux_amd64)
 push-linux-image-arm64: build
 	$(MAKE) DOCKER_BUILD_ARGS=--push build-linux-image-arm64
+
+# Pushes the host architecture's linux image (built via `make build`) into the
+# "agones" minikube instance, and re-tags it with the production tag (i.e.
+# $(PROD_REPO)/$(server_tag)), so that it can be used by the example
+# gameserver/fleet yaml files without modification.
+minikube-push:
+	$(MINIKUBE) image load $(server_tag_linux_host) -p $(MINIKUBE_PROFILE)
+	$(MINIKUBE) image tag $(server_tag_linux_host) $(PROD_REPO)/$(server_tag) -p $(MINIKUBE_PROFILE)
 
 # Pushes all variants of the Windows images to the container image registry.
 push-windows-images: $(foreach winver, $(WINDOWS_VERSIONS), push-windows-image-$(winver))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Introduce `minikube-push` target in the Makefile to load host-specific Linux images into a specified Minikube profile, tagging them for production use. Add architecture normalization logic for improved compatibility.

I found myself loading this into minikube manually a lot for testing, so wanted to make a target to make this easier.

Also updated the development documentation on how to use this when testing with the simple-game-server or if it's not published yet.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
N/A

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

Just because it needed doing.
