### PR TITLE
docs: clarify that SDK state-changing calls are async and batched

### DIFF
--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -61,7 +61,15 @@ functions that implement the core responsibilities of the SDK.
 For language specific documentation, have a look at the respective source (linked above), 
 and the {{< ghlink href="examples" >}}examples{{< /ghlink >}}.
 
-Calling any of state changing functions mentioned below does not guarantee that GameServer Custom Resource object would actually change its state right after the call. For instance, it could be moved to the `Shutdown` state elsewhere (for example, when a fleet scales down), which leads to no changes in `GameServer` object. You can verify the result of this call by waiting for the desired state in a callback to WatchGameServer() function.
+{{% alert title="Tip" color="tip" %}}
+Agones, and Kubernetes itself, are built as eventually consistent, self-healing systems, as a result, calls to any 
+of the state changing functions listed below are interval batched asynchronously queued by the SDK Server for both 
+performance and resiliency.
+
+Because of this, state changes **do not** take effect immediately after calling one of these 
+functions. Instead, verify the result by watching for the desired state in a callback to the `WatchGameServer()` 
+function.
+{{% /alert %}}
 
 Functions which changes GameServer state or settings are:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Explain that Agones and Kubernetes are eventually consistent by design, so state-changing SDK calls are batched and applied asynchronously, and recommend WatchGameServer() to confirm the actual resulting state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
N/A

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y - but heavily edited the output

**Special notes for your reviewer**:


Came up in discussions and I realised it's not super clear. So made it more clear.