### PR TITLE
feat(k8s-export-openapi): add tests and update removal logic for OpenAPI fields

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -315,6 +315,7 @@ test-build-scripts: $(ensure-build-image)
 	$(GO_TEST) $(agones_package)/build/scripts/...
 	$(DOCKER_RUN) bash -c "cd build/scripts/previousversion && go test -v ."
 	$(DOCKER_RUN) bash -c "cd build/scripts/site-config-update-version && go test -v ."
+	$(DOCKER_RUN) bash -c "cd build/scripts/k8s-export-openapi && go test -v ."
 
 # Runs end-to-end tests on the current configured cluster
 # For minikube user the minikube-test-e2e targets

--- a/build/scripts/k8s-export-openapi/main.go
+++ b/build/scripts/k8s-export-openapi/main.go
@@ -219,8 +219,6 @@ func removeFields(filename string) error {
 	}
 
 	keysToRemove := []string{
-		"x-kubernetes-patch-strategy",
-		"x-kubernetes-patch-merge-key",
 		"x-kubernetes-list-type",
 		"x-kubernetes-group-version-kind",
 		"x-kubernetes-list-map-keys",

--- a/build/scripts/k8s-export-openapi/main_test.go
+++ b/build/scripts/k8s-export-openapi/main_test.go
@@ -1,0 +1,94 @@
+// Copyright Contributors to Agones a Series of LF Projects, LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveFieldsKeepsPatchKeys(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"definitions": map[string]any{
+			"io.k8s.api.core.v1.Container": map[string]any{
+				"properties": map[string]any{
+					"env": map[string]any{
+						"type":                         "array",
+						"x-kubernetes-patch-strategy":  "merge",
+						"x-kubernetes-patch-merge-key": "name",
+						"x-kubernetes-list-type":       "map",
+						"x-kubernetes-list-map-keys":   []any{"name"},
+					},
+				},
+				"x-kubernetes-group-version-kind": []any{
+					map[string]any{"group": "", "version": "v1", "kind": "Pod"},
+				},
+				"x-kubernetes-unions": []any{},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "openapi.json")
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	if err := removeFields(path); err != nil {
+		t.Fatalf("removeFields: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(raw, &output); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	defs := output["definitions"].(map[string]any)
+	container := defs["io.k8s.api.core.v1.Container"].(map[string]any)
+	props := container["properties"].(map[string]any)
+	env := props["env"].(map[string]any)
+
+	if got := env["x-kubernetes-patch-strategy"]; got != "merge" {
+		t.Errorf("x-kubernetes-patch-strategy = %v, want merge", got)
+	}
+	if got := env["x-kubernetes-patch-merge-key"]; got != "name" {
+		t.Errorf("x-kubernetes-patch-merge-key = %v, want name", got)
+	}
+	if _, ok := env["x-kubernetes-list-type"]; ok {
+		t.Errorf("x-kubernetes-list-type should be removed")
+	}
+	if _, ok := env["x-kubernetes-list-map-keys"]; ok {
+		t.Errorf("x-kubernetes-list-map-keys should be removed")
+	}
+	if _, ok := container["x-kubernetes-group-version-kind"]; ok {
+		t.Errorf("x-kubernetes-group-version-kind should be removed")
+	}
+	if _, ok := container["x-kubernetes-unions"]; ok {
+		t.Errorf("x-kubernetes-unions should be removed")
+	}
+}

--- a/install/helm/agones/templates/crds/k8s/_io.k8s.api.core.v1.PodTemplateSpec.yaml
+++ b/install/helm/agones/templates/crds/k8s/_io.k8s.api.core.v1.PodTemplateSpec.yaml
@@ -50,6 +50,7 @@ properties:
         items:
           type: string
         type: array
+        x-kubernetes-patch-strategy: merge
       generateName:
         description: |-
           GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -134,6 +135,8 @@ properties:
           type: object
           x-kubernetes-map-type: atomic
         type: array
+        x-kubernetes-patch-merge-key: uid
+        x-kubernetes-patch-strategy: merge
       resourceVersion:
         description: |-
           An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -835,6 +838,8 @@ properties:
                   - name
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: name
+              x-kubernetes-patch-strategy: merge
             envFrom:
               description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
               items:
@@ -1323,6 +1328,8 @@ properties:
                   - containerPort
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: containerPort
+              x-kubernetes-patch-strategy: merge
             readinessProbe:
               description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
               properties:
@@ -1432,7 +1439,7 @@ properties:
                   type: integer
               type: object
             resizePolicy:
-              description: Resources resize policy for the container.
+              description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
               items:
                 properties:
                   resourceName:
@@ -1788,6 +1795,8 @@ properties:
                   - devicePath
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: devicePath
+              x-kubernetes-patch-strategy: merge
             volumeMounts:
               description: Pod volumes to mount into the container's filesystem. Cannot be updated.
               items:
@@ -1837,6 +1846,8 @@ properties:
                   - mountPath
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: mountPath
+              x-kubernetes-patch-strategy: merge
             workingDir:
               description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
               type: string
@@ -1844,6 +1855,8 @@ properties:
             - name
           type: object
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge
       dnsConfig:
         description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
         properties:
@@ -2005,6 +2018,8 @@ properties:
                   - name
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: name
+              x-kubernetes-patch-strategy: merge
             envFrom:
               description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
               items:
@@ -2493,6 +2508,8 @@ properties:
                   - containerPort
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: containerPort
+              x-kubernetes-patch-strategy: merge
             readinessProbe:
               description: Probes are not allowed for ephemeral containers.
               properties:
@@ -2964,6 +2981,8 @@ properties:
                   - devicePath
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: devicePath
+              x-kubernetes-patch-strategy: merge
             volumeMounts:
               description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
               items:
@@ -3013,6 +3032,8 @@ properties:
                   - mountPath
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: mountPath
+              x-kubernetes-patch-strategy: merge
             workingDir:
               description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
               type: string
@@ -3020,6 +3041,8 @@ properties:
             - name
           type: object
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge
       hostAliases:
         description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
         items:
@@ -3036,6 +3059,8 @@ properties:
             - ip
           type: object
         type: array
+        x-kubernetes-patch-merge-key: ip
+        x-kubernetes-patch-strategy: merge
       hostIPC:
         description: "Use the host's ipc namespace. Optional: Default to false."
         type: boolean
@@ -3067,6 +3092,8 @@ properties:
           type: object
           x-kubernetes-map-type: atomic
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge
       initContainers:
         description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
         items:
@@ -3184,6 +3211,8 @@ properties:
                   - name
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: name
+              x-kubernetes-patch-strategy: merge
             envFrom:
               description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
               items:
@@ -3672,6 +3701,8 @@ properties:
                   - containerPort
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: containerPort
+              x-kubernetes-patch-strategy: merge
             readinessProbe:
               description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
               properties:
@@ -3781,7 +3812,7 @@ properties:
                   type: integer
               type: object
             resizePolicy:
-              description: Resources resize policy for the container.
+              description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
               items:
                 properties:
                   resourceName:
@@ -4137,6 +4168,8 @@ properties:
                   - devicePath
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: devicePath
+              x-kubernetes-patch-strategy: merge
             volumeMounts:
               description: Pod volumes to mount into the container's filesystem. Cannot be updated.
               items:
@@ -4186,6 +4219,8 @@ properties:
                   - mountPath
                 type: object
               type: array
+              x-kubernetes-patch-merge-key: mountPath
+              x-kubernetes-patch-strategy: merge
             workingDir:
               description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
               type: string
@@ -4193,6 +4228,8 @@ properties:
             - name
           type: object
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge
       nodeName:
         description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
         type: string
@@ -4254,7 +4291,7 @@ properties:
         description: |-
           ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.
 
-          This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+          This is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.
 
           This field is immutable.
         items:
@@ -4282,6 +4319,8 @@ properties:
             - name
           type: object
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge,retainKeys
       resources:
         description: |-
           Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -4353,6 +4392,8 @@ properties:
             - name
           type: object
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge
       securityContext:
         description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
         properties:
@@ -4556,14 +4597,18 @@ properties:
               type: string
             operator:
               description: |-
-                Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
 
                 Possible enum values:
                  - `"Equal"`
                  - `"Exists"`
+                 - `"Gt"`
+                 - `"Lt"`
               enum:
                 - Equal
                 - Exists
+                - Gt
+                - Lt
               type: string
             tolerationSeconds:
               description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
@@ -4676,6 +4721,8 @@ properties:
             - whenUnsatisfiable
           type: object
         type: array
+        x-kubernetes-patch-merge-key: topologyKey
+        x-kubernetes-patch-strategy: merge
       volumes:
         description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
         items:
@@ -4996,6 +5043,7 @@ properties:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-patch-strategy: merge
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -5080,6 +5128,8 @@ properties:
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
+                          x-kubernetes-patch-merge-key: uid
+                          x-kubernetes-patch-strategy: merge
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -5154,7 +5204,7 @@ properties:
                             - name
                           type: object
                         resources:
-                          description: "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                          description: "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
                           properties:
                             limits:
                               additionalProperties:
@@ -5699,6 +5749,18 @@ properties:
                           signerName:
                             description: Kubelet's generated CSRs will be addressed to this signer.
                             type: string
+                          userAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.
+
+                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.
+
+                              Entries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.
+
+                              Signers should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.
+                            type: object
                         required:
                           - signerName
                           - keyType
@@ -5936,6 +5998,24 @@ properties:
             - name
           type: object
         type: array
+        x-kubernetes-patch-merge-key: name
+        x-kubernetes-patch-strategy: merge,retainKeys
+      workloadRef:
+        description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
+        properties:
+          name:
+            description: Name defines the name of the Workload object this Pod belongs to. Workload must be in the same namespace as the Pod. If it doesn't match any existing Workload, the Pod will remain unschedulable until a Workload object is created and observed by the kube-scheduler. It must be a DNS subdomain.
+            type: string
+          podGroup:
+            description: PodGroup is the name of the PodGroup within the Workload that this Pod belongs to. If it doesn't match any existing PodGroup within the Workload, the Pod will remain unschedulable until the Workload object is recreated and observed by the kube-scheduler. It must be a DNS label.
+            type: string
+          podGroupReplicaKey:
+            description: PodGroupReplicaKey specifies the replica key of the PodGroup to which this Pod belongs. It is used to distinguish pods belonging to different replicas of the same pod group. The pod group policy is applied separately to each replica. When set, it must be a DNS label.
+            type: string
+        required:
+          - name
+          - podGroup
+        type: object
     required:
       - containers
     type: object

--- a/install/helm/agones/templates/crds/k8s/_io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.yaml
+++ b/install/helm/agones/templates/crds/k8s/_io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.yaml
@@ -47,6 +47,7 @@ properties:
     items:
       type: string
     type: array
+    x-kubernetes-patch-strategy: merge
   generateName:
     description: |-
       GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -131,6 +132,8 @@ properties:
       type: object
       x-kubernetes-map-type: atomic
     type: array
+    x-kubernetes-patch-merge-key: uid
+    x-kubernetes-patch-strategy: merge
   resourceVersion:
     description: |-
       An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -348,6 +348,7 @@ spec:
                          items:
                            type: string
                          type: array
+                         x-kubernetes-patch-strategy: merge
                        generateName:
                          description: |-
                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -432,6 +433,8 @@ spec:
                            type: object
                            x-kubernetes-map-type: atomic
                          type: array
+                         x-kubernetes-patch-merge-key: uid
+                         x-kubernetes-patch-strategy: merge
                        resourceVersion:
                          description: |-
                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -490,6 +493,7 @@ spec:
                                  items:
                                    type: string
                                  type: array
+                                 x-kubernetes-patch-strategy: merge
                                generateName:
                                  description: |-
                                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -574,6 +578,8 @@ spec:
                                    type: object
                                    x-kubernetes-map-type: atomic
                                  type: array
+                                 x-kubernetes-patch-merge-key: uid
+                                 x-kubernetes-patch-strategy: merge
                                resourceVersion:
                                  description: |-
                                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -1275,6 +1281,8 @@ spec:
                                            - name
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: name
+                                       x-kubernetes-patch-strategy: merge
                                      envFrom:
                                        description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                        items:
@@ -1763,6 +1771,8 @@ spec:
                                            - containerPort
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: containerPort
+                                       x-kubernetes-patch-strategy: merge
                                      readinessProbe:
                                        description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                        properties:
@@ -1872,7 +1882,7 @@ spec:
                                            type: integer
                                        type: object
                                      resizePolicy:
-                                       description: Resources resize policy for the container.
+                                       description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
                                        items:
                                          properties:
                                            resourceName:
@@ -2228,6 +2238,8 @@ spec:
                                            - devicePath
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: devicePath
+                                       x-kubernetes-patch-strategy: merge
                                      volumeMounts:
                                        description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                        items:
@@ -2277,6 +2289,8 @@ spec:
                                            - mountPath
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: mountPath
+                                       x-kubernetes-patch-strategy: merge
                                      workingDir:
                                        description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                        type: string
@@ -2284,6 +2298,8 @@ spec:
                                      - name
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge
                                dnsConfig:
                                  description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                                  properties:
@@ -2445,6 +2461,8 @@ spec:
                                            - name
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: name
+                                       x-kubernetes-patch-strategy: merge
                                      envFrom:
                                        description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                        items:
@@ -2933,6 +2951,8 @@ spec:
                                            - containerPort
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: containerPort
+                                       x-kubernetes-patch-strategy: merge
                                      readinessProbe:
                                        description: Probes are not allowed for ephemeral containers.
                                        properties:
@@ -3404,6 +3424,8 @@ spec:
                                            - devicePath
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: devicePath
+                                       x-kubernetes-patch-strategy: merge
                                      volumeMounts:
                                        description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                        items:
@@ -3453,6 +3475,8 @@ spec:
                                            - mountPath
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: mountPath
+                                       x-kubernetes-patch-strategy: merge
                                      workingDir:
                                        description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                        type: string
@@ -3460,6 +3484,8 @@ spec:
                                      - name
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge
                                hostAliases:
                                  description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                                  items:
@@ -3476,6 +3502,8 @@ spec:
                                      - ip
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: ip
+                                 x-kubernetes-patch-strategy: merge
                                hostIPC:
                                  description: "Use the host's ipc namespace. Optional: Default to false."
                                  type: boolean
@@ -3507,6 +3535,8 @@ spec:
                                    type: object
                                    x-kubernetes-map-type: atomic
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge
                                initContainers:
                                  description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
                                  items:
@@ -3624,6 +3654,8 @@ spec:
                                            - name
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: name
+                                       x-kubernetes-patch-strategy: merge
                                      envFrom:
                                        description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                        items:
@@ -4112,6 +4144,8 @@ spec:
                                            - containerPort
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: containerPort
+                                       x-kubernetes-patch-strategy: merge
                                      readinessProbe:
                                        description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                        properties:
@@ -4221,7 +4255,7 @@ spec:
                                            type: integer
                                        type: object
                                      resizePolicy:
-                                       description: Resources resize policy for the container.
+                                       description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
                                        items:
                                          properties:
                                            resourceName:
@@ -4577,6 +4611,8 @@ spec:
                                            - devicePath
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: devicePath
+                                       x-kubernetes-patch-strategy: merge
                                      volumeMounts:
                                        description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                        items:
@@ -4626,6 +4662,8 @@ spec:
                                            - mountPath
                                          type: object
                                        type: array
+                                       x-kubernetes-patch-merge-key: mountPath
+                                       x-kubernetes-patch-strategy: merge
                                      workingDir:
                                        description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                        type: string
@@ -4633,6 +4671,8 @@ spec:
                                      - name
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge
                                nodeName:
                                  description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                                  type: string
@@ -4694,7 +4734,7 @@ spec:
                                  description: |-
                                    ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.
                          
-                                   This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+                                   This is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.
                          
                                    This field is immutable.
                                  items:
@@ -4722,6 +4762,8 @@ spec:
                                      - name
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge,retainKeys
                                resources:
                                  description: |-
                                    Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -4793,6 +4835,8 @@ spec:
                                      - name
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge
                                securityContext:
                                  description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
                                  properties:
@@ -4996,14 +5040,18 @@ spec:
                                        type: string
                                      operator:
                                        description: |-
-                                         Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                         Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                          
                                          Possible enum values:
                                           - `"Equal"`
                                           - `"Exists"`
+                                          - `"Gt"`
+                                          - `"Lt"`
                                        enum:
                                          - Equal
                                          - Exists
+                                         - Gt
+                                         - Lt
                                        type: string
                                      tolerationSeconds:
                                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
@@ -5116,6 +5164,8 @@ spec:
                                      - whenUnsatisfiable
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: topologyKey
+                                 x-kubernetes-patch-strategy: merge
                                volumes:
                                  description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
                                  items:
@@ -5436,6 +5486,7 @@ spec:
                                                    items:
                                                      type: string
                                                    type: array
+                                                   x-kubernetes-patch-strategy: merge
                                                  generateName:
                                                    description: |-
                                                      GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -5520,6 +5571,8 @@ spec:
                                                      type: object
                                                      x-kubernetes-map-type: atomic
                                                    type: array
+                                                   x-kubernetes-patch-merge-key: uid
+                                                   x-kubernetes-patch-strategy: merge
                                                  resourceVersion:
                                                    description: |-
                                                      An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -5594,7 +5647,7 @@ spec:
                                                      - name
                                                    type: object
                                                  resources:
-                                                   description: "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                                                   description: "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
                                                    properties:
                                                      limits:
                                                        additionalProperties:
@@ -6139,6 +6192,18 @@ spec:
                                                    signerName:
                                                      description: Kubelet's generated CSRs will be addressed to this signer.
                                                      type: string
+                                                   userAnnotations:
+                                                     additionalProperties:
+                                                       type: string
+                                                     description: |-
+                                                       userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.
+                         
+                                                       These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.
+                         
+                                                       Entries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.
+                         
+                                                       Signers should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.
+                                                     type: object
                                                  required:
                                                    - signerName
                                                    - keyType
@@ -6376,6 +6441,24 @@ spec:
                                      - name
                                    type: object
                                  type: array
+                                 x-kubernetes-patch-merge-key: name
+                                 x-kubernetes-patch-strategy: merge,retainKeys
+                               workloadRef:
+                                 description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
+                                 properties:
+                                   name:
+                                     description: Name defines the name of the Workload object this Pod belongs to. Workload must be in the same namespace as the Pod. If it doesn't match any existing Workload, the Pod will remain unschedulable until a Workload object is created and observed by the kube-scheduler. It must be a DNS subdomain.
+                                     type: string
+                                   podGroup:
+                                     description: PodGroup is the name of the PodGroup within the Workload that this Pod belongs to. If it doesn't match any existing PodGroup within the Workload, the Pod will remain unschedulable until the Workload object is recreated and observed by the kube-scheduler. It must be a DNS label.
+                                     type: string
+                                   podGroupReplicaKey:
+                                     description: PodGroupReplicaKey specifies the replica key of the PodGroup to which this Pod belongs. It is used to distinguish pods belonging to different replicas of the same pod group. The pod group policy is applied separately to each replica. When set, it must be a DNS label.
+                                     type: string
+                                 required:
+                                   - name
+                                   - podGroup
+                                 type: object
                              required:
                                - containers
                              type: object
@@ -7468,6 +7551,7 @@ spec:
                          items:
                            type: string
                          type: array
+                         x-kubernetes-patch-strategy: merge
                        generateName:
                          description: |-
                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -7552,6 +7636,8 @@ spec:
                            type: object
                            x-kubernetes-map-type: atomic
                          type: array
+                         x-kubernetes-patch-merge-key: uid
+                         x-kubernetes-patch-strategy: merge
                        resourceVersion:
                          description: |-
                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -8253,6 +8339,8 @@ spec:
                                    - name
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: name
+                               x-kubernetes-patch-strategy: merge
                              envFrom:
                                description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                items:
@@ -8741,6 +8829,8 @@ spec:
                                    - containerPort
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: containerPort
+                               x-kubernetes-patch-strategy: merge
                              readinessProbe:
                                description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                properties:
@@ -8850,7 +8940,7 @@ spec:
                                    type: integer
                                type: object
                              resizePolicy:
-                               description: Resources resize policy for the container.
+                               description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
                                items:
                                  properties:
                                    resourceName:
@@ -9206,6 +9296,8 @@ spec:
                                    - devicePath
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: devicePath
+                               x-kubernetes-patch-strategy: merge
                              volumeMounts:
                                description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                items:
@@ -9255,6 +9347,8 @@ spec:
                                    - mountPath
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: mountPath
+                               x-kubernetes-patch-strategy: merge
                              workingDir:
                                description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                type: string
@@ -9262,6 +9356,8 @@ spec:
                              - name
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge
                        dnsConfig:
                          description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                          properties:
@@ -9423,6 +9519,8 @@ spec:
                                    - name
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: name
+                               x-kubernetes-patch-strategy: merge
                              envFrom:
                                description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                items:
@@ -9911,6 +10009,8 @@ spec:
                                    - containerPort
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: containerPort
+                               x-kubernetes-patch-strategy: merge
                              readinessProbe:
                                description: Probes are not allowed for ephemeral containers.
                                properties:
@@ -10382,6 +10482,8 @@ spec:
                                    - devicePath
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: devicePath
+                               x-kubernetes-patch-strategy: merge
                              volumeMounts:
                                description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                items:
@@ -10431,6 +10533,8 @@ spec:
                                    - mountPath
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: mountPath
+                               x-kubernetes-patch-strategy: merge
                              workingDir:
                                description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                type: string
@@ -10438,6 +10542,8 @@ spec:
                              - name
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge
                        hostAliases:
                          description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                          items:
@@ -10454,6 +10560,8 @@ spec:
                              - ip
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: ip
+                         x-kubernetes-patch-strategy: merge
                        hostIPC:
                          description: "Use the host's ipc namespace. Optional: Default to false."
                          type: boolean
@@ -10485,6 +10593,8 @@ spec:
                            type: object
                            x-kubernetes-map-type: atomic
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge
                        initContainers:
                          description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
                          items:
@@ -10602,6 +10712,8 @@ spec:
                                    - name
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: name
+                               x-kubernetes-patch-strategy: merge
                              envFrom:
                                description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                items:
@@ -11090,6 +11202,8 @@ spec:
                                    - containerPort
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: containerPort
+                               x-kubernetes-patch-strategy: merge
                              readinessProbe:
                                description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                properties:
@@ -11199,7 +11313,7 @@ spec:
                                    type: integer
                                type: object
                              resizePolicy:
-                               description: Resources resize policy for the container.
+                               description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
                                items:
                                  properties:
                                    resourceName:
@@ -11555,6 +11669,8 @@ spec:
                                    - devicePath
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: devicePath
+                               x-kubernetes-patch-strategy: merge
                              volumeMounts:
                                description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                items:
@@ -11604,6 +11720,8 @@ spec:
                                    - mountPath
                                  type: object
                                type: array
+                               x-kubernetes-patch-merge-key: mountPath
+                               x-kubernetes-patch-strategy: merge
                              workingDir:
                                description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                type: string
@@ -11611,6 +11729,8 @@ spec:
                              - name
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge
                        nodeName:
                          description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                          type: string
@@ -11672,7 +11792,7 @@ spec:
                          description: |-
                            ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.
                  
-                           This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+                           This is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.
                  
                            This field is immutable.
                          items:
@@ -11700,6 +11820,8 @@ spec:
                              - name
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge,retainKeys
                        resources:
                          description: |-
                            Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -11771,6 +11893,8 @@ spec:
                              - name
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge
                        securityContext:
                          description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
                          properties:
@@ -11974,14 +12098,18 @@ spec:
                                type: string
                              operator:
                                description: |-
-                                 Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                 Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                  
                                  Possible enum values:
                                   - `"Equal"`
                                   - `"Exists"`
+                                  - `"Gt"`
+                                  - `"Lt"`
                                enum:
                                  - Equal
                                  - Exists
+                                 - Gt
+                                 - Lt
                                type: string
                              tolerationSeconds:
                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
@@ -12094,6 +12222,8 @@ spec:
                              - whenUnsatisfiable
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: topologyKey
+                         x-kubernetes-patch-strategy: merge
                        volumes:
                          description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
                          items:
@@ -12414,6 +12544,7 @@ spec:
                                            items:
                                              type: string
                                            type: array
+                                           x-kubernetes-patch-strategy: merge
                                          generateName:
                                            description: |-
                                              GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -12498,6 +12629,8 @@ spec:
                                              type: object
                                              x-kubernetes-map-type: atomic
                                            type: array
+                                           x-kubernetes-patch-merge-key: uid
+                                           x-kubernetes-patch-strategy: merge
                                          resourceVersion:
                                            description: |-
                                              An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -12572,7 +12705,7 @@ spec:
                                              - name
                                            type: object
                                          resources:
-                                           description: "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                                           description: "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
                                            properties:
                                              limits:
                                                additionalProperties:
@@ -13117,6 +13250,18 @@ spec:
                                            signerName:
                                              description: Kubelet's generated CSRs will be addressed to this signer.
                                              type: string
+                                           userAnnotations:
+                                             additionalProperties:
+                                               type: string
+                                             description: |-
+                                               userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.
+                 
+                                               These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.
+                 
+                                               Entries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.
+                 
+                                               Signers should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.
+                                             type: object
                                          required:
                                            - signerName
                                            - keyType
@@ -13354,6 +13499,24 @@ spec:
                              - name
                            type: object
                          type: array
+                         x-kubernetes-patch-merge-key: name
+                         x-kubernetes-patch-strategy: merge,retainKeys
+                       workloadRef:
+                         description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
+                         properties:
+                           name:
+                             description: Name defines the name of the Workload object this Pod belongs to. Workload must be in the same namespace as the Pod. If it doesn't match any existing Workload, the Pod will remain unschedulable until a Workload object is created and observed by the kube-scheduler. It must be a DNS subdomain.
+                             type: string
+                           podGroup:
+                             description: PodGroup is the name of the PodGroup within the Workload that this Pod belongs to. If it doesn't match any existing PodGroup within the Workload, the Pod will remain unschedulable until the Workload object is recreated and observed by the kube-scheduler. It must be a DNS label.
+                             type: string
+                           podGroupReplicaKey:
+                             description: PodGroupReplicaKey specifies the replica key of the PodGroup to which this Pod belongs. It is used to distinguish pods belonging to different replicas of the same pod group. The pod group policy is applied separately to each replica. When set, it must be a DNS label.
+                             type: string
+                         required:
+                           - name
+                           - podGroup
+                         type: object
                      required:
                        - containers
                      type: object
@@ -13898,6 +14061,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-patch-strategy: merge
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -13982,6 +14146,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
+                          x-kubernetes-patch-merge-key: uid
+                          x-kubernetes-patch-strategy: merge
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -14040,6 +14206,7 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-patch-strategy: merge
                                 generateName:
                                   description: |-
                                     GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -14124,6 +14291,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type: array
+                                  x-kubernetes-patch-merge-key: uid
+                                  x-kubernetes-patch-strategy: merge
                                 resourceVersion:
                                   description: |-
                                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -14825,6 +14994,8 @@ spec:
                                             - name
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: name
+                                        x-kubernetes-patch-strategy: merge
                                       envFrom:
                                         description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                         items:
@@ -15313,6 +15484,8 @@ spec:
                                             - containerPort
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: containerPort
+                                        x-kubernetes-patch-strategy: merge
                                       readinessProbe:
                                         description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                         properties:
@@ -15422,7 +15595,7 @@ spec:
                                             type: integer
                                         type: object
                                       resizePolicy:
-                                        description: Resources resize policy for the container.
+                                        description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
                                         items:
                                           properties:
                                             resourceName:
@@ -15778,6 +15951,8 @@ spec:
                                             - devicePath
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: devicePath
+                                        x-kubernetes-patch-strategy: merge
                                       volumeMounts:
                                         description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                         items:
@@ -15827,6 +16002,8 @@ spec:
                                             - mountPath
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: mountPath
+                                        x-kubernetes-patch-strategy: merge
                                       workingDir:
                                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                         type: string
@@ -15834,6 +16011,8 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge
                                 dnsConfig:
                                   description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                                   properties:
@@ -15995,6 +16174,8 @@ spec:
                                             - name
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: name
+                                        x-kubernetes-patch-strategy: merge
                                       envFrom:
                                         description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                         items:
@@ -16483,6 +16664,8 @@ spec:
                                             - containerPort
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: containerPort
+                                        x-kubernetes-patch-strategy: merge
                                       readinessProbe:
                                         description: Probes are not allowed for ephemeral containers.
                                         properties:
@@ -16954,6 +17137,8 @@ spec:
                                             - devicePath
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: devicePath
+                                        x-kubernetes-patch-strategy: merge
                                       volumeMounts:
                                         description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                         items:
@@ -17003,6 +17188,8 @@ spec:
                                             - mountPath
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: mountPath
+                                        x-kubernetes-patch-strategy: merge
                                       workingDir:
                                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                         type: string
@@ -17010,6 +17197,8 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge
                                 hostAliases:
                                   description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                                   items:
@@ -17026,6 +17215,8 @@ spec:
                                       - ip
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: ip
+                                  x-kubernetes-patch-strategy: merge
                                 hostIPC:
                                   description: "Use the host's ipc namespace. Optional: Default to false."
                                   type: boolean
@@ -17057,6 +17248,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge
                                 initContainers:
                                   description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
                                   items:
@@ -17174,6 +17367,8 @@ spec:
                                             - name
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: name
+                                        x-kubernetes-patch-strategy: merge
                                       envFrom:
                                         description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                         items:
@@ -17662,6 +17857,8 @@ spec:
                                             - containerPort
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: containerPort
+                                        x-kubernetes-patch-strategy: merge
                                       readinessProbe:
                                         description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                         properties:
@@ -17771,7 +17968,7 @@ spec:
                                             type: integer
                                         type: object
                                       resizePolicy:
-                                        description: Resources resize policy for the container.
+                                        description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
                                         items:
                                           properties:
                                             resourceName:
@@ -18127,6 +18324,8 @@ spec:
                                             - devicePath
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: devicePath
+                                        x-kubernetes-patch-strategy: merge
                                       volumeMounts:
                                         description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                         items:
@@ -18176,6 +18375,8 @@ spec:
                                             - mountPath
                                           type: object
                                         type: array
+                                        x-kubernetes-patch-merge-key: mountPath
+                                        x-kubernetes-patch-strategy: merge
                                       workingDir:
                                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                         type: string
@@ -18183,6 +18384,8 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge
                                 nodeName:
                                   description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                                   type: string
@@ -18244,7 +18447,7 @@ spec:
                                   description: |-
                                     ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.
                           
-                                    This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+                                    This is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.
                           
                                     This field is immutable.
                                   items:
@@ -18272,6 +18475,8 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge,retainKeys
                                 resources:
                                   description: |-
                                     Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -18343,6 +18548,8 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge
                                 securityContext:
                                   description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
                                   properties:
@@ -18546,14 +18753,18 @@ spec:
                                         type: string
                                       operator:
                                         description: |-
-                                          Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                          Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           
                                           Possible enum values:
                                            - `"Equal"`
                                            - `"Exists"`
+                                           - `"Gt"`
+                                           - `"Lt"`
                                         enum:
                                           - Equal
                                           - Exists
+                                          - Gt
+                                          - Lt
                                         type: string
                                       tolerationSeconds:
                                         description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
@@ -18666,6 +18877,8 @@ spec:
                                       - whenUnsatisfiable
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: topologyKey
+                                  x-kubernetes-patch-strategy: merge
                                 volumes:
                                   description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
                                   items:
@@ -18986,6 +19199,7 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-patch-strategy: merge
                                                   generateName:
                                                     description: |-
                                                       GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -19070,6 +19284,8 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     type: array
+                                                    x-kubernetes-patch-merge-key: uid
+                                                    x-kubernetes-patch-strategy: merge
                                                   resourceVersion:
                                                     description: |-
                                                       An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -19144,7 +19360,7 @@ spec:
                                                       - name
                                                     type: object
                                                   resources:
-                                                    description: "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                                                    description: "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
                                                     properties:
                                                       limits:
                                                         additionalProperties:
@@ -19689,6 +19905,18 @@ spec:
                                                     signerName:
                                                       description: Kubelet's generated CSRs will be addressed to this signer.
                                                       type: string
+                                                    userAnnotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.
+                          
+                                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.
+                          
+                                                        Entries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.
+                          
+                                                        Signers should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.
+                                                      type: object
                                                   required:
                                                     - signerName
                                                     - keyType
@@ -19926,6 +20154,24 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                  x-kubernetes-patch-merge-key: name
+                                  x-kubernetes-patch-strategy: merge,retainKeys
+                                workloadRef:
+                                  description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
+                                  properties:
+                                    name:
+                                      description: Name defines the name of the Workload object this Pod belongs to. Workload must be in the same namespace as the Pod. If it doesn't match any existing Workload, the Pod will remain unschedulable until a Workload object is created and observed by the kube-scheduler. It must be a DNS subdomain.
+                                      type: string
+                                    podGroup:
+                                      description: PodGroup is the name of the PodGroup within the Workload that this Pod belongs to. If it doesn't match any existing PodGroup within the Workload, the Pod will remain unschedulable until the Workload object is recreated and observed by the kube-scheduler. It must be a DNS label.
+                                      type: string
+                                    podGroupReplicaKey:
+                                      description: PodGroupReplicaKey specifies the replica key of the PodGroup to which this Pod belongs. It is used to distinguish pods belonging to different replicas of the same pod group. The pod group policy is applied separately to each replica. When set, it must be a DNS label.
+                                      type: string
+                                  required:
+                                    - name
+                                    - podGroup
+                                  type: object
                               required:
                                 - containers
                               type: object


### PR DESCRIPTION
…


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind bug 


**What this PR does / Why we need it**:

- Introduced a new test file for the k8s-export-openapi script to validate the removal of specific fields from OpenAPI definitions.
- Updated the `removeFields` function to retain certain keys (`x-kubernetes-patch-strategy`, `x-kubernetes-patch-merge-key`) while removing others.
- Modified the Makefile to include the new test in the build process.
- Enhanced YAML templates to include `x-kubernetes-patch-strategy` and `x-kubernetes-patch-merge-key` where necessary.

This change improves the testing coverage and ensures compliance with Kubernetes API specifications.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Closes #3112 

**Did you use AI tools in preparing this PR?**:
Yes, I used AI tools to investigate the issue, but I implemented the fix myself. I also used AI to help draft GitHub commit msg.


**Special notes for your reviewer**:


